### PR TITLE
feat(auth): opt-in FABRO_CLI_TRUST_HOST_AUTH so claude CLI can use a host-side Max subscription

### DIFF
--- a/lib/crates/fabro-auth/src/resolve.rs
+++ b/lib/crates/fabro-auth/src/resolve.rs
@@ -373,18 +373,31 @@ impl CredentialResolver {
         let provider = Provider::from_id(&credential.provider);
         let login_command = match (provider, &credential.details, kind) {
             // Opt-in: when FABRO_CLI_TRUST_HOST_AUTH is set, do not inject
-            // ANTHROPIC_API_KEY into the claude subprocess environment. claude
-            // CLI then falls back to its own credentials on the host (e.g. a
-            // Max subscription's OAuth session), so the registered API key is
-            // not billed for CLI-backend runs. A registered credential is
-            // still required to satisfy the resolver gate; the key value
-            // itself is never propagated to the subprocess.
+            // provider credentials into the CLI agent subprocess for the
+            // (provider, agent) pairs that support a host-side credential
+            // fallback (currently Anthropic+claude and OpenAI+codex). The CLI
+            // then resolves auth using whatever it finds on the host (e.g.
+            // ~/.claude/ for claude Max OAuth, ~/.codex/auth.json for a Codex
+            // ChatGPT Pro session). A registered credential is still required
+            // to satisfy the resolver gate; the secret material is never
+            // propagated to the subprocess and the codex_login_command
+            // (which would clobber ~/.codex/auth.json) is skipped.
             //
             // The flag must reach the worker subprocess that runs the
             // credential resolver; see WORKER_ENV_ALLOWLIST in
             // `lib/crates/fabro-server/src/spawn_env.rs`.
             (Some(Provider::Anthropic), AuthDetails::ApiKey { .. }, CliAgentKind::Claude)
-                if claude_cli_trust_host_auth() =>
+                if cli_trust_host_auth() =>
+            {
+                None
+            }
+            (Some(Provider::OpenAi), AuthDetails::ApiKey { .. }, CliAgentKind::Codex)
+                if cli_trust_host_auth() =>
+            {
+                None
+            }
+            (Some(Provider::OpenAi), AuthDetails::CodexOAuth { .. }, CliAgentKind::Codex)
+                if cli_trust_host_auth() =>
             {
                 None
             }
@@ -475,18 +488,26 @@ fn primary_api_key_env_var(provider: &ProviderId) -> Option<&'static str> {
 
 /// Read the opt-in `FABRO_CLI_TRUST_HOST_AUTH` flag.
 ///
-/// When set to a truthy value, Fabro skips injecting provider API-key env vars
-/// into the CLI agent subprocess for providers that support a host-side
-/// credential fallback (currently: Anthropic + claude). The CLI then resolves
-/// auth using whatever it finds on the host (for example, a Max subscription
-/// OAuth session under `~/.claude/`).
+/// When set to a truthy value, Fabro skips injecting provider credentials into
+/// the CLI agent subprocess for (provider, agent) pairs that support a
+/// host-side credential fallback. Currently covered:
+///
+/// - Anthropic + claude: skip `ANTHROPIC_API_KEY` injection. claude CLI then
+///   resolves auth from `~/.claude/` (e.g. a Max subscription OAuth session).
+/// - OpenAI + codex: skip `OPENAI_API_KEY` injection AND skip the
+///   `codex login --with-api-key` step that would clobber `~/.codex/auth.json`.
+///   codex CLI then resolves auth from `~/.codex/auth.json` (e.g. a ChatGPT
+///   Pro OAuth session).
+///
+/// A registered credential is still required in both cases to satisfy the
+/// resolver gate; the secret material is never propagated to the subprocess.
 ///
 /// Truthy: any non-empty value except `0` / `false` (case-insensitive).
 #[expect(
     clippy::disallowed_methods,
     reason = "Opt-in env flag for trusting host-side CLI credentials instead of injecting API keys into subprocesses."
 )]
