### PR TITLE
chore(deps): patch openssl and rmcp Dependabot advisories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5736,9 +5736,9 @@ checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
 
 [[package]]
 name = "rmcp"
-version = "1.3.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2231b2c085b371c01bc90c0e6c1cab8834711b6394533375bdbf870b0166d419"
+checksum = "0810a9f717d9828f475fe1f629f4c305c8464b7f496c3a854b58d29e65f4058e"
 dependencies = [
  "async-trait",
  "base64",
@@ -5763,9 +5763,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "1.3.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36ea0e100fadf81be85d7ff70f86cd805c7572601d4ab2946207f36540854b43"
+checksum = "6aefac48c364756e97f04c0401ba3231e8607882c7c1d92da0437dc16307904d"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4765,15 +4765,14 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.78"
+version = "0.10.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f38c4372413cdaaf3cc79dd92d29d7d9f5ab09b51b10dded508fb90bb70b9222"
+checksum = "bf0b434746ee2832f4f0baf10137e1cabb18cbe6912c69e2e33263c45250f542"
 dependencies = [
  "bitflags",
  "cfg-if",
  "foreign-types",
  "libc",
- "once_cell",
  "openssl-macros",
  "openssl-sys",
 ]
@@ -4812,9 +4811,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.114"
+version = "0.9.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
+checksum = "158fe5b292746440aa6e7a7e690e55aeb72d41505e2804c23c6973ad0e9c9781"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ git2 = { version = "0.20", default-features = false, features = ["vendored-libgi
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
 tracing-appender = "0.2"
-rmcp = { version = "1.3", default-features = false }
+rmcp = { version = "1.4", default-features = false }
 walkdir = "2"
 regex = "1"
 semver = "1"


### PR DESCRIPTION
## Summary

Patches all three open Dependabot alerts on `main`:

- **#26 / #28 (openssl, high + medium)** — bump `openssl` 0.10.78 → 0.10.79. Patches `GHSA-xp3w-r5p5-63rr` (UB in `X509Ref::ocsp_responders` for certs with non-UTF-8 OCSP URLs) and `GHSA-xv59-967r-8726` (heap buffer overflow in AES key-wrap-with-padding). Lockfile-only.
- **#27 (rmcp, high)** — bump workspace `rmcp` from `1.3` to `1.4`, which resolves to 1.7.0. Patches `GHSA-89vp-x53w-74fx` (DNS rebinding in the Streamable HTTP **server** transport). Fabro only uses the streamable-http **client** transport (`lib/crates/fabro-mcp/src/client.rs`), so practical exposure was nil — bumping anyway to stay on a supported, patched line.

Each fix is in its own commit so it can be reverted independently.

## Test plan

- [x] `cargo build --workspace` clean after each bump
- [x] `cargo nextest run -p fabro-mcp -p fabro-mcp-server` — 30/30 pass on rmcp 1.7
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)