### PR TITLE
ci: add dylint try_io_result check

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -74,6 +74,25 @@ jobs:
           cache-on-failure: true
       - run: cargo +nightly-2026-04-14 clippy --workspace --all-targets -- -D warnings
 
+  dylint:
+    name: Dylint
+    runs-on: ubuntu-24.04-x86-32-cores
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
+        with:
+          toolchain: nightly-2025-09-18
+          components: rustc-dev,llvm-tools-preview
+      - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
+        with:
+          cache-on-failure: true
+      - run: cargo install cargo-dylint dylint-link --version 5.0.0
+      - run: cargo dylint --all --workspace -- --all-targets
+
   generated-docs:
     name: Generated Docs
     runs-on: ubuntu-24.04-x86-32-cores

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - `cargo +nightly-2026-04-14 fmt --check --all` — check formatting (pinned nightly required for rustfmt config; CI uses the same date)
 - `cargo +nightly-2026-04-14 fmt --all` — auto-format
 - `cargo +nightly-2026-04-14 clippy --workspace --all-targets -- -D warnings` — lint (CI runs nightly clippy to match; install with `rustup toolchain install nightly-2026-04-14 --profile minimal --component clippy,rustfmt`)
+- `cargo dylint --all --workspace -- --all-targets` — run configured Dylint libraries (`try_io_result`); install with `rustup toolchain install nightly-2025-09-18 --profile minimal --component rustc-dev,llvm-tools-preview && cargo install cargo-dylint dylint-link --version 5.0.0`
 
 macOS note: if `cargo nextest run` fails with `Too many open files (os error 24)` / `EMFILE`, raise the shell's soft FD limit before running tests, for example `ulimit -n 4096 && cargo nextest run --workspace`. Some terminals and inherited agent sessions start with `ulimit -n 256`, which is too low for the shared CLI test daemon under parallel nextest load.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,6 +126,11 @@ use_self = "warn"
 wildcard_imports = "warn"
 absolute_paths = "warn"
 
+[workspace.metadata.dylint]
+libraries = [
+  { git = "https://github.com/trailofbits/dylint", tag = "v5.0.0", pattern = "examples/restriction/try_io_result" },
+]
+
 [profile.release]
 lto = "thin"
 strip = true


### PR DESCRIPTION
## Summary

Adds Trail of Bits Dylint's `try_io_result` example lint to the workspace and runs it in Rust CI as a warning-only check. This surfaces lossy `std::io::Result` propagation without blocking the existing baseline, and documents the local command and pinned toolchain prerequisites for contributors.

## Verification

- `cargo dylint --all --workspace -- --all-targets` exits 0 with the current `try_io_result` warning baseline
- `cargo +nightly-2026-04-14 fmt --check --all`
- `git diff --check`

---

[![Compound Engineering](https://img.shields.io/badge/Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with GPT-5 via [Codex](https://openai.com/codex)