### PR TITLE
refactor(llm): simplify catalog cleanup paths

### DIFF
--- a/apps/fabro-web/app/lib/format.ts
+++ b/apps/fabro-web/app/lib/format.ts
@@ -88,7 +88,14 @@ export function formatDurationMs(ms: number): string {
   return seconds > 0 ? `${minutes}m ${seconds}s` : `${minutes}m`;
 }
 
-export function formatTokenCount(value: number): string {
+export function formatTokenCount(
+  value: number,
+  options: { compactDecimal?: boolean } = {},
+): string {
+  if (options.compactDecimal) {
+    if (value < 1_000_000) return `${(value / 1000).toFixed(1)}k`;
+    return `${(value / 1_000_000).toFixed(1)}M`;
+  }
   if (value < 1000) return `${value}`;
   if (value < 1_000_000) return `${Math.round(value / 1000)}k`;
   return `${Math.round(value / 1_000_000)}M`;

--- a/apps/fabro-web/app/routes/run-billing.tsx
+++ b/apps/fabro-web/app/routes/run-billing.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from "react";
 
 import { EmptyState } from "../components/state";
-import { formatDurationSecs } from "../lib/format";
+import { formatDurationSecs, formatTokenCount } from "../lib/format";
 import { useRunBilling } from "../lib/queries";
 import { IN_FLIGHT_STAGE_STATES } from "../lib/stage-sidebar";
 import { useTickingNow } from "../lib/time";
@@ -15,7 +15,7 @@ const EMPTY_VALUE = "—";
 
 function formatTokens(n: number | null | undefined) {
   if (n == null) return EMPTY_VALUE;
-  return `${(n / 1000).toFixed(1)}k`;
+  return formatTokenCount(n, { compactDecimal: true });
 }
 
 function formatUsdMicros(usdMicros?: number | null) {

--- a/lib/crates/fabro-agent/src/profiles/openai.rs
+++ b/lib/crates/fabro-agent/src/profiles/openai.rs
@@ -226,11 +226,16 @@ in the project.");
 mod tests {
     use std::sync::Arc;
 
+    use fabro_model::catalog::LlmCatalogSettings;
     use tokio::sync::Mutex as AsyncMutex;
 
     use super::*;
     use crate::subagent::{SessionFactory, SubAgentManager};
     use crate::test_support::MockSandbox;
+
+    fn test_catalog() -> Arc<Catalog> {
+        Arc::new(Catalog::from_builtin_with_overrides(&LlmCatalogSettings::default()).unwrap())
+    }
 
     #[test]
     fn openai_profile_identity() {
@@ -326,33 +331,41 @@ mod tests {
     }
 
     #[test]
-    fn kimi_provider_prompt_says_moonshot() {
-        let profile = OpenAiProfile::new("kimi-k2.5").with_provider(Provider::Kimi);
+    fn kimi_provider_prompt_uses_catalog_display_name() {
+        let profile = OpenAiProfile::new("kimi-k2.5")
+            .with_provider(Provider::Kimi)
+            .with_catalog(test_catalog());
         let env = MockSandbox::linux();
         let prompt = profile.build_system_prompt(&env, &EnvContext::default(), &[], None, &[]);
-        assert!(prompt.contains("powered by Moonshot"));
+        assert!(prompt.contains("powered by Kimi"));
         assert!(!prompt.contains("powered by OpenAI"));
     }
 
     #[test]
-    fn zai_provider_prompt_says_zhipu() {
-        let profile = OpenAiProfile::new("glm-4.7").with_provider(Provider::Zai);
+    fn zai_provider_prompt_uses_catalog_display_name() {
+        let profile = OpenAiProfile::new("glm-4.7")
+            .with_provider(Provider::Zai)
+            .with_catalog(test_catalog());
         let env = MockSandbox::linux();
         let prompt = profile.build_system_prompt(&env, &EnvContext::default(), &[], None, &[]);
-        assert!(prompt.contains("powered by Zhipu AI"));
+        assert!(prompt.contains("powered by Z.ai"));
     }
 
     #[test]
-    fn minimax_provider_prompt_says_minimax() {
-        let profile = OpenAiProfile::new("minimax-m2.5").with_provider(Provider::Minimax);
+    fn minimax_provider_prompt_uses_catalog_display_name() {
+        let profile = OpenAiProfile::new("minimax-m2.5")
+            .with_provider(Provider::Minimax)
+            .with_catalog(test_catalog());
         let env = MockSandbox::linux();
         let prompt = profile.build_system_prompt(&env, &EnvContext::default(), &[], None, &[]);
         assert!(prompt.contains("powered by MiniMax"));
     }
 
     #[test]
-    fn inception_provider_prompt_says_inception() {
-        let profile = OpenAiProfile::new("mercury-2").with_provider(Provider::Inception);
+    fn inception_provider_prompt_uses_catalog_display_name() {
+        let profile = OpenAiProfile::new("mercury-2")
+            .with_provider(Provider::Inception)
+            .with_catalog(test_catalog());
         let env = MockSandbox::linux();
         let prompt = profile.build_system_prompt(&env, &EnvContext::default(), &[], None, &[]);
         assert!(prompt.contains("powered by Inception"));

--- a/lib/crates/fabro-agent/src/profiles/openai.rs
+++ b/lib/crates/fabro-agent/src/profiles/openai.rs
@@ -66,15 +66,15 @@ impl OpenAiProfile {
         self
     }
 
-    fn provider_display_name(&self) -> &str {
-        match self.base.provider {
-            Provider::OpenAi => "OpenAI",
-            Provider::Kimi => "Moonshot",
-            Provider::Zai => "Zhipu AI",
-            Provider::Minimax => "MiniMax",
-            Provider::Inception => "Inception",
-            other => <&'static str>::from(other),
-        }
+    fn provider_display_name(&self) -> String {
+        self.base
+            .catalog
+            .as_ref()
+            .and_then(|catalog| catalog.provider(&self.base.provider_id))
+            .map_or_else(
+                || self.base.provider.display_name().to_string(),
+                |provider| provider.display_name.clone(),
+            )
     }
 }
 

--- a/lib/crates/fabro-auth/src/resolve.rs
+++ b/lib/crates/fabro-auth/src/resolve.rs
@@ -12,6 +12,8 @@ use tokio::sync::RwLock as AsyncRwLock;
 use tokio::task::spawn_blocking;
 
 use crate::credential::{ApiKeyHeader, AuthCredential, AuthDetails, credential_id_for};
+use crate::credential_source::CredentialSource;
+use crate::env_source::EnvCredentialSource;
 use crate::refresh::refresh_oauth_credential;
 use crate::vault_ext::{vault_get_credential, vault_set_credential};
 
@@ -267,14 +269,19 @@ impl CredentialResolver {
         provider: &CatalogProvider,
         catalog: &Catalog,
     ) -> bool {
-        provider.credentials.iter().any(|credential_ref| {
+        let has_declared_credential = provider.credentials.iter().any(|credential_ref| {
             self.credential_from_ref(vault, &provider.id, credential_ref)
                 .is_some()
-        }) || (!provider.extra_headers.is_empty()
+        });
+        let has_provider_id_credential =
+            vault_get_credential(vault, provider.id.as_str()).is_some();
+        let has_header_only_credentials = !provider.extra_headers.is_empty()
             && provider.credentials.is_empty()
             && self
                 .resolved_extra_headers_for_catalog(vault, &provider.id, catalog)
-                .is_ok())
+                .is_ok();
+
+        has_declared_credential || has_provider_id_credential || has_header_only_credentials
     }
 
     fn credential_from_ref(
@@ -482,26 +489,12 @@ pub async fn configured_providers_from_process_env(
             let guard = vault_arc.read().await;
             resolver.configured_providers(&guard, catalog)
         }
-        None => catalog
-            .providers()
-            .iter()
-            .filter(|provider| provider_has_process_env_api_key(provider))
-            .map(|provider| provider.id.clone())
-            .collect(),
+        None => {
+            EnvCredentialSource::new()
+                .configured_providers(catalog)
+                .await
+        }
     }
-}
-
-#[expect(
-    clippy::disallowed_methods,
-    reason = "Provider discovery intentionally checks documented API-key env names."
-)]
-fn provider_has_process_env_api_key(provider: &CatalogProvider) -> bool {
-    provider
-        .credentials
-        .iter()
-        .any(|credential_ref| {
-            matches!(credential_ref, CredentialRef::Env(name) if std::env::var(name).is_ok())
-        })
 }
 
 fn primary_api_key_env_var<'a>(provider: &ProviderId, catalog: &'a Catalog) -> Option<&'a str> {

--- a/lib/crates/fabro-cli/src/commands/run/overrides.rs
+++ b/lib/crates/fabro-cli/src/commands/run/overrides.rs
@@ -2,7 +2,9 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use anyhow::{Result, anyhow};
-use fabro_config::{CliLayer, CliOutputLayer, RunGoalLayer, RunLayer, parse_input_overrides};
+use fabro_config::{
+    CliLayer, CliOutputLayer, RunGoalLayer, RunLayer, parse_input_overrides, parse_labels,
+};
 use fabro_manifest::{RunOverrideInput, build_run_overrides};
 use fabro_sandbox::SandboxProvider;
 use fabro_types::settings::cli::OutputVerbosity;
@@ -19,14 +21,6 @@ pub(crate) struct ManifestSettingsOverrides {
 
 fn sparse_flag(value: bool) -> Option<bool> {
     value.then_some(true)
-}
-
-pub(crate) fn parse_labels(labels: &[String]) -> HashMap<String, String> {
-    labels
-        .iter()
-        .filter_map(|label| label.split_once('='))
-        .map(|(key, value)| (key.to_string(), value.to_string()))
-        .collect()
 }
 
 fn cli_layer_for_verbose(verbose: bool) -> Option<CliLayer> {

--- a/lib/crates/fabro-config/src/input_overrides.rs
+++ b/lib/crates/fabro-config/src/input_overrides.rs
@@ -62,6 +62,15 @@ pub fn parse_input_overrides(
     Ok(parsed)
 }
 
+#[must_use]
+pub fn parse_labels(labels: &[String]) -> HashMap<String, String> {
+    labels
+        .iter()
+        .filter_map(|label| label.split_once('='))
+        .map(|(key, value)| (key.to_string(), value.to_string()))
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -69,6 +78,21 @@ mod tests {
     fn parse_one(key: &str, raw_value: &str) -> Result<toml::Value, InputOverrideParseError> {
         parse_input_overrides(&[format!("{key}={raw_value}")])
             .map(|mut parsed| parsed.remove(key).expect("input should be present"))
+    }
+
+    #[test]
+    fn parse_labels_keeps_key_value_pairs() {
+        assert_eq!(
+            parse_labels(&[
+                "environment=prod".to_string(),
+                "missing_equals".to_string(),
+                "owner=platform".to_string(),
+            ]),
+            HashMap::from([
+                ("environment".to_string(), "prod".to_string()),
+                ("owner".to_string(), "platform".to_string()),
+            ])
+        );
     }
 
     #[test]

--- a/lib/crates/fabro-config/src/lib.rs
+++ b/lib/crates/fabro-config/src/lib.rs
@@ -37,7 +37,7 @@ pub use builders::{
 pub use error::{Error, Result};
 pub use fabro_util::path::expand_tilde;
 pub use home::Home;
-pub use input_overrides::{InputOverrideParseError, parse_input_overrides};
+pub use input_overrides::{InputOverrideParseError, parse_input_overrides, parse_labels};
 pub use layers::{
     CliAuthLayer, CliExecAgentLayer, CliExecLayer, CliExecModelLayer, CliLayer, CliLoggingLayer,
     CliOutputLayer, CliTargetLayer, CliUpdatesLayer, CostRates, CredentialRef,

--- a/lib/crates/fabro-model/src/adapter.rs
+++ b/lib/crates/fabro-model/src/adapter.rs
@@ -11,6 +11,8 @@
 use strum::VariantArray;
 
 use crate::Speed;
+use crate::ids::ProviderId;
+use crate::provider::Provider;
 use crate::reasoning::ReasoningEffort;
 
 /// Internal dispatch key that `fabro-agent` maps to a concrete agent profile.
@@ -135,6 +137,25 @@ pub fn get(key: &str) -> Option<&'static AdapterMetadata> {
 /// Iterate every registered adapter key.
 pub fn keys() -> impl Iterator<Item = &'static str> {
     ALL_ADAPTERS.iter().map(|a| a.key)
+}
+
+/// Default adapter key for a provider ID when no explicit catalog provider row
+/// is available.
+#[must_use]
+pub fn default_for_provider_id(provider: &ProviderId) -> &'static str {
+    match Provider::from_id(provider) {
+        Some(Provider::Anthropic) => ANTHROPIC.key,
+        Some(Provider::OpenAi) => OPENAI.key,
+        Some(Provider::Gemini) => GEMINI.key,
+        Some(
+            Provider::Kimi
+            | Provider::Zai
+            | Provider::Minimax
+            | Provider::Inception
+            | Provider::OpenAiCompatible,
+        )
+        | None => OPENAI_COMPATIBLE.key,
+    }
 }
 
 #[cfg(test)]

--- a/lib/crates/fabro-model/src/billing.rs
+++ b/lib/crates/fabro-model/src/billing.rs
@@ -115,6 +115,13 @@ pub enum Speed {
     Fast,
 }
 
+impl Speed {
+    #[must_use]
+    pub fn variants() -> &'static [Self] {
+        <Self as strum::VariantArray>::VARIANTS
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct ModelRef {
     pub provider: ProviderId,
@@ -530,26 +537,14 @@ impl Model {
             return None;
         }
         let provider = self.builtin_provider()?;
+        let provider_id = provider.id();
         pricing_for_model_costs(
             self,
-            provider.id(),
-            adapter_key_for_builtin_provider(provider),
+            provider_id.clone(),
+            adapter::default_for_provider_id(&provider_id),
             speed,
             &self.costs,
         )
-    }
-}
-
-fn adapter_key_for_builtin_provider(provider: Provider) -> &'static str {
-    match provider {
-        Provider::Anthropic => adapter::ANTHROPIC.key,
-        Provider::OpenAi => adapter::OPENAI.key,
-        Provider::Gemini => adapter::GEMINI.key,
-        Provider::Kimi
-        | Provider::Zai
-        | Provider::Minimax
-        | Provider::Inception
-        | Provider::OpenAiCompatible => adapter::OPENAI_COMPATIBLE.key,
     }
 }
 

--- a/lib/crates/fabro-model/src/catalog.rs
+++ b/lib/crates/fabro-model/src/catalog.rs
@@ -638,7 +638,7 @@ impl Catalog {
             providers.push(CatalogProvider {
                 id:            model.provider.clone(),
                 display_name:  Provider::display_name_for_id(&model.provider),
-                adapter:       default_adapter_for_provider(&model.provider).to_string(),
+                adapter:       adapter::default_for_provider_id(&model.provider).to_string(),
                 base_url:      None,
                 credentials:   Vec::new(),
                 extra_headers: HashMap::new(),
@@ -1474,22 +1474,6 @@ fn validate_builtin_fragment(
         }
     }
     Ok(())
-}
-
-fn default_adapter_for_provider(provider: &ProviderId) -> &'static str {
-    match Provider::from_id(provider) {
-        Some(Provider::Anthropic) => adapter::ANTHROPIC.key,
-        Some(Provider::OpenAi) => adapter::OPENAI.key,
-        Some(Provider::Gemini) => adapter::GEMINI.key,
-        Some(
-            Provider::Kimi
-            | Provider::Zai
-            | Provider::Minimax
-            | Provider::Inception
-            | Provider::OpenAiCompatible,
-        )
-        | None => adapter::OPENAI_COMPATIBLE.key,
-    }
 }
 
 fn default_controls_for_model(model: &Model) -> CatalogModelControls {

--- a/lib/crates/fabro-model/src/reasoning.rs
+++ b/lib/crates/fabro-model/src/reasoning.rs
@@ -32,6 +32,13 @@ pub enum ReasoningEffort {
     Max,
 }
 
+impl ReasoningEffort {
+    #[must_use]
+    pub fn variants() -> &'static [Self] {
+        <Self as strum::VariantArray>::VARIANTS
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::str::FromStr;

--- a/lib/crates/fabro-server/src/run_manifest.rs
+++ b/lib/crates/fabro-server/src/run_manifest.rs
@@ -10,7 +10,7 @@ use fabro_auth::auth_issue_message;
 use fabro_config::run::parse_run_layer_from_settings_toml;
 use fabro_config::{
     CliLayer, CliOutputLayer, DaytonaDockerfileLayer, RunLayer, WorkflowSettingsBuilder,
-    parse_input_overrides,
+    parse_input_overrides, parse_labels,
 };
 use fabro_graphviz::graph::{Graph, is_llm_handler_type};
 use fabro_graphviz::render::apply_direction;
@@ -357,14 +357,6 @@ fn manifest_args_overrides(
         cli,
         input_overrides: parse_input_overrides(&args.input)?,
     })
-}
-
-fn parse_labels(labels: &[String]) -> HashMap<String, String> {
-    labels
-        .iter()
-        .filter_map(|label| label.split_once('='))
-        .map(|(key, value)| (key.to_string(), value.to_string()))
-        .collect()
 }
 
 fn resolve_working_directory(settings: &WorkflowSettings, caller_cwd: &Path) -> PathBuf {
@@ -935,59 +927,43 @@ async fn run_llm_check(
 ) -> bool {
     let (model, provider) = resolve_model_provider(settings, graph, configured_providers, catalog);
     let default_provider = provider.as_deref().unwrap_or("anthropic");
+    let mut model_providers = std::collections::BTreeSet::new();
+    let mut has_llm_nodes = false;
+
+    for node in graph.nodes.values() {
+        if !is_llm_handler_type(node.handler_type()) {
+            continue;
+        }
+        has_llm_nodes = true;
+        let node_model = node.model().unwrap_or(&model);
+        let node_provider = node.provider().unwrap_or(default_provider);
+        let (resolved_model, resolved_provider) = if let Some(info) = catalog.get(node_model) {
+            (info.id.clone(), info.provider.to_string())
+        } else {
+            (node_model.to_string(), node_provider.to_string())
+        };
+        let final_provider = if node.provider().is_some() {
+            node_provider.to_string()
+        } else {
+            resolved_provider
+        };
+        model_providers.insert((resolved_model, final_provider));
+    }
+
+    if !has_llm_nodes {
+        return true;
+    }
 
     match state.resolve_llm_client().await {
         Ok(result) => {
-            let configured = result
-                .client
-                .provider_names()
-                .iter()
-                .map(std::string::ToString::to_string)
-                .collect::<Vec<_>>();
             let auth_issues = result.auth_issues;
             let client = Arc::new(result.client);
-            let mut model_providers = std::collections::BTreeSet::new();
-            let mut has_llm_nodes = false;
-
-            for node in graph.nodes.values() {
-                if !is_llm_handler_type(node.handler_type()) {
-                    continue;
-                }
-                has_llm_nodes = true;
-                let node_model = node.model().unwrap_or(&model);
-                let node_provider = node.provider().unwrap_or(default_provider);
-                let (resolved_model, resolved_provider) =
-                    if let Some(info) = catalog.get(node_model) {
-                        (info.id.clone(), info.provider.to_string())
-                    } else {
-                        (node_model.to_string(), node_provider.to_string())
-                    };
-                let final_provider = if node.provider().is_some() {
-                    node_provider.to_string()
-                } else {
-                    resolved_provider
-                };
-                model_providers.insert((resolved_model, final_provider));
-            }
-
-            if !has_llm_nodes {
-                return true;
-            }
-
-            if model_providers.is_empty() {
-                let (resolved_model, resolved_provider) = if let Some(info) = catalog.get(&model) {
-                    (info.id.clone(), info.provider.to_string())
-                } else {
-                    (model.clone(), default_provider.to_string())
-                };
-                model_providers.insert((resolved_model, resolved_provider));
-            }
 
             let mut all_ok = true;
             let mut completed_checks: Vec<(usize, CheckResult)> = Vec::new();
             let mut pending_probes = Vec::new();
             for (index, (model_id, provider_name)) in model_providers.iter().enumerate() {
-                let provider_id = ProviderId::from(provider_name.as_str());
+                let provider_id = canonical_provider_id(catalog, provider_name);
                 if let Some((_, issue)) = auth_issues
                     .iter()
                     .find(|(candidate, _)| candidate == &provider_id)
@@ -1000,7 +976,7 @@ async fn run_llm_check(
                         details:     vec![CheckDetail::new(format!("Provider: {provider_name}"))],
                         remediation: Some(auth_issue_message(&provider_id, issue)),
                     }));
-                } else if !configured.iter().any(|name| name == provider_name) {
+                } else if !client.has_provider(provider_name) {
                     all_ok = false;
                     completed_checks.push((index, CheckResult {
                         name:        "LLM".into(),
@@ -1078,6 +1054,13 @@ async fn run_llm_check(
             false
         }
     }
+}
+
+fn canonical_provider_id(catalog: &Catalog, provider_name: &str) -> ProviderId {
+    let provider_id = ProviderId::from(provider_name);
+    catalog
+        .provider(&provider_id)
+        .map_or(provider_id, |provider| provider.id.clone())
 }
 
 fn resolve_model_provider(

--- a/lib/crates/fabro-server/src/server/handler/models.rs
+++ b/lib/crates/fabro-server/src/server/handler/models.rs
@@ -48,7 +48,7 @@ async fn list_models(
         .into_iter()
         .collect();
 
-    let mut models = catalog
+    let mut data = catalog
         .list(provider_id.as_ref())
         .into_iter()
         .filter(|model| match &query {
@@ -62,6 +62,8 @@ async fn list_models(
             }
             None => true,
         })
+        .skip(offset)
+        .take(limit + 1)
         .cloned()
         .map(|mut model| {
             model.configured = configured.contains(&model.provider);
@@ -69,13 +71,13 @@ async fn list_models(
         })
         .collect::<Vec<_>>();
 
-    let has_more = models.len() > offset.saturating_add(limit);
-    let data = models.drain(offset..models.len().min(offset.saturating_add(limit)));
+    let has_more = data.len() > limit;
+    data.truncate(limit);
 
     (
         StatusCode::OK,
         Json(serde_json::json!({
-            "data": data.collect::<Vec<_>>(),
+            "data": data,
             "meta": { "has_more": has_more }
         })),
     )

--- a/lib/crates/fabro-workflow/src/handler/llm/api.rs
+++ b/lib/crates/fabro-workflow/src/handler/llm/api.rs
@@ -240,8 +240,9 @@ fn parse_reasoning_effort(node: &Node, value: &str) -> Result<ReasoningEffort, E
     value.parse::<ReasoningEffort>().map_err(|source| {
         Error::handler_with_source(
             format!(
-                "Invalid reasoning_effort \"{value}\" for node \"{}\"; expected one of: low, medium, high, xhigh, max",
-                node.id
+                "Invalid reasoning_effort \"{value}\" for node \"{}\"; expected one of: {}",
+                node.id,
+                expected_values(ReasoningEffort::variants()),
             ),
             source,
         )
@@ -252,12 +253,24 @@ fn parse_speed(node: &Node, value: &str) -> Result<Speed, Error> {
     value.parse::<Speed>().map_err(|source| {
         Error::handler_with_source(
             format!(
-                "Invalid speed \"{value}\" for node \"{}\"; expected one of: standard, fast",
-                node.id
+                "Invalid speed \"{value}\" for node \"{}\"; expected one of: {}",
+                node.id,
+                expected_values(Speed::variants()),
             ),
             source,
         )
     })
+}
+
+fn expected_values<T>(values: &[T]) -> String
+where
+    T: ToString,
+{
+    values
+        .iter()
+        .map(ToString::to_string)
+        .collect::<Vec<_>>()
+        .join(", ")
 }
 
 fn legacy_reasoning_effort_default(catalog: &Catalog, model: &str) -> Option<ReasoningEffort> {

--- a/lib/crates/fabro-workflow/src/operations/start.rs
+++ b/lib/crates/fabro-workflow/src/operations/start.rs
@@ -14,7 +14,6 @@ use fabro_sandbox::daytona::DaytonaConfig;
 use fabro_sandbox::{DockerSandboxOptions, SandboxProvider, SandboxSpec};
 use fabro_static::EnvVars;
 use fabro_types::RunId;
-use fabro_types::settings::InterpString;
 use fabro_types::settings::run::{
     ApprovalMode, DaytonaNetworkLayer, DaytonaSettings, DockerSettings,
     DockerfileSource as ResolvedDockerfileSource, HookDefinition as ResolvedHookDefinition,
@@ -23,6 +22,7 @@ use fabro_types::settings::run::{
     PullRequestSettings, RunMode, RunModelSettings as ResolvedRunModelSettings,
     RunNamespace as ResolvedRunSettings, TlsMode as ResolvedTlsMode,
 };
+use fabro_types::settings::{InterpString, ModelRegistry, ResolvedModelRef};
 use fabro_vault::Vault;
 use tokio::runtime::Handle;
 use tokio::sync::RwLock as AsyncRwLock;
@@ -584,28 +584,71 @@ fn resolve_docker_config(settings: &ResolvedRunSettings) -> DockerSandboxOptions
 
 fn resolve_fallback_chain(
     catalog: &Catalog,
-    provider: &ProviderId,
+    _provider: &ProviderId,
     model: &str,
     settings: &ResolvedRunModelSettings,
 ) -> Vec<FallbackTarget> {
     if settings.fallbacks.is_empty() {
         return Vec::new();
     }
-    // Group v2 ModelRef entries by provider name, preserving the legacy
-    // shape expected by `Catalog::build_fallback_chain`. The historical
-    // bridge grouped all fallback tokens under the empty-string key; we
-    // preserve that behavior here so `Catalog::build_fallback_chain`
-    // returns an empty chain unless a consumer has explicitly wired
-    // provider-keyed fallbacks. A proper provider-aware fallback chain
-    // is a follow-up along with the model registry work.
-    let mut by_provider: HashMap<String, Vec<String>> = HashMap::new();
-    for model_ref in &settings.fallbacks {
-        by_provider
-            .entry(String::new())
-            .or_default()
-            .push(model_ref.to_string());
+    let registry = CatalogModelRegistry { catalog };
+    let primary = catalog.get(model);
+
+    settings
+        .fallbacks
+        .iter()
+        .filter_map(|model_ref| match model_ref.resolve(&registry).ok()? {
+            ResolvedModelRef::Provider(provider_name) => {
+                let provider_id = canonical_provider_id(catalog, &provider_name);
+                let reference = primary?;
+                catalog
+                    .closest(&provider_id, reference)
+                    .map(|model| FallbackTarget {
+                        provider: provider_id.to_string(),
+                        model:    model.id.clone(),
+                    })
+            }
+            ResolvedModelRef::Model { provider, model } => {
+                let provider =
+                    provider.map(|provider| canonical_provider_id(catalog, &provider).to_string());
+                if let Some(info) = catalog.get(&model) {
+                    let provider = provider.unwrap_or_else(|| info.provider.to_string());
+                    return Some(FallbackTarget {
+                        provider,
+                        model: info.id.clone(),
+                    });
+                }
+                provider.map(|provider| FallbackTarget { provider, model })
+            }
+        })
+        .collect()
+}
+
+fn canonical_provider_id(catalog: &Catalog, provider_name: &str) -> ProviderId {
+    let provider_id = ProviderId::from(provider_name);
+    catalog
+        .provider(&provider_id)
+        .map_or(provider_id, |provider| provider.id.clone())
+}
+
+struct CatalogModelRegistry<'a> {
+    catalog: &'a Catalog,
+}
+
+impl ModelRegistry for CatalogModelRegistry<'_> {
+    fn is_provider(&self, token: &str) -> bool {
+        self.catalog.provider(&ProviderId::from(token)).is_some()
     }
-    catalog.build_fallback_chain(provider, model, &by_provider)
+
+    fn is_model(&self, token: &str) -> bool {
+        self.catalog.get(token).is_some()
+    }
+
+    fn provider_of(&self, token: &str) -> Option<String> {
+        self.catalog
+            .get(token)
+            .map(|model| model.provider.to_string())
+    }
 }
 
 fn runtime_mcp_server(settings: &ResolvedMcpServerSettings) -> McpServerSettings {
@@ -1077,6 +1120,7 @@ mod tests {
     use fabro_config::{RunCloneLayer, RunExecutionLayer, RunLayer, WorkflowSettingsBuilder};
     use fabro_model::catalog::LlmCatalogSettings;
     use fabro_store::Database;
+    use fabro_types::settings::ModelRef;
     use fabro_types::settings::run::RunMode;
     use fabro_types::{WorkflowSettings, fixtures};
     use object_store::memory::InMemory;
@@ -1131,6 +1175,48 @@ mod tests {
             Catalog::from_builtin_with_overrides(&LlmCatalogSettings::default())
                 .expect("default catalog should build"),
         )
+    }
+
+    #[test]
+    fn resolve_fallback_chain_resolves_provider_fallbacks() {
+        let catalog = test_catalog();
+        let settings = ResolvedRunModelSettings {
+            fallbacks: vec!["openai".parse::<ModelRef>().unwrap()],
+            ..ResolvedRunModelSettings::default()
+        };
+
+        let chain = resolve_fallback_chain(
+            catalog.as_ref(),
+            &Provider::Anthropic.id(),
+            "claude-opus-4-6",
+            &settings,
+        );
+
+        assert_eq!(chain, vec![FallbackTarget {
+            provider: "openai".to_string(),
+            model:    "gpt-5.5".to_string(),
+        }]);
+    }
+
+    #[test]
+    fn resolve_fallback_chain_resolves_explicit_model_fallbacks() {
+        let catalog = test_catalog();
+        let settings = ResolvedRunModelSettings {
+            fallbacks: vec!["openai/gpt-5.4-mini".parse::<ModelRef>().unwrap()],
+            ..ResolvedRunModelSettings::default()
+        };
+
+        let chain = resolve_fallback_chain(
+            catalog.as_ref(),
+            &Provider::Anthropic.id(),
+            "claude-opus-4-6",
+            &settings,
+        );
+
+        assert_eq!(chain, vec![FallbackTarget {
+            provider: "openai".to_string(),
+            model:    "gpt-5.4-mini".to_string(),
+        }]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

This is a cleanup pass over the configurable LLM provider/catalog work from issue #210. It addresses reuse, quality, and efficiency findings from the phase 0-9 review without changing the public provider settings contract.

Notable changes:

- skip LLM client initialization during run preflight when the workflow has no LLM nodes
- make preflight provider checks use alias-aware `Client::has_provider`
- resolve `run.model.fallbacks` through the catalog instead of the old empty-key bridge
- paginate `/models` before cloning returned rows
- share label parsing, provider default-adapter lookup, enum expected-value formatting, and billing token formatting helpers
- use catalog provider display names for OpenAI-compatible agent profiles
- align process-env configured-provider discovery with `EnvCredentialSource`

## Verification

- `cargo check -p fabro-config -p fabro-model -p fabro-auth -p fabro-agent -p fabro-workflow -p fabro-server -p fabro-cli`
- `cargo nextest run -p fabro-config parse_labels_keeps_key_value_pairs`
- `cargo nextest run -p fabro-workflow resolve_fallback_chain_resolves`
- `cargo nextest run -p fabro-auth configured_providers`
- `cargo nextest run -p fabro-server list_models`
- `cargo +nightly-2026-04-14 fmt --check --all`
- `cargo +nightly-2026-04-14 clippy -p fabro-model -p fabro-auth -p fabro-workflow -p fabro-server -p fabro-agent -p fabro-config -p fabro-cli --all-targets -- -D warnings`
- `cd apps/fabro-web && bun test app/routes/run-billing.test.tsx`
- `cd apps/fabro-web && bun run typecheck`
- `git diff --check`