### PR TITLE
fix(cli): print full run id on rm

### DIFF
--- a/lib/crates/fabro-cli/src/commands/runs/rm.rs
+++ b/lib/crates/fabro-cli/src/commands/runs/rm.rs
@@ -1,6 +1,5 @@
 use anyhow::{Result, bail};
 
-use super::short_run_id;
 use crate::args::RunsRemoveArgs;
 use crate::command_context::CommandContext;
 use crate::server_client;
@@ -57,7 +56,7 @@ async fn remove_from(args: &RunsRemoveArgs, ctx: &CommandContext) -> Result<()> 
         let run_id_string = run_id.to_string();
         removed.push(run_id_string.clone());
         if !json {
-            fabro_util::printerr!(printer, "{}", short_run_id(&run_id_string));
+            fabro_util::printerr!(printer, "{run_id_string}");
         }
     }
 

--- a/lib/crates/fabro-cli/tests/it/cmd/rm.rs
+++ b/lib/crates/fabro-cli/tests/it/cmd/rm.rs
@@ -43,7 +43,7 @@ fn rm_deletes_completed_run() {
     let run = setup_seeded_completed_dry_run(&context);
     let mut filters = context.filters();
     filters.push((
-        r"\b[0-9A-HJKMNP-TV-Z]{12}\b".to_string(),
+        r"\b[0-9A-HJKMNP-TV-Z]{26}\b".to_string(),
         "[ULID]".to_string(),
     ));
 
@@ -96,7 +96,7 @@ fn rm_force_deletes_submitted_run() {
     let run = setup_seeded_created_dry_run(&context);
     let mut filters = context.filters();
     filters.push((
-        r"\b[0-9A-HJKMNP-TV-Z]{12}\b".to_string(),
+        r"\b[0-9A-HJKMNP-TV-Z]{26}\b".to_string(),
         "[ULID]".to_string(),
     ));
 
@@ -129,7 +129,7 @@ fn rm_force_deletes_run_without_sandbox_json_when_store_has_sandbox() {
 
     let mut filters = context.filters();
     filters.push((
-        r"\b[0-9A-HJKMNP-TV-Z]{12}\b".to_string(),
+        r"\b[0-9A-HJKMNP-TV-Z]{26}\b".to_string(),
         "[ULID]".to_string(),
     ));
 
@@ -163,7 +163,7 @@ fn rm_force_removes_active_run() {
 
     let mut filters = context.filters();
     filters.push((
-        r"\b[0-9A-HJKMNP-TV-Z]{12}\b".to_string(),
+        r"\b[0-9A-HJKMNP-TV-Z]{26}\b".to_string(),
         "[ULID]".to_string(),
     ));
     let mut cmd = context.command();
@@ -248,7 +248,7 @@ fn rm_partial_failure_reports_which_identifiers_failed() {
     let run = setup_seeded_completed_dry_run(&context);
     let mut filters = context.filters();
     filters.push((
-        r"\b[0-9A-HJKMNP-TV-Z]{12}\b".to_string(),
+        r"\b[0-9A-HJKMNP-TV-Z]{26}\b".to_string(),
         "[ULID]".to_string(),
     ));
     let mut cmd = context.command();


### PR DESCRIPTION
When `fabro rm` succeeds, the confirmation output should identify exactly which run was removed. Today the human-readable path prints a shortened run ID, which is less precise than the JSON output and less useful for copy/paste confirmation.

## Summary
- print the full run ID after successful `fabro rm` removal
- keep `--json` behavior unchanged
- update CLI snapshots to expect full IDs on success paths

## Testing
- cargo test -p fabro-cli rm_ -- --nocapture
- cargo +nightly-2026-04-14 fmt --check --all
