### PR TITLE
fix(web): raise timeout for build tests that run a real vite build

### DIFF
--- a/apps/fabro-web/scripts/build.test.ts
+++ b/apps/fabro-web/scripts/build.test.ts
@@ -43,7 +43,7 @@ test("production build copies Pierre worker assets", async () => {
   for (const wasmFile of wasmFiles) {
     expect(existsSync(join(workerDist, wasmFile))).toBe(true);
   }
-});
+}, 60000);
 
 test("dist is a symlink into .dist-builds and old builds are pruned", async () => {
   await runBuild();
@@ -62,7 +62,7 @@ test("dist is a symlink into .dist-builds and old builds are pruned", async () =
   expect(remaining).toEqual([buildId]);
 
   expect(existsSync(join(distPath, "index.html"))).toBe(true);
-});
+}, 60000);
 
 test("watch mode keeps running until interrupted", async () => {
   const process = Bun.spawn([


### PR DESCRIPTION
## Summary
- The TypeScript CI on main started failing because two tests in `apps/fabro-web/scripts/build.test.ts` shell out to a real production Vite build and were hitting Bun's default 5000ms test timeout.
- When the test timed out, Bun killed the build subprocess (SIGTERM → exit 143), reported as `build failed with code 143`.
- Raise the per-test timeout to 60s on the two build-running tests so CI variance no longer kills the build.

Failing run: https://github.com/fabro-sh/fabro/actions/runs/26042062252/job/76556114190

## Test plan
- [x] `cd apps/fabro-web && bun test scripts/build.test.ts` passes locally
- [ ] TypeScript CI passes on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)