### PR TITLE
fix(workflow): allow workflow-root template partials

### DIFF
--- a/lib/crates/fabro-cli/tests/it/cmd/validate.rs
+++ b/lib/crates/fabro-cli/tests/it/cmd/validate.rs
@@ -223,6 +223,22 @@ fn validate_accepts_static_template_dependencies() {
 }
 
 #[test]
+fn validate_accepts_template_partial_sibling_under_workflow_root() {
+    let context = test_context!();
+    let mut cmd = context.validate();
+    cmd.arg(fixture("templates/sibling_partial/workflow.fabro"));
+    fabro_snapshot!(context.filters(), cmd, @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    ----- stderr -----
+    Workflow: SiblingPartialTemplateInclude (3 nodes, 2 edges)
+    Graph: [FIXTURES]/templates/sibling_partial/workflow.fabro
+    Validation: OK
+    ");
+}
+
+#[test]
 fn validate_reports_missing_template_dependency() {
     let context = test_context!();
     let mut cmd = context.validate();

--- a/lib/crates/fabro-manifest/src/lib.rs
+++ b/lib/crates/fabro-manifest/src/lib.rs
@@ -352,6 +352,8 @@ fn collect_workflow_files(
             )?;
             let source = std::fs::read_to_string(&bundled.absolute_path)
                 .with_context(|| format!("Failed to read {}", bundled.absolute_path.display()))?;
+            let template_root =
+                template_root_for_bundled_file(&bundled.path, &workflow_template_root)?;
             collect_template_include_files(
                 files,
                 context.cwd,
@@ -359,7 +361,7 @@ fn collect_workflow_files(
                     path:    bundled.path.clone(),
                     content: source,
                 },
-                &manifest_parent_or_dot(&bundled.path)?,
+                &template_root,
                 Some(&bundled.path),
                 &context.inputs,
             )?;
@@ -394,6 +396,8 @@ fn collect_workflow_files(
                     std::fs::read_to_string(&bundled.absolute_path).with_context(|| {
                         format!("Failed to read {}", bundled.absolute_path.display())
                     })?;
+                let template_root =
+                    template_root_for_bundled_file(&bundled.path, &workflow_template_root)?;
                 collect_template_include_files(
                     files,
                     context.cwd,
@@ -401,7 +405,7 @@ fn collect_workflow_files(
                         path:    bundled.path.clone(),
                         content: source,
                     },
-                    &manifest_parent_or_dot(&bundled.path)?,
+                    &template_root,
                     Some(&bundled.path),
                     &context.inputs,
                 )?;
@@ -498,6 +502,27 @@ fn collect_template_include_files(
             });
     }
     Ok(())
+}
+
+fn template_root_for_bundled_file(
+    path: &ManifestPath,
+    workflow_template_root: &ManifestPath,
+) -> Result<ManifestPath> {
+    if manifest_path_is_within_root(path, workflow_template_root) {
+        Ok(workflow_template_root.clone())
+    } else {
+        manifest_parent_or_dot(path)
+    }
+}
+
+fn manifest_path_is_within_root(path: &ManifestPath, root: &ManifestPath) -> bool {
+    if root.as_path().as_os_str().is_empty() {
+        return !matches!(
+            path.as_path().components().next(),
+            Some(Component::ParentDir)
+        );
+    }
+    path.starts_with(root)
 }
 
 fn verify_recorded_template_dependencies(

--- a/lib/crates/fabro-manifest/src/lib.rs
+++ b/lib/crates/fabro-manifest/src/lib.rs
@@ -357,11 +357,7 @@ fn collect_workflow_files(
             collect_template_include_files(
                 files,
                 context.cwd,
-                TemplateSource {
-                    path:    bundled.path.clone(),
-                    content: source,
-                },
-                &template_root,
+                TemplateSource::new(bundled.path.clone(), template_root, source),
                 Some(&bundled.path),
                 &context.inputs,
             )?;
@@ -369,11 +365,11 @@ fn collect_workflow_files(
             collect_template_include_files(
                 files,
                 context.cwd,
-                TemplateSource {
-                    path:    workflow.dot_path.clone(),
-                    content: goal_ref.to_owned(),
-                },
-                &workflow_template_root,
+                TemplateSource::new(
+                    workflow.dot_path.clone(),
+                    workflow_template_root.clone(),
+                    goal_ref.to_owned(),
+                ),
                 Some(&workflow.dot_path),
                 &context.inputs,
             )?;
@@ -401,11 +397,7 @@ fn collect_workflow_files(
                 collect_template_include_files(
                     files,
                     context.cwd,
-                    TemplateSource {
-                        path:    bundled.path.clone(),
-                        content: source,
-                    },
-                    &template_root,
+                    TemplateSource::new(bundled.path.clone(), template_root, source),
                     Some(&bundled.path),
                     &context.inputs,
                 )?;
@@ -413,11 +405,11 @@ fn collect_workflow_files(
                 collect_template_include_files(
                     files,
                     context.cwd,
-                    TemplateSource {
-                        path:    workflow.dot_path.clone(),
-                        content: prompt_ref.to_owned(),
-                    },
-                    &workflow_template_root,
+                    TemplateSource::new(
+                        workflow.dot_path.clone(),
+                        workflow_template_root.clone(),
+                        prompt_ref.to_owned(),
+                    ),
                     Some(&workflow.dot_path),
                     &context.inputs,
                 )?;
@@ -468,22 +460,14 @@ fn collect_template_include_files(
     files: &mut HashMap<String, types::ManifestFileEntry>,
     cwd: &Path,
     source: TemplateSource,
-    template_root: &ManifestPath,
     from: Option<&ManifestPath>,
     inputs: &HashMap<String, toml::Value>,
 ) -> Result<()> {
     let source_path = source.path.clone();
-    let store = FilesystemTemplateStore::new(cwd.to_path_buf(), template_root.clone());
+    let store = FilesystemTemplateStore::new(cwd.to_path_buf());
     let closure = discover_static_dependency_closure([source], &store)
         .map_err(|err| anyhow!("failed to discover template dependencies: {err}"))?;
-    verify_recorded_template_dependencies(
-        &source_path,
-        &closure,
-        template_root,
-        files,
-        from,
-        inputs,
-    )?;
+    verify_recorded_template_dependencies(&source_path, &closure, files, from, inputs)?;
 
     for (path, source) in closure.sources {
         if path == source_path {
@@ -528,7 +512,6 @@ fn manifest_path_is_within_root(path: &ManifestPath, root: &ManifestPath) -> boo
 fn verify_recorded_template_dependencies(
     source_path: &ManifestPath,
     closure: &fabro_template::TemplateDependencyClosure,
-    template_root: &ManifestPath,
     files: &HashMap<String, types::ManifestFileEntry>,
     from: Option<&ManifestPath>,
     inputs: &HashMap<String, toml::Value>,
@@ -547,10 +530,8 @@ fn verify_recorded_template_dependencies(
         }
     }
     let allowed = bundled_files.keys().cloned().collect();
-    let store = RecordingTemplateStore::with_allowed(
-        BundleTemplateStore::new(template_root.clone(), bundled_files),
-        allowed,
-    );
+    let store =
+        RecordingTemplateStore::with_allowed(BundleTemplateStore::new(bundled_files), allowed);
     let ctx = TemplateContext::for_input_scan(inputs.clone());
     render_source(source, &ctx, Arc::new(store), TemplateRenderMode::Lenient).with_context(
         || {

--- a/lib/crates/fabro-template/src/dependency.rs
+++ b/lib/crates/fabro-template/src/dependency.rs
@@ -100,12 +100,12 @@ pub fn discover_static_dependency_closure(
             });
         }
         for dependency in dependencies.static_references {
-            let loaded = store
-                .load(&source.path, &dependency.reference)?
-                .ok_or_else(|| TemplateDiscoveryError::Missing {
+            let loaded = store.load(&source, &dependency.reference)?.ok_or_else(|| {
+                TemplateDiscoveryError::Missing {
                     parent:    source.path.clone(),
                     reference: dependency.reference.clone(),
-                })?;
+                }
+            })?;
             if sources
                 .insert(loaded.path.clone(), loaded.clone())
                 .is_none()

--- a/lib/crates/fabro-template/src/lib.rs
+++ b/lib/crates/fabro-template/src/lib.rs
@@ -18,7 +18,7 @@ pub use dependency::{
 };
 pub use store::{
     BundleTemplateStore, CachedTemplateStore, FilesystemTemplateStore, RecordingTemplateStore,
-    TemplateLoadError, TemplateSource, TemplateStore,
+    TemplateIncludeResolver, TemplateLoadError, TemplateSource, TemplateStore,
 };
 
 pub type TemplateLoader = Arc<dyn Fn(&str) -> Option<String> + Send + Sync>;
@@ -530,23 +530,28 @@ fn render_rooted_source(
     env.set_undefined_behavior(undefined);
     env.set_auto_escape_callback(|_| AutoEscape::None);
     env.set_debug(true);
-    env.set_path_join_callback(|name, parent| joined_template_path(name, parent).into());
+    let root = source.root.clone();
+    env.set_path_join_callback(move |name, parent| {
+        joined_template_path(&root, name, parent).into()
+    });
 
     let load_error = Arc::new(Mutex::new(None));
     let loader_error = Arc::clone(&load_error);
-    env.set_loader(move |name| {
-        let parent = ManifestPath::from_wire(".").expect("root manifest path should parse");
-        match store.load(&parent, name) {
-            Ok(source) => Ok(source.map(|source| source.content)),
-            Err(error) => {
-                *loader_error
-                    .lock()
-                    .expect("template load error mutex should not be poisoned") = Some(error);
-                Err(minijinja::Error::new(
-                    ErrorKind::InvalidOperation,
-                    "template load failed",
-                ))
-            }
+    let loader_parent = TemplateSource::new(
+        ManifestPath::from_wire(".").expect("root manifest path should parse"),
+        source.root.clone(),
+        String::new(),
+    );
+    env.set_loader(move |name| match store.load(&loader_parent, name) {
+        Ok(source) => Ok(source.map(|source| source.content)),
+        Err(error) => {
+            *loader_error
+                .lock()
+                .expect("template load error mutex should not be poisoned") = Some(error);
+            Err(minijinja::Error::new(
+                ErrorKind::InvalidOperation,
+                "template load failed",
+            ))
         }
     });
 
@@ -571,12 +576,13 @@ fn render_rooted_source(
     })
 }
 
-fn joined_template_path(name: &str, parent: &str) -> String {
+fn joined_template_path(root: &ManifestPath, name: &str, parent: &str) -> String {
     let Some(parent) = ManifestPath::from_wire(parent) else {
         return name.to_owned();
     };
-    ManifestPath::from_reference(parent.parent_or_dot(), name)
-        .map_or_else(|| name.to_owned(), |path| path.to_string())
+    TemplateIncludeResolver::new(root.clone())
+        .resolve(&parent, name)
+        .map_or_else(|_| name.to_owned(), |path| path.to_string())
 }
 
 fn reject_loader_dependent_string(name: Option<&str>, template: &str) -> Result<(), TemplateError> {
@@ -605,7 +611,6 @@ mod tests {
 
     fn bundle_store(files: &[(&str, &str)]) -> Arc<dyn TemplateStore> {
         Arc::new(BundleTemplateStore::new(
-            manifest_path("."),
             files
                 .iter()
                 .map(|(path, content)| (manifest_path(path), (*content).to_string()))
@@ -742,10 +747,11 @@ mod tests {
     #[test]
     fn render_source_supports_rooted_include() {
         let ctx = TemplateContext::new();
-        let source = TemplateSource {
-            path:    manifest_path("prompts/main.md"),
-            content: r#"{% include "partial.md" %}"#.to_string(),
-        };
+        let source = TemplateSource::new(
+            manifest_path("prompts/main.md"),
+            manifest_path("prompts"),
+            r#"{% include "partial.md" %}"#,
+        );
 
         let rendered = render_source(
             &source,
@@ -761,10 +767,11 @@ mod tests {
     #[test]
     fn render_source_supports_nested_include() {
         let ctx = TemplateContext::new();
-        let source = TemplateSource {
-            path:    manifest_path("prompts/main.md"),
-            content: r#"{% include "partial.md" %}"#.to_string(),
-        };
+        let source = TemplateSource::new(
+            manifest_path("prompts/main.md"),
+            manifest_path("prompts"),
+            r#"{% include "partial.md" %}"#,
+        );
 
         let rendered = render_source(
             &source,
@@ -783,10 +790,11 @@ mod tests {
     #[test]
     fn render_source_supports_extends() {
         let ctx = TemplateContext::new();
-        let source = TemplateSource {
-            path:    manifest_path("pages/main.md"),
-            content: r#"{% extends "layout.md" %}{% block body %}Body{% endblock %}"#.to_string(),
-        };
+        let source = TemplateSource::new(
+            manifest_path("pages/main.md"),
+            manifest_path("pages"),
+            r#"{% extends "layout.md" %}{% block body %}Body{% endblock %}"#,
+        );
 
         let rendered = render_source(
             &source,
@@ -805,10 +813,11 @@ mod tests {
     #[test]
     fn render_source_supports_import() {
         let ctx = TemplateContext::new();
-        let source = TemplateSource {
-            path:    manifest_path("prompts/main.md"),
-            content: r#"{% import "macros.md" as macros %}{{ macros.greet("Ada") }}"#.to_string(),
-        };
+        let source = TemplateSource::new(
+            manifest_path("prompts/main.md"),
+            manifest_path("prompts"),
+            r#"{% import "macros.md" as macros %}{{ macros.greet("Ada") }}"#,
+        );
 
         let rendered = render_source(
             &source,
@@ -827,10 +836,11 @@ mod tests {
     #[test]
     fn render_source_supports_from_import() {
         let ctx = TemplateContext::new();
-        let source = TemplateSource {
-            path:    manifest_path("prompts/main.md"),
-            content: r#"{% from "macros.md" import greet %}{{ greet("Ada") }}"#.to_string(),
-        };
+        let source = TemplateSource::new(
+            manifest_path("prompts/main.md"),
+            manifest_path("prompts"),
+            r#"{% from "macros.md" import greet %}{{ greet("Ada") }}"#,
+        );
 
         let rendered = render_source(
             &source,
@@ -849,14 +859,12 @@ mod tests {
     #[test]
     fn render_source_rejects_unsafe_include() {
         let ctx = TemplateContext::new();
-        let source = TemplateSource {
-            path:    manifest_path("prompts/main.md"),
-            content: r#"{% include "../outside.md" %}"#.to_string(),
-        };
-        let store: Arc<dyn TemplateStore> = Arc::new(BundleTemplateStore::new(
+        let source = TemplateSource::new(
+            manifest_path("prompts/main.md"),
             manifest_path("prompts"),
-            HashMap::new(),
-        ));
+            r#"{% include "../outside.md" %}"#,
+        );
+        let store: Arc<dyn TemplateStore> = Arc::new(BundleTemplateStore::new(HashMap::new()));
 
         let err = render_source(&source, &ctx, store, TemplateRenderMode::Strict).unwrap_err();
 
@@ -867,6 +875,29 @@ mod tests {
                 ..
             } if matches!(*source, TemplateLoadError::EscapesRoot { .. })
         ));
+    }
+
+    #[test]
+    fn render_source_uses_source_root_for_sibling_include() {
+        let ctx = TemplateContext::new();
+        let source = TemplateSource::new(
+            manifest_path("prompts/audits/audit.prompt.md"),
+            manifest_path("prompts"),
+            r#"{% include "../partials/audit.partial.tpl" %}"#,
+        );
+
+        let rendered = render_source(
+            &source,
+            &ctx,
+            Arc::new(BundleTemplateStore::new(HashMap::from([(
+                manifest_path("prompts/partials/audit.partial.tpl"),
+                "shared partial".to_string(),
+            )]))),
+            TemplateRenderMode::Strict,
+        )
+        .unwrap();
+
+        assert_eq!(rendered, "shared partial");
     }
 
     #[test]
@@ -897,11 +928,11 @@ mod tests {
 
     #[test]
     fn static_dependency_closure_collects_both_branches() {
-        let source = TemplateSource {
-            path:    manifest_path("main.md"),
-            content: r#"{% if inputs.use_a %}{% include "a.md" %}{% else %}{% include "b.md" %}{% endif %}"#
-                .to_string(),
-        };
+        let source = TemplateSource::new(
+            manifest_path("main.md"),
+            manifest_path("."),
+            r#"{% if inputs.use_a %}{% include "a.md" %}{% else %}{% include "b.md" %}{% endif %}"#,
+        );
 
         let closure = discover_static_dependency_closure(
             [source],
@@ -915,10 +946,11 @@ mod tests {
 
     #[test]
     fn static_dependency_closure_collects_unused_macro_body_dependencies() {
-        let source = TemplateSource {
-            path:    manifest_path("main.md"),
-            content: r#"{% from "helpers.md" import render_advanced_prompt %}"#.to_string(),
-        };
+        let source = TemplateSource::new(
+            manifest_path("main.md"),
+            manifest_path("."),
+            r#"{% from "helpers.md" import render_advanced_prompt %}"#,
+        );
 
         let closure = discover_static_dependency_closure(
             [source],
@@ -939,10 +971,11 @@ mod tests {
 
     #[test]
     fn static_dependency_closure_rejects_dynamic_include() {
-        let source = TemplateSource {
-            path:    manifest_path("main.md"),
-            content: r"{% include inputs.partial %}".to_string(),
-        };
+        let source = TemplateSource::new(
+            manifest_path("main.md"),
+            manifest_path("."),
+            r"{% include inputs.partial %}",
+        );
 
         let err =
             discover_static_dependency_closure([source], bundle_store(&[]).as_ref()).unwrap_err();

--- a/lib/crates/fabro-template/src/store.rs
+++ b/lib/crates/fabro-template/src/store.rs
@@ -8,13 +8,25 @@ use thiserror::Error;
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TemplateSource {
     pub path:    ManifestPath,
+    pub root:    ManifestPath,
     pub content: String,
+}
+
+impl TemplateSource {
+    #[must_use]
+    pub fn new(path: ManifestPath, root: ManifestPath, content: impl Into<String>) -> Self {
+        Self {
+            path,
+            root,
+            content: content.into(),
+        }
+    }
 }
 
 pub trait TemplateStore: Send + Sync {
     fn load(
         &self,
-        parent: &ManifestPath,
+        parent: &TemplateSource,
         reference: &str,
     ) -> Result<Option<TemplateSource>, TemplateLoadError>;
 }
@@ -43,17 +55,13 @@ pub enum TemplateLoadError {
 
 #[derive(Clone, Debug)]
 pub struct FilesystemTemplateStore {
-    cwd:  PathBuf,
-    root: ManifestPath,
+    cwd: PathBuf,
 }
 
 impl FilesystemTemplateStore {
     #[must_use]
-    pub fn new(cwd: impl Into<PathBuf>, root: ManifestPath) -> Self {
-        Self {
-            cwd: cwd.into(),
-            root,
-        }
+    pub fn new(cwd: impl Into<PathBuf>) -> Self {
+        Self { cwd: cwd.into() }
     }
 }
 
@@ -64,12 +72,13 @@ impl TemplateStore for FilesystemTemplateStore {
     )]
     fn load(
         &self,
-        parent: &ManifestPath,
+        parent: &TemplateSource,
         reference: &str,
     ) -> Result<Option<TemplateSource>, TemplateLoadError> {
-        let logical = resolve_logical_reference(parent, reference, &self.root)?;
+        let logical =
+            TemplateIncludeResolver::new(parent.root.clone()).resolve(&parent.path, reference)?;
         let absolute = self.cwd.join(logical.as_path());
-        let root = self.cwd.join(self.root.as_path());
+        let root = self.cwd.join(parent.root.as_path());
 
         let canonical = match absolute.canonicalize() {
             Ok(path) if path.is_file() => path,
@@ -90,9 +99,9 @@ impl TemplateStore for FilesystemTemplateStore {
             })?;
         if !canonical.starts_with(&canonical_root) {
             return Err(TemplateLoadError::EscapesRoot {
-                parent:    parent.clone(),
+                parent:    parent.path.clone(),
                 reference: reference.to_owned(),
-                root:      self.root.clone(),
+                root:      parent.root.clone(),
             });
         }
 
@@ -101,44 +110,45 @@ impl TemplateStore for FilesystemTemplateStore {
                 path: canonical.clone(),
                 source,
             })?;
-        Ok(Some(TemplateSource {
-            path: logical,
+        Ok(Some(TemplateSource::new(
+            logical,
+            parent.root.clone(),
             content,
-        }))
+        )))
     }
 }
 
 #[derive(Clone, Debug, Default)]
 pub struct BundleTemplateStore {
-    root:  ManifestPath,
     files: HashMap<ManifestPath, String>,
 }
 
 impl BundleTemplateStore {
     #[must_use]
-    pub fn new(root: ManifestPath, files: HashMap<ManifestPath, String>) -> Self {
-        Self { root, files }
+    pub fn new(files: HashMap<ManifestPath, String>) -> Self {
+        Self { files }
     }
 }
 
 impl TemplateStore for BundleTemplateStore {
     fn load(
         &self,
-        parent: &ManifestPath,
+        parent: &TemplateSource,
         reference: &str,
     ) -> Result<Option<TemplateSource>, TemplateLoadError> {
-        let path = resolve_logical_reference(parent, reference, &self.root)?;
-        Ok(self.files.get(&path).map(|content| TemplateSource {
-            path,
-            content: content.clone(),
-        }))
+        let path =
+            TemplateIncludeResolver::new(parent.root.clone()).resolve(&parent.path, reference)?;
+        Ok(self
+            .files
+            .get(&path)
+            .map(|content| TemplateSource::new(path, parent.root.clone(), content.clone())))
     }
 }
 
 #[derive(Debug)]
 pub struct CachedTemplateStore<T> {
     inner: T,
-    cache: Mutex<HashMap<(ManifestPath, String), Option<TemplateSource>>>,
+    cache: Mutex<HashMap<(ManifestPath, ManifestPath, String), Option<TemplateSource>>>,
 }
 
 impl<T> CachedTemplateStore<T> {
@@ -157,10 +167,14 @@ where
 {
     fn load(
         &self,
-        parent: &ManifestPath,
+        parent: &TemplateSource,
         reference: &str,
     ) -> Result<Option<TemplateSource>, TemplateLoadError> {
-        let key = (parent.clone(), reference.to_owned());
+        let key = (
+            parent.path.clone(),
+            parent.root.clone(),
+            reference.to_owned(),
+        );
         if let Some(source) = lock(&self.cache).get(&key).cloned() {
             return Ok(source);
         }
@@ -208,7 +222,7 @@ where
 {
     fn load(
         &self,
-        parent: &ManifestPath,
+        parent: &TemplateSource,
         reference: &str,
     ) -> Result<Option<TemplateSource>, TemplateLoadError> {
         let source = self.inner.load(parent, reference)?;
@@ -226,32 +240,44 @@ where
     }
 }
 
-pub(crate) fn resolve_logical_reference(
-    parent: &ManifestPath,
-    reference: &str,
-    root: &ManifestPath,
-) -> Result<ManifestPath, TemplateLoadError> {
-    if !is_safe_template_reference(reference) {
-        return Err(TemplateLoadError::UnsafeReference {
-            parent:    parent.clone(),
-            reference: reference.to_owned(),
-        });
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TemplateIncludeResolver {
+    root: ManifestPath,
+}
+
+impl TemplateIncludeResolver {
+    #[must_use]
+    pub fn new(root: ManifestPath) -> Self {
+        Self { root }
     }
-    let path =
-        ManifestPath::from_reference(parent.parent_or_dot(), reference).ok_or_else(|| {
-            TemplateLoadError::UnsafeReference {
+
+    pub fn resolve(
+        &self,
+        parent: &ManifestPath,
+        reference: &str,
+    ) -> Result<ManifestPath, TemplateLoadError> {
+        if !is_safe_template_reference(reference) {
+            return Err(TemplateLoadError::UnsafeReference {
                 parent:    parent.clone(),
                 reference: reference.to_owned(),
-            }
-        })?;
-    if !is_within_root(&path, root) {
-        return Err(TemplateLoadError::EscapesRoot {
-            parent:    parent.clone(),
-            reference: reference.to_owned(),
-            root:      root.clone(),
-        });
+            });
+        }
+        let path =
+            ManifestPath::from_reference(parent.parent_or_dot(), reference).ok_or_else(|| {
+                TemplateLoadError::UnsafeReference {
+                    parent:    parent.clone(),
+                    reference: reference.to_owned(),
+                }
+            })?;
+        if !is_within_root(&path, &self.root) {
+            return Err(TemplateLoadError::EscapesRoot {
+                parent:    parent.clone(),
+                reference: reference.to_owned(),
+                root:      self.root.clone(),
+            });
+        }
+        Ok(path)
     }
-    Ok(path)
 }
 
 pub(crate) fn is_safe_template_reference(reference: &str) -> bool {
@@ -284,4 +310,73 @@ fn lock<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
     mutex
         .lock()
         .expect("template store mutex should not be poisoned")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn manifest_path(value: &str) -> ManifestPath {
+        ManifestPath::from_wire(value).expect("path should parse")
+    }
+
+    #[test]
+    fn include_resolver_allows_sibling_reference_within_root() {
+        let resolver = TemplateIncludeResolver::new(manifest_path("prompts"));
+
+        let resolved = resolver
+            .resolve(
+                &manifest_path("prompts/audits/audit.prompt.md"),
+                "../partials/audit.partial.tpl",
+            )
+            .unwrap();
+
+        assert_eq!(
+            resolved,
+            manifest_path("prompts/partials/audit.partial.tpl")
+        );
+    }
+
+    #[test]
+    fn include_resolver_rejects_reference_that_escapes_root() {
+        let resolver = TemplateIncludeResolver::new(manifest_path("prompts"));
+
+        let err = resolver
+            .resolve(
+                &manifest_path("prompts/audits/audit.prompt.md"),
+                "../../secret.md",
+            )
+            .unwrap_err();
+
+        assert!(matches!(
+            err,
+            TemplateLoadError::EscapesRoot {
+                parent,
+                reference,
+                root,
+            } if parent == manifest_path("prompts/audits/audit.prompt.md")
+                && reference == "../../secret.md"
+                && root == manifest_path("prompts")
+        ));
+    }
+
+    #[test]
+    fn include_resolver_rejects_unsafe_references() {
+        let resolver = TemplateIncludeResolver::new(manifest_path("prompts"));
+        let parent = manifest_path("prompts/main.md");
+
+        for reference in [
+            "",
+            "~/secret.md",
+            "/tmp/secret.md",
+            r"partials\secret.md",
+            "C:/secret.md",
+        ] {
+            let err = resolver.resolve(&parent, reference).unwrap_err();
+            assert!(
+                matches!(err, TemplateLoadError::UnsafeReference { .. }),
+                "{reference} should be unsafe, got {err:?}"
+            );
+        }
+    }
 }

--- a/lib/crates/fabro-workflow/src/file_resolver.rs
+++ b/lib/crates/fabro-workflow/src/file_resolver.rs
@@ -5,7 +5,9 @@
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
+use fabro_template::{TemplateIncludeResolver, TemplateLoadError, TemplateSource, TemplateStore};
 use fabro_types::ManifestPath;
 
 pub trait FileResolver: Send + Sync {
@@ -16,6 +18,34 @@ pub trait FileResolver: Send + Sync {
 pub struct ResolvedFile {
     pub path:    PathBuf,
     pub content: String,
+}
+
+#[derive(Clone)]
+pub struct FileResolverTemplateStore {
+    base_dir: PathBuf,
+    resolver: Arc<dyn FileResolver>,
+}
+
+impl FileResolverTemplateStore {
+    #[must_use]
+    pub fn new(base_dir: PathBuf, resolver: Arc<dyn FileResolver>) -> Self {
+        Self { base_dir, resolver }
+    }
+}
+
+impl TemplateStore for FileResolverTemplateStore {
+    fn load(
+        &self,
+        parent: &TemplateSource,
+        reference: &str,
+    ) -> Result<Option<TemplateSource>, TemplateLoadError> {
+        let path =
+            TemplateIncludeResolver::new(parent.root.clone()).resolve(&parent.path, reference)?;
+        Ok(self
+            .resolver
+            .resolve(&self.base_dir, &path.to_string())
+            .map(|resolved| TemplateSource::new(path, parent.root.clone(), resolved.content)))
+    }
 }
 
 #[derive(Clone, Debug, Default)]

--- a/lib/crates/fabro-workflow/src/transforms/file_inlining.rs
+++ b/lib/crates/fabro-workflow/src/transforms/file_inlining.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 use std::sync::Arc;
 
 use fabro_graphviz::graph::{AttrValue, Graph};
@@ -36,10 +36,13 @@ pub fn resolve_file_ref(
 
 pub(crate) fn template_include_loader(
     current_dir: PathBuf,
+    template_root: PathBuf,
     resolver: Arc<dyn FileResolver>,
 ) -> TemplateLoader {
     Arc::new(move |name| {
-        if !is_safe_include_name(name) {
+        if !is_safe_include_name(name)
+            || !include_stays_within_root(&current_dir, &template_root, name)
+        {
             return None;
         }
         resolver
@@ -49,11 +52,52 @@ pub(crate) fn template_include_loader(
 }
 
 fn is_safe_include_name(name: &str) -> bool {
-    if name.is_empty() || name.starts_with('~') || Path::new(name).is_absolute() {
+    !name.is_empty()
+        && !name.starts_with('~')
+        && !name.contains('\\')
+        && !has_windows_drive_prefix(name)
+        && !Path::new(name).is_absolute()
+}
+
+fn has_windows_drive_prefix(path: &str) -> bool {
+    let mut chars = path.chars();
+    matches!(
+        (chars.next(), chars.next()),
+        (Some(first), Some(':')) if first.is_ascii_alphabetic()
+    )
+}
+
+fn include_stays_within_root(current_dir: &Path, template_root: &Path, name: &str) -> bool {
+    let Some(path) = normalize_template_path(current_dir.join(name)) else {
         return false;
+    };
+    let Some(root) = normalize_template_path(template_root) else {
+        return false;
+    };
+    if root.as_os_str().is_empty() {
+        return !path.has_root() && !matches!(path.components().next(), Some(Component::ParentDir));
     }
-    name.split('/')
-        .all(|segment| !segment.starts_with('.') && !segment.contains('\\'))
+    path.starts_with(root)
+}
+
+fn normalize_template_path(path: impl AsRef<Path>) -> Option<PathBuf> {
+    let mut normalized = PathBuf::new();
+    for component in path.as_ref().components() {
+        match component {
+            Component::CurDir => {}
+            Component::Normal(part) => normalized.push(part),
+            Component::ParentDir => {
+                if normalized.file_name().is_some() {
+                    normalized.pop();
+                } else if !normalized.has_root() {
+                    normalized.push("..");
+                }
+            }
+            Component::RootDir => normalized.push(Path::new("/")),
+            Component::Prefix(_) => return None,
+        }
+    }
+    Some(normalized)
 }
 
 fn parent_dir_or_dot(path: &Path) -> PathBuf {
@@ -142,6 +186,7 @@ impl FileInliningTransform {
             .with_source_text(self.source_text.as_deref(), prompt)
             .with_include_loader(Some(template_include_loader(
                 self.current_dir.clone(),
+                self.current_dir.clone(),
                 Arc::clone(&self.resolver),
             )));
             let rendered = render_template_for_target(
@@ -173,6 +218,7 @@ impl FileInliningTransform {
         let target = TemplateRenderTarget::graph_attr(self.source_name.clone(), "goal")
             .with_source_text(self.source_text.as_deref(), goal)
             .with_include_loader(Some(template_include_loader(
+                self.current_dir.clone(),
                 self.current_dir.clone(),
                 Arc::clone(&self.resolver),
             )));
@@ -207,6 +253,7 @@ impl FileInliningTransform {
             .with_source_text(Some(&resolved.content), &resolved.content)
             .with_include_loader(Some(template_include_loader(
                 parent_dir_or_dot(&resolved.path),
+                self.template_root_for_resolved_file(&resolved.path),
                 Arc::clone(&self.resolver),
             )));
         Ok(Some(render_file_contents(
@@ -217,6 +264,28 @@ impl FileInliningTransform {
             diagnostics,
         )?))
     }
+
+    fn template_root_for_resolved_file(&self, path: &Path) -> PathBuf {
+        let parent = parent_dir_or_dot(path);
+        if path_is_within_root(&parent, &self.current_dir) {
+            self.current_dir.clone()
+        } else {
+            parent
+        }
+    }
+}
+
+fn path_is_within_root(path: &Path, root: &Path) -> bool {
+    let Some(path) = normalize_template_path(path) else {
+        return false;
+    };
+    let Some(root) = normalize_template_path(root) else {
+        return false;
+    };
+    if root.as_os_str().is_empty() {
+        return !path.has_root() && !matches!(path.components().next(), Some(Component::ParentDir));
+    }
+    path.starts_with(root)
 }
 
 impl Transform for FileInliningTransform {

--- a/lib/crates/fabro-workflow/src/transforms/file_inlining.rs
+++ b/lib/crates/fabro-workflow/src/transforms/file_inlining.rs
@@ -1,17 +1,19 @@
 use std::collections::HashMap;
-use std::path::{Component, Path, PathBuf};
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use fabro_graphviz::graph::{AttrValue, Graph};
-use fabro_template::{TemplateContext, TemplateLoader};
+use fabro_template::{TemplateContext, TemplateSource, TemplateStore};
+use fabro_types::ManifestPath;
 use fabro_validate::Diagnostic;
 
 use super::Transform;
 use crate::error::Error;
-use crate::file_resolver::{FileResolver, ResolvedFile};
+use crate::file_resolver::{FileResolver, FileResolverTemplateStore, ResolvedFile};
 use crate::static_reference::{ReferenceKind, validate_static_reference};
 use crate::transforms::variable_expansion::{
-    RenderMode, TemplateRenderTarget, TemplateTransform, render_template_for_target,
+    RenderMode, TemplateRenderStore, TemplateRenderTarget, TemplateTransform,
+    render_template_for_target,
 };
 
 /// Resolve a potential `@path` file reference.
@@ -34,76 +36,91 @@ pub fn resolve_file_ref(
         .map_or_else(|| value.to_string(), |resolved| resolved.content))
 }
 
-pub(crate) fn template_include_loader(
-    current_dir: PathBuf,
-    template_root: PathBuf,
-    resolver: Arc<dyn FileResolver>,
-) -> TemplateLoader {
-    Arc::new(move |name| {
-        if !is_safe_include_name(name)
-            || !include_stays_within_root(&current_dir, &template_root, name)
-        {
-            return None;
-        }
-        resolver
-            .resolve(&current_dir, name)
-            .map(|resolved| resolved.content)
-    })
-}
-
-fn is_safe_include_name(name: &str) -> bool {
-    !name.is_empty()
-        && !name.starts_with('~')
-        && !name.contains('\\')
-        && !has_windows_drive_prefix(name)
-        && !Path::new(name).is_absolute()
-}
-
-fn has_windows_drive_prefix(path: &str) -> bool {
-    let mut chars = path.chars();
-    matches!(
-        (chars.next(), chars.next()),
-        (Some(first), Some(':')) if first.is_ascii_alphabetic()
-    )
-}
-
-fn include_stays_within_root(current_dir: &Path, template_root: &Path, name: &str) -> bool {
-    let Some(path) = normalize_template_path(current_dir.join(name)) else {
-        return false;
-    };
-    let Some(root) = normalize_template_path(template_root) else {
-        return false;
-    };
-    if root.as_os_str().is_empty() {
-        return !path.has_root() && !matches!(path.components().next(), Some(Component::ParentDir));
-    }
-    path.starts_with(root)
-}
-
-fn normalize_template_path(path: impl AsRef<Path>) -> Option<PathBuf> {
-    let mut normalized = PathBuf::new();
-    for component in path.as_ref().components() {
-        match component {
-            Component::CurDir => {}
-            Component::Normal(part) => normalized.push(part),
-            Component::ParentDir => {
-                if normalized.file_name().is_some() {
-                    normalized.pop();
-                } else if !normalized.has_root() {
-                    normalized.push("..");
-                }
-            }
-            Component::RootDir => normalized.push(Path::new("/")),
-            Component::Prefix(_) => return None,
-        }
-    }
-    Some(normalized)
-}
-
 fn parent_dir_or_dot(path: &Path) -> PathBuf {
     path.parent()
         .filter(|parent| !parent.as_os_str().is_empty())
         .map_or_else(|| PathBuf::from("."), Path::to_path_buf)
+}
+
+pub(crate) fn template_render_store(
+    current_dir: &Path,
+    resolver: Arc<dyn FileResolver>,
+    source_name: Option<&str>,
+    content: &str,
+) -> Result<TemplateRenderStore, Error> {
+    let root = template_root_for_current_dir(current_dir)?;
+    let source_path = template_source_path_for_current_dir(current_dir, source_name, &root)?;
+    let base_dir = template_store_base_dir(current_dir);
+    Ok(TemplateRenderStore::new(
+        TemplateSource::new(source_path, root, content.to_owned()),
+        Arc::new(FileResolverTemplateStore::new(base_dir, resolver)),
+    ))
+}
+
+fn template_store_base_dir(current_dir: &Path) -> PathBuf {
+    if current_dir.is_absolute() {
+        current_dir.to_path_buf()
+    } else {
+        PathBuf::from(".")
+    }
+}
+
+fn template_root_for_current_dir(current_dir: &Path) -> Result<ManifestPath, Error> {
+    if current_dir.is_absolute() {
+        return manifest_path(".");
+    }
+    manifest_path_from_path(current_dir)
+}
+
+fn template_source_path_for_current_dir(
+    current_dir: &Path,
+    source_name: Option<&str>,
+    root: &ManifestPath,
+) -> Result<ManifestPath, Error> {
+    if let Some(source_name) = source_name {
+        let source_path = Path::new(source_name);
+        if source_path.is_absolute() {
+            if let Some(path) = ManifestPath::from_absolute(source_path, current_dir) {
+                return Ok(path);
+            }
+        } else if let Some(path) = ManifestPath::from_wire(source_name) {
+            if root.as_path().as_os_str().is_empty() || path.starts_with(root) {
+                return Ok(path);
+            }
+            if let Some(path) = ManifestPath::from_reference(root.as_path(), source_name) {
+                return Ok(path);
+            }
+        }
+    }
+    ManifestPath::from_reference(root.as_path(), "workflow.fabro")
+        .ok_or_else(|| Error::Validation("invalid workflow template source path".to_string()))
+}
+
+fn manifest_path(value: &str) -> Result<ManifestPath, Error> {
+    ManifestPath::from_wire(value)
+        .ok_or_else(|| Error::Validation(format!("invalid manifest path: {value}")))
+}
+
+fn manifest_path_from_path(path: &Path) -> Result<ManifestPath, Error> {
+    let value = path
+        .to_str()
+        .ok_or_else(|| Error::Validation(format!("invalid UTF-8 path: {}", path.display())))?;
+    manifest_path(value)
+}
+
+fn manifest_parent_or_dot(path: &ManifestPath) -> Result<ManifestPath, Error> {
+    manifest_path_from_path(path.parent_or_dot())
+}
+
+fn manifest_path_is_within_root(path: &ManifestPath, root: &ManifestPath) -> bool {
+    if root.as_path().as_os_str().is_empty() {
+        return !path
+            .as_path()
+            .components()
+            .next()
+            .is_some_and(|component| matches!(component, std::path::Component::ParentDir));
+    }
+    path.starts_with(root)
 }
 
 /// Inlines `@file` references in node prompts and the graph-level goal.
@@ -184,11 +201,12 @@ impl FileInliningTransform {
                 "prompt",
             )
             .with_source_text(self.source_text.as_deref(), prompt)
-            .with_include_loader(Some(template_include_loader(
-                self.current_dir.clone(),
-                self.current_dir.clone(),
+            .with_template_store(template_render_store(
+                &self.current_dir,
                 Arc::clone(&self.resolver),
-            )));
+                self.source_name.as_deref(),
+                prompt,
+            )?);
             let rendered = render_template_for_target(
                 prompt,
                 &ctx,
@@ -217,11 +235,12 @@ impl FileInliningTransform {
         let ctx = TemplateContext::for_input_scan(self.inputs.clone());
         let target = TemplateRenderTarget::graph_attr(self.source_name.clone(), "goal")
             .with_source_text(self.source_text.as_deref(), goal)
-            .with_include_loader(Some(template_include_loader(
-                self.current_dir.clone(),
-                self.current_dir.clone(),
+            .with_template_store(template_render_store(
+                &self.current_dir,
                 Arc::clone(&self.resolver),
-            )));
+                self.source_name.as_deref(),
+                goal,
+            )?);
         let rendered =
             render_template_for_target(goal, &ctx, self.render_mode, &target, diagnostics)?;
         let value = self
@@ -248,14 +267,11 @@ impl FileInliningTransform {
         let Some(resolved) = self.resolver.resolve(&self.current_dir, path_str) else {
             return Ok(None);
         };
+        let (source, store) = self.template_source_for_resolved_file(&resolved)?;
         let target = owner_target
             .with_source_name(resolved.path.display().to_string())
             .with_source_text(Some(&resolved.content), &resolved.content)
-            .with_include_loader(Some(template_include_loader(
-                parent_dir_or_dot(&resolved.path),
-                self.template_root_for_resolved_file(&resolved.path),
-                Arc::clone(&self.resolver),
-            )));
+            .with_template_store(TemplateRenderStore::new(source, store));
         Ok(Some(render_file_contents(
             &resolved,
             ctx,
@@ -267,25 +283,49 @@ impl FileInliningTransform {
 
     fn template_root_for_resolved_file(&self, path: &Path) -> PathBuf {
         let parent = parent_dir_or_dot(path);
-        if path_is_within_root(&parent, &self.current_dir) {
+        if self.current_dir.is_absolute() && path.starts_with(&self.current_dir) {
             self.current_dir.clone()
         } else {
             parent
         }
     }
-}
 
-fn path_is_within_root(path: &Path, root: &Path) -> bool {
-    let Some(path) = normalize_template_path(path) else {
-        return false;
-    };
-    let Some(root) = normalize_template_path(root) else {
-        return false;
-    };
-    if root.as_os_str().is_empty() {
-        return !path.has_root() && !matches!(path.components().next(), Some(Component::ParentDir));
+    fn template_source_for_resolved_file(
+        &self,
+        resolved: &ResolvedFile,
+    ) -> Result<(TemplateSource, Arc<dyn TemplateStore>), Error> {
+        if resolved.path.is_absolute() {
+            let root_dir = self.template_root_for_resolved_file(&resolved.path);
+            let path = ManifestPath::from_absolute(&resolved.path, &root_dir).ok_or_else(|| {
+                Error::Validation(format!(
+                    "invalid resolved template path: {}",
+                    resolved.path.display()
+                ))
+            })?;
+            return Ok((
+                TemplateSource::new(path, manifest_path(".")?, resolved.content.clone()),
+                Arc::new(FileResolverTemplateStore::new(
+                    root_dir,
+                    Arc::clone(&self.resolver),
+                )),
+            ));
+        }
+
+        let path = manifest_path_from_path(&resolved.path)?;
+        let current_root = template_root_for_current_dir(&self.current_dir)?;
+        let root = if manifest_path_is_within_root(&path, &current_root) {
+            current_root
+        } else {
+            manifest_parent_or_dot(&path)?
+        };
+        Ok((
+            TemplateSource::new(path, root, resolved.content.clone()),
+            Arc::new(FileResolverTemplateStore::new(
+                PathBuf::from("."),
+                Arc::clone(&self.resolver),
+            )),
+        ))
     }
-    path.starts_with(root)
 }
 
 impl Transform for FileInliningTransform {
@@ -318,9 +358,15 @@ mod tests {
     use std::sync::Arc;
 
     use fabro_graphviz::graph::{AttrValue, Graph, Node};
+    use fabro_template::{TemplateRenderMode, TemplateSource, render_source};
+    use fabro_types::ManifestPath;
 
     use super::*;
-    use crate::file_resolver::FilesystemFileResolver;
+    use crate::file_resolver::{BundleFileResolver, FilesystemFileResolver};
+
+    fn manifest_path(value: &str) -> ManifestPath {
+        ManifestPath::from_wire(value).expect("path should parse")
+    }
 
     #[test]
     fn resolve_file_ref_passthrough_non_at() {
@@ -482,6 +528,54 @@ mod tests {
             graph.attrs.get("goal").and_then(AttrValue::as_str),
             Some("included goal")
         );
+    }
+
+    #[test]
+    fn file_resolver_template_store_renders_sibling_partial_under_root() {
+        let resolver = Arc::new(BundleFileResolver::new(HashMap::from([(
+            manifest_path("prompts/partials/audit.partial.tpl"),
+            "shared partial".to_string(),
+        )])));
+        let store = FileResolverTemplateStore::new(PathBuf::from("."), resolver);
+        let source = TemplateSource::new(
+            manifest_path("prompts/audits/audit.prompt.md"),
+            manifest_path("prompts"),
+            r#"{% include "../partials/audit.partial.tpl" %}"#,
+        );
+
+        let rendered = render_source(
+            &source,
+            &TemplateContext::new(),
+            Arc::new(store),
+            TemplateRenderMode::Strict,
+        )
+        .unwrap();
+
+        assert_eq!(rendered, "shared partial");
+    }
+
+    #[test]
+    fn file_resolver_template_store_rejects_escaping_include() {
+        let resolver = Arc::new(BundleFileResolver::new(HashMap::from([(
+            manifest_path("outside.md"),
+            "outside".to_string(),
+        )])));
+        let store = FileResolverTemplateStore::new(PathBuf::from("."), resolver);
+        let source = TemplateSource::new(
+            manifest_path("prompts/audits/audit.prompt.md"),
+            manifest_path("prompts"),
+            r#"{% include "../../outside.md" %}"#,
+        );
+
+        let err = render_source(
+            &source,
+            &TemplateContext::new(),
+            Arc::new(store),
+            TemplateRenderMode::Strict,
+        )
+        .unwrap_err();
+
+        assert!(matches!(err, fabro_template::TemplateError::Load { .. }));
     }
 
     #[test]

--- a/lib/crates/fabro-workflow/src/transforms/import.rs
+++ b/lib/crates/fabro-workflow/src/transforms/import.rs
@@ -678,6 +678,7 @@ impl ImportTransform {
             .with_source_text(self.source_text.as_deref(), graph.goal())
             .with_include_loader(Some(template_include_loader(
                 self.current_dir.clone(),
+                self.current_dir.clone(),
                 Arc::clone(&self.resolver),
             )));
         let parent_goal = render_template_for_target(

--- a/lib/crates/fabro-workflow/src/transforms/import.rs
+++ b/lib/crates/fabro-workflow/src/transforms/import.rs
@@ -7,7 +7,7 @@ use fabro_graphviz::parser;
 use fabro_template::TemplateContext;
 use fabro_validate::Diagnostic;
 
-use super::file_inlining::template_include_loader;
+use super::file_inlining::template_render_store;
 use super::{FileInliningTransform, Transform};
 use crate::error::Error;
 use crate::file_resolver::{FileResolver, ResolvedFile};
@@ -676,11 +676,12 @@ impl ImportTransform {
         let mut ignored_goal_diagnostics = Vec::new();
         let goal_target = TemplateRenderTarget::graph_attr(self.source_name.clone(), "goal")
             .with_source_text(self.source_text.as_deref(), graph.goal())
-            .with_include_loader(Some(template_include_loader(
-                self.current_dir.clone(),
-                self.current_dir.clone(),
+            .with_template_store(template_render_store(
+                &self.current_dir,
                 Arc::clone(&self.resolver),
-            )));
+                self.source_name.as_deref(),
+                graph.goal(),
+            )?);
         let parent_goal = render_template_for_target(
             graph.goal(),
             &path_ctx,

--- a/lib/crates/fabro-workflow/src/transforms/variable_expansion.rs
+++ b/lib/crates/fabro-workflow/src/transforms/variable_expansion.rs
@@ -1,10 +1,11 @@
 use std::collections::HashMap;
 use std::fmt::Write as _;
+use std::sync::Arc;
 
 use fabro_graphviz::graph::{AttrValue, Graph};
 use fabro_template::{
-    TemplateContext, TemplateError, TemplateLoader, render_lenient_named,
-    render_lenient_named_with_loader, render_named, render_named_with_loader,
+    TemplateContext, TemplateError, TemplateRenderMode, TemplateSource, TemplateStore,
+    render_lenient_named, render_named, render_source,
 };
 use fabro_util::error::collect_chain;
 use fabro_validate::{Diagnostic, Severity};
@@ -40,7 +41,31 @@ pub(crate) struct TemplateRenderTarget {
     pub node_id:       Option<String>,
     pub edge:          Option<(String, String)>,
     pub owner:         String,
-    include_loader:    Option<TemplateLoader>,
+    template_store:    Option<TemplateRenderStore>,
+}
+
+#[derive(Clone)]
+pub(crate) struct TemplateRenderStore {
+    source: TemplateSource,
+    store:  Arc<dyn TemplateStore>,
+}
+
+impl TemplateRenderStore {
+    #[must_use]
+    pub(crate) fn new(source: TemplateSource, store: Arc<dyn TemplateStore>) -> Self {
+        Self { source, store }
+    }
+
+    fn render(
+        &self,
+        text: &str,
+        ctx: &TemplateContext,
+        mode: TemplateRenderMode,
+    ) -> Result<String, TemplateError> {
+        let mut source = self.source.clone();
+        text.clone_into(&mut source.content);
+        render_source(&source, ctx, Arc::clone(&self.store), mode)
+    }
 }
 
 impl TemplateRenderTarget {
@@ -54,7 +79,7 @@ impl TemplateRenderTarget {
             node_id: None,
             edge: None,
             owner: format!("graph attribute `{attr_name}`"),
-            include_loader: None,
+            template_store: None,
         }
     }
 
@@ -73,7 +98,7 @@ impl TemplateRenderTarget {
             node_id: Some(node_id.clone()),
             edge: None,
             owner: format!("node `{node_id}` attribute `{attr_name}`"),
-            include_loader: None,
+            template_store: None,
         }
     }
 
@@ -94,7 +119,7 @@ impl TemplateRenderTarget {
             node_id: None,
             edge: Some((from.clone(), to.clone())),
             owner: format!("edge `{from} -> {to}` attribute `{attr_name}`"),
-            include_loader: None,
+            template_store: None,
         }
     }
 
@@ -112,8 +137,8 @@ impl TemplateRenderTarget {
     }
 
     #[must_use]
-    pub(crate) fn with_include_loader(mut self, include_loader: Option<TemplateLoader>) -> Self {
-        self.include_loader = include_loader;
+    pub(crate) fn with_template_store(mut self, template_store: TemplateRenderStore) -> Self {
+        self.template_store = Some(template_store);
         self
     }
 
@@ -133,23 +158,22 @@ pub(crate) fn render_template_for_target(
     diagnostics: &mut Vec<Diagnostic>,
 ) -> Result<String, Error> {
     let source_name = target.template_source_name();
-    let render_strict = || match target.include_loader.as_ref() {
-        Some(loader) => render_named_with_loader(source_name.clone(), text, ctx, loader),
-        None => render_named(source_name.clone(), text, ctx),
+    let render_with_mode = |mode| match target.template_store.as_ref() {
+        Some(template_store) => template_store.render(text, ctx, mode),
+        None if matches!(mode, TemplateRenderMode::Strict) => {
+            render_named(source_name.clone(), text, ctx)
+        }
+        None => render_lenient_named(source_name.clone(), text, ctx),
     };
     match render_mode {
-        RenderMode::Strict => render_strict().map_err(|err| template_error_for_target(target, err)),
-        RenderMode::Structural => match render_strict() {
+        RenderMode::Strict => render_with_mode(TemplateRenderMode::Strict)
+            .map_err(|err| template_error_for_target(target, err)),
+        RenderMode::Structural => match render_with_mode(TemplateRenderMode::Strict) {
             Ok(rendered) => Ok(rendered),
             Err(err @ TemplateError::UndefinedVariable { .. }) => {
                 diagnostics.push(template_diagnostic(&err, target));
-                match target.include_loader.as_ref() {
-                    Some(loader) => {
-                        render_lenient_named_with_loader(source_name, text, ctx, loader)
-                    }
-                    None => render_lenient_named(source_name, text, ctx),
-                }
-                .map_err(|err| template_error_for_target(target, err))
+                render_with_mode(TemplateRenderMode::Lenient)
+                    .map_err(|err| template_error_for_target(target, err))
             }
             Err(err) => Err(template_error_for_target(target, err)),
         },

--- a/test/templates/sibling_partial/prompts/audits/audit.prompt.md
+++ b/test/templates/sibling_partial/prompts/audits/audit.prompt.md
@@ -1,0 +1,3 @@
+Audit this change:
+
+{% include "../partials/audit.partial.tpl" %}

--- a/test/templates/sibling_partial/prompts/partials/audit.partial.tpl
+++ b/test/templates/sibling_partial/prompts/partials/audit.partial.tpl
@@ -1,0 +1,1 @@
+Shared audit checklist.

--- a/test/templates/sibling_partial/workflow.fabro
+++ b/test/templates/sibling_partial/workflow.fabro
@@ -1,0 +1,7 @@
+digraph SiblingPartialTemplateInclude {
+    start [shape=Mdiamond, label="Start"]
+    audit [label="Audit", prompt="@prompts/audits/audit.prompt.md"]
+    exit  [shape=Msquare,  label="Exit"]
+
+    start -> audit -> exit
+}


### PR DESCRIPTION
## Summary
- Add a CLI validation regression for workflow-root prompt partials included from nested prompt files.
- Allow bundled prompt templates to resolve sibling partials from the workflow root instead of jailing each prompt file to its own directory.
- Refactor include handling so manifest discovery and runtime rendering share rooted template sources, include normalization, root containment checks, and FileResolver-backed TemplateStore loading.

## Testing
- `cargo nextest run -p fabro-template`
- `cargo nextest run -p fabro-manifest`
- `cargo nextest run -p fabro-workflow`
- `cargo nextest run -p fabro-cli cmd::validate`
- `cargo +nightly-2026-04-14 fmt --check --all`
- `cargo +nightly-2026-04-14 clippy -p fabro-template -p fabro-manifest -p fabro-workflow -p fabro-cli --all-targets -- -D warnings`