### PR TITLE
fix(sandbox): resolve bash via PATH instead of /bin/bash

### DIFF
--- a/lib/crates/fabro-sandbox/src/local.rs
+++ b/lib/crates/fabro-sandbox/src/local.rs
@@ -358,7 +358,7 @@ impl Sandbox for LocalSandbox {
         let effective_dir =
             working_dir.map_or_else(|| self.working_directory.clone(), std::path::PathBuf::from);
 
-        let mut cmd = Command::new("/bin/bash");
+        let mut cmd = Command::new("bash");
         cmd.arg("-c")
             .arg(command)
             .current_dir(&effective_dir)
@@ -435,7 +435,7 @@ impl Sandbox for LocalSandbox {
         let effective_dir =
             working_dir.map_or_else(|| self.working_directory.clone(), std::path::PathBuf::from);
 
-        let mut cmd = Command::new("/bin/bash");
+        let mut cmd = Command::new("bash");
         cmd.arg("-c")
             .arg(command)
             .current_dir(&effective_dir)
@@ -515,7 +515,7 @@ impl Sandbox for LocalSandbox {
         let effective_dir =
             working_dir.map_or_else(|| self.working_directory.clone(), std::path::PathBuf::from);
 
-        let mut cmd = Command::new("/bin/bash");
+        let mut cmd = Command::new("bash");
         cmd.arg("-lc")
             .arg(format!("exec {command}"))
             .current_dir(&effective_dir)


### PR DESCRIPTION
## Summary

The local sandbox provider hard-codes `/bin/bash` at three call sites in `fabro-sandbox/src/local.rs` (`exec_command`, `exec_command_streaming`, `spawn_stdio_process`). NixOS doesn't ship `/bin/bash` — only `/bin/sh` and `/usr/bin/env` are managed under `/`, with bash living on `PATH` at `/run/current-system/sw/bin/bash`. The result: a first run on NixOS dies on the very first sandbox call (the git probe) with `No such file or directory (os error 2)`, surfaced as `sandbox git unavailable`.

## Fix

Switch all three sites from `Command::new("/bin/bash")` to `Command::new("bash")`. `PATH` is already preserved by `filtered_env_vars` (and explicitly tested at `local.rs:1164`), so libc's `execvp` lookup resolves bash on every distribution that has it installed, including NixOS, without forcing users to symlink `/bin/bash`.

The `/bin/bash` references in `docker.rs` are unaffected — those execute inside containers where the path always exists.

## Credit

Diagnosis and proposed fix by @allouis in #232 — they ran the PATH-lookup variant locally on NixOS 26.05 and confirmed workflows ran cleanly without the symlink workaround.

Closes #232

---

[![Compound Engineering v2.60.0](https://img.shields.io/badge/Compound_Engineering-v2.60.0-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.7 (1M context, extended thinking) via [Claude Code](https://claude.com/claude-code)