### PR TITLE
chore(deps): bump rustls-webpki to 0.103.13 (GHSA-82j2-j2ch-gfr8)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5740,9 +5740,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",


### PR DESCRIPTION
## Summary

- Bumps `rustls-webpki` from 0.103.12 → 0.103.13 to patch [GHSA-82j2-j2ch-gfr8](https://github.com/rustls/webpki/security/advisories/GHSA-82j2-j2ch-gfr8) (CVSS 7.5, high).
- A malformed CRL `BIT STRING` of `[0x00]` (zero padding bits, zero data bytes) trips an out-of-bounds index in `bit_string_flags()` and panics the process. Reachable through `BorrowedCertRevocationList::from_der()` via the `issuingDistributionPoint` CRL extension.
- Affects callers that opt into CRL checking via `RevocationOptions` and load CRL bytes from an attacker-influenced source. Default rustls config is unaffected.
- Resolves Dependabot alert [#25](https://github.com/fabro-sh/fabro/security/dependabot/25).

Lockfile-only change — no other dependencies updated.

## Test plan

- [x] `cargo check --workspace --all-targets` passes locally
- [ ] CI green (workspace tests + clippy + fmt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)