### PR TITLE
fix(cli): use working_directory for manifest git detection

### DIFF
--- a/lib/crates/fabro-cli/src/manifest_builder.rs
+++ b/lib/crates/fabro-cli/src/manifest_builder.rs
@@ -106,15 +106,17 @@ pub(crate) fn build_run_manifest(input: ManifestBuildInput) -> Result<BuiltManif
         });
     }
 
+    let working_directory = project::resolve_working_directory(&merged_settings, &input.cwd);
+
     let goal = resolve_manifest_goal(
         &input.args_layer,
         &merged_settings,
         &root_source,
         &target_path,
-        &input.cwd,
+        &working_directory,
     )?;
 
-    let git = build_manifest_git(&input.cwd);
+    let git = build_manifest_git(&working_directory);
     let args = input.args.filter(|args| !manifest_args_is_empty(args));
 
     Ok(BuiltManifest {
@@ -391,13 +393,11 @@ fn resolve_manifest_goal(
     settings: &SettingsLayer,
     root_source: &str,
     root_dot_path: &Path,
-    cwd: &Path,
+    working_directory: &Path,
 ) -> Result<Option<types::ManifestGoal>> {
-    let working_directory = project::resolve_working_directory(settings, cwd);
-
     // Precedence 1: CLI args (`--goal` / `--goal-file`). These are already
     // resolved to absolute paths by `overrides::goal_layer_from_args`.
-    if let Some(resolved) = resolve_run_goal(args_layer, &working_directory)
+    if let Some(resolved) = resolve_run_goal(args_layer, working_directory)
         .context("failed to resolve --goal-file contents")?
     {
         return Ok(Some(resolved_goal_to_manifest(resolved)));
@@ -406,7 +406,7 @@ fn resolve_manifest_goal(
     // Precedence 2: merged config `run.goal`. Config-sourced `goal.file`
     // paths were rewritten to absolute by `load_settings_path` at the
     // directory of the config file that declared them.
-    if let Some(resolved) = resolve_run_goal(settings, &working_directory)
+    if let Some(resolved) = resolve_run_goal(settings, working_directory)
         .context("failed to resolve run.goal.file contents")?
     {
         return Ok(Some(resolved_goal_to_manifest(resolved)));
@@ -458,11 +458,11 @@ fn resolved_goal_to_manifest(resolved: ResolvedRunGoal) -> types::ManifestGoal {
     }
 }
 
-fn build_manifest_git(cwd: &Path) -> Option<types::ManifestGit> {
-    let (origin_url, branch) = detect_repo_info(cwd).ok()?;
+fn build_manifest_git(repo_path: &Path) -> Option<types::ManifestGit> {
+    let (origin_url, branch) = detect_repo_info(repo_path).ok()?;
     let branch = branch?;
-    let sha = head_sha(cwd).ok()?;
-    let clean = sync_status(cwd, "origin", Some(&branch)) != GitSyncStatus::Dirty;
+    let sha = head_sha(repo_path).ok()?;
+    let clean = sync_status(repo_path, "origin", Some(&branch)) != GitSyncStatus::Dirty;
     Some(types::ManifestGit {
         branch,
         clean,
@@ -754,5 +754,103 @@ file = "prompts/goal.md"
         let resolved = goal.path.expect("file goal must carry a path");
         let expected = workflow_dir.join("prompts").join("goal.md");
         assert_eq!(PathBuf::from(resolved), expected);
+    }
+
+    /// When `[run] working_dir` points to a nested git repo, the manifest's
+    /// `git.branch` and `git.origin_url` must come from that target repo, not
+    /// from an enclosing workspace repo that happens to be the CLI's cwd.
+    /// Regression test for https://github.com/fabro-sh/fabro/issues/159.
+    #[test]
+    fn build_manifest_git_follows_working_directory_into_nested_repo() {
+        let temp = tempfile::tempdir().unwrap();
+        let workspace = temp.path();
+        let target = workspace.join("repos").join("target");
+        std::fs::create_dir_all(&target).unwrap();
+
+        init_git_repo(
+            workspace,
+            "workspace-branch",
+            "https://github.com/example/workspace.git",
+        );
+        init_git_repo(
+            &target,
+            "target-branch",
+            "https://github.com/example/target.git",
+        );
+
+        let workflow_dir = workspace.join(".fabro/workflows/demo");
+        std::fs::create_dir_all(&workflow_dir).unwrap();
+        std::fs::write(
+            workspace.join(".fabro/project.toml"),
+            r#"_version = 1
+
+[run]
+working_dir = "repos/target"
+"#,
+        )
+        .unwrap();
+        std::fs::write(
+            workflow_dir.join("workflow.toml"),
+            "_version = 1\n\n[workflow]\ngraph = \"workflow.fabro\"\n",
+        )
+        .unwrap();
+        std::fs::write(
+            workflow_dir.join("workflow.fabro"),
+            r"digraph Demo { start [shape=Mdiamond] exit [shape=Msquare] start -> exit }",
+        )
+        .unwrap();
+
+        let built = build_run_manifest(ManifestBuildInput {
+            workflow:           PathBuf::from(".fabro/workflows/demo/workflow.toml"),
+            cwd:                workspace.to_path_buf(),
+            args_layer:         SettingsLayer::default(),
+            args:               None,
+            run_id:             None,
+            user_layer:         SettingsLayer::default(),
+            user_settings_path: None,
+        })
+        .unwrap();
+
+        let git = built
+            .manifest
+            .git
+            .expect("manifest git info should be detected");
+        assert_eq!(git.branch, "target-branch");
+        assert_eq!(git.origin_url, "https://github.com/example/target");
+    }
+
+    fn init_git_repo(path: &Path, branch: &str, origin_url: &str) {
+        use std::process::Command;
+        let run = |args: &[&str]| {
+            let output = Command::new("git")
+                .args(args)
+                .current_dir(path)
+                .output()
+                .unwrap_or_else(|e| panic!("failed to spawn git {args:?}: {e}"));
+            assert!(
+                output.status.success(),
+                "git {args:?} failed: stdout={} stderr={}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr),
+            );
+        };
+        run(&[
+            "-c",
+            &format!("init.defaultBranch={branch}"),
+            "init",
+            "--quiet",
+        ]);
+        run(&[
+            "-c",
+            "user.name=test",
+            "-c",
+            "user.email=test@example.com",
+            "commit",
+            "--allow-empty",
+            "--quiet",
+            "-m",
+            "init",
+        ]);
+        run(&["remote", "add", "origin", origin_url]);
     }
 }


### PR DESCRIPTION
## Summary

- `build_manifest_git()` was called with the CLI's cwd. When fabro is invoked from a workspace directory that contains a different git repo at `[run] working_dir` (e.g. `working_dir = "repos/foo"` in `.fabro/project.toml`), the manifest's `git.branch` and `git.origin_url` were detected from the **workspace** repo instead of the **target** repo.
- This caused `base_branch` in the run record to be wrong (workspace branch, not target branch), while `host_repo_path` correctly pointed at the target — creating a mismatch that also triggered a harmless-but-confusing "push non-existent branch to target remote" warning from `resolve_worktree_plan`.

## Change

Resolve `working_directory` once in `build_run_manifest`, share it with `resolve_manifest_goal` (dropping the duplicate resolution that was already happening inside it), and pass it to `build_manifest_git`. Rename the `build_manifest_git` parameter from `cwd` to `repo_path` to reflect what it actually receives.

## Attribution

This ports @durandom's fix in https://github.com/durandom/fabro/pull/2 to the current fabro-2 code (where `Settings` has been renamed to `SettingsLayer`). Commit authored to Marcel Hild to preserve credit.

## Regression test

Added `build_manifest_git_follows_working_directory_into_nested_repo` in `manifest_builder.rs`. It creates a workspace git repo on `workspace-branch` with origin `example/workspace`, nests a separate target git repo at `repos/target` on `target-branch` with origin `example/target`, points `[run] working_dir` at the target, and asserts the manifest's `git.branch` == `target-branch` and `git.origin_url` == `https://github.com/example/target`.

Confirmed the test fails on `main` with `left: "workspace-branch" right: "target-branch"` and passes after the fix.

Closes #159

## Test plan
- [x] `cargo nextest run -p fabro-cli` — 710 passed, 0 failed
- [x] `cargo +nightly-2026-04-14 fmt --check --all`
- [x] `cargo +nightly-2026-04-14 clippy -p fabro-cli --all-targets -- -D warnings`
- [x] New regression test fails on unfixed code, passes with the fix