### PR TITLE
Make GitHub more prominent on homepage

### DIFF
--- a/apps/marketing/src/pages/index.astro
+++ b/apps/marketing/src/pages/index.astro
@@ -115,9 +115,9 @@ const cssExample = `<span class="text-ice-300">/* All nodes default to fast + ch
 
       <div class="relative mx-auto max-w-5xl px-6 text-center">
         <div class="reveal">
-          <p class="mb-6 inline-block rounded-full border border-teal-700/40 bg-teal-700/10 px-4 py-1.5 text-sm font-medium text-teal-300">
+          <a href="https://github.com/fabro-sh/fabro" class="mb-6 inline-block rounded-full border border-teal-700/40 bg-teal-700/10 px-4 py-1.5 text-sm font-medium text-teal-300 transition-colors hover:border-teal-500/60 hover:text-teal-200">
             Open Source &middot; MIT Licensed
-          </p>
+          </a>
         </div>
         <h1 class="reveal reveal-d1 font-display text-5xl font-bold tracking-tight text-ice-50 sm:text-7xl leading-[1.08]">
           The dark software factory<br />
@@ -161,10 +161,10 @@ const cssExample = `<span class="text-ice-300">/* All nodes default to fast + ch
               Get started
             </a>
             <a
-              href="https://docs.fabro.sh"
+              href="https://github.com/fabro-sh/fabro"
               class="rounded-xl border border-navy-600 px-7 py-3.5 text-sm font-semibold text-ice-300 transition-all hover:border-teal-700/60 hover:text-ice-50"
             >
-              Read the docs
+              View on GitHub
             </a>
           </div>
         </div>
@@ -675,7 +675,7 @@ const cssExample = `<span class="text-ice-300">/* All nodes default to fast + ch
         <div>
           <img src="/logotype.svg" alt="Fabro" class="h-6 mb-4" />
           <p class="text-sm text-ice-300/60">The dark software factory for expert engineers.</p>
-          <p class="mt-2 text-xs text-ice-300/40">Open source, MIT-licensed</p>
+          <a href="https://github.com/fabro-sh/fabro" class="mt-2 block text-xs text-ice-300/40 transition-colors hover:text-ice-300/70">Open source, MIT-licensed</a>
         </div>
         <!-- Col 2: Product -->
         <div>


### PR DESCRIPTION
## Summary
- Replaces the "Read the docs" secondary CTA in the hero with "View on GitHub" — both CTAs were previously pointing to docs
- Links the "Open Source · MIT Licensed" badge at the top of the hero to GitHub
- Links the footer "Open source, MIT-licensed" text to GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)