### PR TITLE
fix(docs): point docs.json to renamed stage events endpoint

### DIFF
--- a/docs/public/docs.json
+++ b/docs/public/docs.json
@@ -214,7 +214,7 @@
                 "pages": [
                   "GET /api/v1/runs/{id}/checkpoint",
                   "GET /api/v1/runs/{id}/stages",
-                  "GET /api/v1/runs/{id}/stages/{stageId}/turns",
+                  "GET /api/v1/runs/{id}/stages/{stageId}/events",
                   "GET /api/v1/runs/{id}/settings"
                 ]
               }


### PR DESCRIPTION
## Summary
- `docs.json` referenced `GET /api/v1/runs/{id}/stages/{stageId}/turns`, but that operation was renamed to `/events` in `fabro-api.yaml` between the last passing and first failing Mintlify deploy.
- Mintlify could not resolve the operation under the API Reference tab and reported `Failed to fetch OpenAPI file for anchor or tab`, failing every docs deploy on `main` since commit `e40dc7d9a`.

## Verification
- Cross-checked every operation page reference in `docs/public/docs.json` against operations defined in `docs/public/api-reference/fabro-api.yaml`; all references now resolve.

## Test plan
- [ ] Mintlify Deployment check turns green on this PR
- [ ] After merge, https://docs.fabro.sh updates and the API Reference > Run Internals group shows the renamed `List Stage Events` endpoint