-fn claude_cli_trust_host_auth() -> bool {
+fn cli_trust_host_auth() -> bool {
     std::env::var(EnvVars::FABRO_CLI_TRUST_HOST_AUTH)
         .ok()
         .is_some_and(|value| {

--- a/lib/crates/fabro-auth/src/resolve.rs
+++ b/lib/crates/fabro-auth/src/resolve.rs
@@ -372,6 +372,22 @@ impl CredentialResolver {
         let mut env_vars = HashMap::new();
         let provider = Provider::from_id(&credential.provider);
         let login_command = match (provider, &credential.details, kind) {
+            // Opt-in: when FABRO_CLI_TRUST_HOST_AUTH is set, do not inject
+            // ANTHROPIC_API_KEY into the claude subprocess environment. claude
+            // CLI then falls back to its own credentials on the host (e.g. a
+            // Max subscription's OAuth session), so the registered API key is
+            // not billed for CLI-backend runs. A registered credential is
+            // still required to satisfy the resolver gate; the key value
+            // itself is never propagated to the subprocess.
+            //
+            // The flag must reach the worker subprocess that runs the
+            // credential resolver; see WORKER_ENV_ALLOWLIST in
+            // `lib/crates/fabro-server/src/spawn_env.rs`.
+            (Some(Provider::Anthropic), AuthDetails::ApiKey { .. }, CliAgentKind::Claude)
+                if claude_cli_trust_host_auth() =>
+            {
+                None
+            }
             (Some(Provider::OpenAi), AuthDetails::ApiKey { key }, CliAgentKind::Codex) => {
                 env_vars.insert(EnvVars::OPENAI_API_KEY.to_string(), key.clone());
                 Some(codex_login_command(key))
@@ -454,6 +470,28 @@ fn primary_api_key_env_var(provider: &ProviderId) -> Option<&'static str> {
         .find_map(|credential_ref| match credential_ref {
             CredentialRef::Env(name) => Some(name.as_str()),
             CredentialRef::Credential(_) => None,
+        })
+}
+
+/// Read the opt-in `FABRO_CLI_TRUST_HOST_AUTH` flag.
+///
+/// When set to a truthy value, Fabro skips injecting provider API-key env vars
+/// into the CLI agent subprocess for providers that support a host-side
+/// credential fallback (currently: Anthropic + claude). The CLI then resolves
+/// auth using whatever it finds on the host (for example, a Max subscription
+/// OAuth session under `~/.claude/`).
+///
+/// Truthy: any non-empty value except `0` / `false` (case-insensitive).
+#[expect(
+    clippy::disallowed_methods,
+    reason = "Opt-in env flag for trusting host-side CLI credentials instead of injecting API keys into subprocesses."
+)]
+fn claude_cli_trust_host_auth() -> bool {
+    std::env::var(EnvVars::FABRO_CLI_TRUST_HOST_AUTH)
+        .ok()
+        .is_some_and(|value| {
+            let trimmed = value.trim();
+            !trimmed.is_empty() && trimmed != "0" && !trimmed.eq_ignore_ascii_case("false")
         })
 }
 

--- a/lib/crates/fabro-server/src/spawn_env.rs
+++ b/lib/crates/fabro-server/src/spawn_env.rs
@@ -13,6 +13,7 @@ const WORKER_ENV_ALLOWLIST: &[&str] = &[
     EnvVars::FABRO_LOG,
     EnvVars::FABRO_HOME,
     EnvVars::FABRO_STORAGE_ROOT,
+    EnvVars::FABRO_CLI_TRUST_HOST_AUTH,
     EnvVars::TERM,
     EnvVars::NO_COLOR,
     EnvVars::CLICOLOR,

--- a/lib/crates/fabro-static/src/env_vars.rs
+++ b/lib/crates/fabro-static/src/env_vars.rs
@@ -10,6 +10,7 @@ impl EnvVars {
     pub const FABRO_BUILD_DATE: &'static str = "FABRO_BUILD_DATE";
     pub const FABRO_BUILD_PROFILE: &'static str = "FABRO_BUILD_PROFILE";
     pub const FABRO_BUILD_PROFILE_SUFFIX: &'static str = "FABRO_BUILD_PROFILE_SUFFIX";
+    pub const FABRO_CLI_TRUST_HOST_AUTH: &'static str = "FABRO_CLI_TRUST_HOST_AUTH";
     pub const FABRO_CONFIG: &'static str = "FABRO_CONFIG";
     pub const FABRO_DEBUG: &'static str = "FABRO_DEBUG";
     pub const FABRO_DEV_TOKEN: &'static str = "FABRO_DEV_TOKEN";
@@ -151,6 +152,7 @@ mod tests {
             EnvVars::FABRO_BUILD_DATE,
             EnvVars::FABRO_BUILD_PROFILE,
             EnvVars::FABRO_BUILD_PROFILE_SUFFIX,
+            EnvVars::FABRO_CLI_TRUST_HOST_AUTH,
             EnvVars::FABRO_CONFIG,
             EnvVars::FABRO_DEBUG,
             EnvVars::FABRO_DEV_TOKEN,


### PR DESCRIPTION
## Problem

For operators on a Claude Max subscription who want to use the `cli` backend with `provider="anthropic"`, the current behavior silently bills the registered Anthropic API key per token rather than consuming Max quota. The flow:

1. Operator runs `fabro provider login --provider anthropic` and registers an API key.
2. Operator authors a workflow with `backend="cli"` (the documented path to use the inner `claude` CLI's own auth).
3. On run, Fabro's credential resolver returns `CliCredential { env_vars: { "ANTHROPIC_API_KEY": ... } }`. `launch_env.rs` injects that into the spawned subprocess. claude CLI sees `ANTHROPIC_API_KEY` in its env and prefers it over any host-side OAuth credentials it already has.
4. The run consumes API tokens, billed against the registered key, even though the operator has Max and wants to use it.

Verified on `0.232.0-nightly.0` against the latest claude CLI (2.1.77):

- claude CLI's init payload in `agent.cli.completed` reports `apiKeySource: "ANTHROPIC_API_KEY"`.
- Anthropic Console balance shows real per-token spend (confirmed at `total_cost_usd: 0.063` on a trivial single-step lookup).

This is a blocker for the subscription-only deployment shape: any operator who wants Fabro orchestration with Max-covered execution cannot get there with current Fabro.

## Short-term fix in this PR

Add an opt-in env var, `FABRO_CLI_TRUST_HOST_AUTH`. Three files, +41 lines:

- `lib/crates/fabro-static/src/env_vars.rs`: declare the constant.
- `lib/crates/fabro-server/src/spawn_env.rs`: add it to `WORKER_ENV_ALLOWLIST` so it reaches the worker that runs the resolver.
- `lib/crates/fabro-auth/src/resolve.rs`: when the flag is truthy AND the credential is `(Provider::Anthropic, AuthDetails::ApiKey, CliAgentKind::Claude)`, `to_cli_credential` returns `CliCredential { env_vars: empty, login_command: None }`.

Behavior unchanged for: any unset / falsy flag value, any provider other than Anthropic, any credential variant other than `ApiKey`, any CLI agent other than Claude. Existing API-key users see no change.

When the flag is set, claude CLI starts with no `ANTHROPIC_API_KEY` in its environment and falls back to whatever credentials it finds on the host (typically a Max subscription OAuth session at `~/.claude/`). End-to-end verification on a Max subscription:

- `apiKeySource` in the agent.cli init payload flips from `"ANTHROPIC_API_KEY"` to `"none"`.
- Anthropic Console-side token counts do not increase across patched runs.
- A registered Anthropic API key is still required to satisfy the resolver gate; the value is never propagated.

The reasoning behind the env-var-and-allowlist approach (rather than a settings.toml field): smallest possible diff, easy to reason about, easy to revert. Operator's settings.toml stays untouched. Happy to refactor to a `[providers.anthropic] cli_skip_env_credentials = true` field in `settings.toml` if you'd prefer that surface; the resolver-side logic is the same either way.

## A more robust solution we'd love to work on

This PR is the smallest correct change to unblock Max-subscription operators today. We'd be happy to follow up with a proper Anthropic OAuth credential path that mirrors the existing `CodexOAuth` shape for OpenAI:

- New `AuthDetails::AnthropicOAuth { tokens, account_id, ... }` variant alongside `AuthDetails::ApiKey`.
- `fabro provider login --provider anthropic` defaults to a browser OAuth PKCE flow (with `--api-key` fallback for headless setups), tied to the operator's Max account.
- Tokens stored in Fabro's vault; refresh handled by the existing `refresh_oauth_credential` infrastructure that already covers Codex.
- `to_cli_credential` for `(Anthropic, AnthropicOAuth, Claude)` either (a) returns an empty env_vars with a `login_command` that runs `claude /login` (or equivalent) on host-side, or (b) injects the OAuth access_token directly. Whichever matches Anthropic's actual CLI semantics; we'd dig into claude CLI's auth contract in the implementation.

The two approaches coexist cleanly. The env-var flag from this PR becomes "I'll manage claude's auth on the host myself"; the OAuth path becomes "Fabro manages it for me." Different deployment shapes call for different modes. No migration cost for operators on either path.

**Would you be open to a follow-on PR for the OAuth variant?** We have bandwidth to start on it today if there's interest. Happy to align on the credential-variant shape and the `provider login` UX before we write code, or to send a draft for review. If you'd prefer to leave the OAuth path on the roadmap and merge just this minimal env-var fix for now, that's a clean stopping point too.

## Notes

- This PR is from `gathercommunity/fabro`, a fork in the gather.community org. Filing on behalf of a small team that's building an agentic orchestration layer on Fabro for our own workflows.
- We've been running the patched binary for a few hours of testing against a real Max-subscription workflow; no surprises beyond what's documented here.
- The 3 test failures on `cargo test --release -p fabro-server --lib` in our environment (`install::tests::write_artifact_store_metadata_creates_marker_in_overridden_storage_root`, `serve::tests::build_object_store_from_settings_rejects_partial_static_credentials`, `serve::tests::build_slatedb_store_uses_configured_local_root`) reproduce on a clean `main` checkout in the same environment, so they are pre-existing environment-dependent issues unrelated to this change. Both `spawn_env` tests pass.

Thanks for Fabro. The DOT-graph model + the CLI-backend escape hatch is exactly the shape we needed.