### PR TITLE
fix(workflow): honor human gate timeout defaults

### DIFF
--- a/lib/crates/fabro-workflow/src/handler/agent.rs
+++ b/lib/crates/fabro-workflow/src/handler/agent.rs
@@ -7,7 +7,7 @@ use fabro_graphviz::graph::{Graph, Node};
 use fabro_types::RunId;
 use tokio_util::sync::CancellationToken;
 
-use super::{EngineServices, Handler};
+use super::{EngineServices, Handler, NodeTimeoutPolicy};
 use crate::context::{Context, WorkflowContext, keys};
 use crate::error::Error;
 use crate::event::{Emitter, Event, StageScope};
@@ -61,6 +61,10 @@ pub trait CodergenBackend: Send + Sync {
     }
 
     async fn shutdown(&self, _emitter: &Arc<Emitter>) {}
+
+    fn node_timeout_policy(&self, _node: &Node) -> NodeTimeoutPolicy {
+        NodeTimeoutPolicy::ExecutorEnforced
+    }
 }
 
 /// The default handler for LLM task nodes.
@@ -395,6 +399,14 @@ impl Handler for AgentHandler {
         outcome.files_touched = backend_files_touched;
 
         Ok(outcome)
+    }
+
+    fn node_timeout_policy(&self, node: &Node) -> NodeTimeoutPolicy {
+        self.backend
+            .as_ref()
+            .map_or(NodeTimeoutPolicy::ExecutorEnforced, |backend| {
+                backend.node_timeout_policy(node)
+            })
     }
 }
 

--- a/lib/crates/fabro-workflow/src/handler/command.rs
+++ b/lib/crates/fabro-workflow/src/handler/command.rs
@@ -5,7 +5,7 @@ use fabro_agent::CommandOutputCallback;
 use fabro_graphviz::graph::{Graph, Node};
 use fabro_types::CommandTermination;
 
-use super::{EngineServices, Handler};
+use super::{EngineServices, Handler, NodeTimeoutPolicy};
 use crate::command_log::CommandLogRecorder;
 use crate::context::{Context, keys};
 use crate::error::Error;
@@ -192,6 +192,10 @@ impl Handler for CommandHandler {
             );
             Ok(outcome)
         }
+    }
+
+    fn node_timeout_policy(&self, _node: &Node) -> NodeTimeoutPolicy {
+        NodeTimeoutPolicy::HandlerManaged
     }
 }
 

--- a/lib/crates/fabro-workflow/src/handler/human.rs
+++ b/lib/crates/fabro-workflow/src/handler/human.rs
@@ -6,11 +6,11 @@ use std::time::Instant;
 
 use async_trait::async_trait;
 use fabro_graphviz::graph::{Graph, Node};
-use fabro_interview::{Answer, AnswerValue, Interviewer, Question};
+use fabro_interview::{Answer, AnswerValue, Interviewer, Question, ask_with_timeout};
 use fabro_types::{BlockedReason, InterviewOption, Principal, QuestionType, SystemActorKind};
 use ulid::Ulid;
 
-use super::{EngineServices, Handler};
+use super::{EngineServices, Handler, NodeTimeoutPolicy};
 use crate::context::{Context, keys};
 use crate::error::Error;
 use crate::event::{Emitter, Event, StageScope};
@@ -249,6 +249,7 @@ impl Handler for HumanHandler {
         question.options = options;
         question.allow_freeform = freeform_target.is_some();
         question.stage.clone_from(&node.id);
+        question.timeout_seconds = node.timeout().map(|duration| duration.as_secs_f64());
 
         // Look up the prior node's full response
         if let Some(serde_json::Value::String(last_node)) = context.get(keys::LAST_STAGE) {
@@ -290,7 +291,7 @@ impl Handler for HumanHandler {
         self.tracker
             .interview_started(services.run.emitter.as_ref());
         let interview_start = Instant::now();
-        let answer_submission = self.interviewer.ask(question).await;
+        let answer_submission = ask_with_timeout(self.interviewer.as_ref(), question).await;
         let answer_actor = answer_submission.actor.clone();
         let answer = answer_submission.answer;
 
@@ -448,6 +449,10 @@ impl Handler for HumanHandler {
 
         Ok(Outcome::fail_deterministic("No matching choice"))
     }
+
+    fn node_timeout_policy(&self, _node: &Node) -> NodeTimeoutPolicy {
+        NodeTimeoutPolicy::HandlerManaged
+    }
 }
 
 fn make_choice_outcome(key: &str, label: &str, to: &str) -> Outcome {
@@ -600,6 +605,7 @@ fn answer_text(answer: &Answer) -> String {
 #[cfg(test)]
 mod tests {
     use std::sync::Mutex;
+    use std::time::Duration;
 
     use fabro_graphviz::graph::{AttrValue, Edge};
     use fabro_interview::{AutoApproveInterviewer, CallbackInterviewer, RecordingInterviewer};
@@ -1006,6 +1012,51 @@ mod tests {
             outcome.context_updates.get("human.gate.gate.answer"),
             Some(&serde_json::json!("yes"))
         );
+    }
+
+    #[tokio::test]
+    async fn wait_human_copies_node_timeout_to_question_and_started_event() {
+        let inner = Box::new(AutoApproveInterviewer::engine());
+        let recorder = Arc::new(RecordingInterviewer::new(inner));
+        let handler = HumanHandler::new(recorder.clone());
+        let mut graph = build_graph_with_human_gate();
+        let timeout = Duration::from_millis(125);
+        let timeout_seconds = timeout.as_secs_f64();
+        graph
+            .nodes
+            .get_mut("gate")
+            .unwrap()
+            .attrs
+            .insert("timeout".to_string(), AttrValue::Duration(timeout));
+        let node = graph.nodes.get("gate").unwrap();
+        let context = Context::new();
+        let run_dir = Path::new("/tmp/test");
+        let events = Arc::new(Mutex::new(Vec::new()));
+
+        handler
+            .execute(
+                node,
+                &context,
+                &graph,
+                run_dir,
+                &make_services_with_events(Arc::clone(&events)),
+            )
+            .await
+            .unwrap();
+
+        let recordings = recorder.recordings();
+        assert_eq!(recordings.len(), 1);
+        assert_eq!(recordings[0].0.timeout_seconds, Some(timeout_seconds));
+
+        let started_timeout = events
+            .lock()
+            .expect("event log lock poisoned")
+            .iter()
+            .find_map(|event| match &event.body {
+                EventBody::InterviewStarted(props) => props.timeout_seconds,
+                _ => None,
+            });
+        assert_eq!(started_timeout, Some(timeout_seconds));
     }
 
     #[tokio::test]

--- a/lib/crates/fabro-workflow/src/handler/human.rs
+++ b/lib/crates/fabro-workflow/src/handler/human.rs
@@ -30,6 +30,12 @@ struct ChoiceMatch<'a> {
     selected_label: String,
 }
 
+struct HumanGateQuestion {
+    choices:         Vec<Choice>,
+    freeform_target: Option<String>,
+    question:        Question,
+}
+
 /// Parse an accelerator key from a label.
 /// Patterns: `[K] Label`, `K) Label`, `K - Label`, or first character.
 fn parse_accelerator_key(label: &str) -> String {
@@ -71,6 +77,65 @@ fn parse_accelerator_key(label: &str) -> String {
         .next()
         .map(|c| c.to_string())
         .unwrap_or_default()
+}
+
+fn build_human_gate_question(
+    node: &Node,
+    context: &Context,
+    graph: &Graph,
+) -> Result<HumanGateQuestion, String> {
+    let edges = graph.outgoing_edges(&node.id);
+    let mut freeform_target: Option<String> = None;
+    let mut choices: Vec<Choice> = Vec::new();
+
+    for edge in &edges {
+        if edge.freeform() {
+            freeform_target = Some(edge.to.clone());
+            continue;
+        }
+        let label = edge.label().filter(|l| !l.is_empty()).unwrap_or(&edge.to);
+        let key = parse_accelerator_key(label);
+        choices.push(Choice {
+            key,
+            label: label.to_string(),
+            to: edge.to.clone(),
+        });
+    }
+
+    if choices.is_empty() && freeform_target.is_none() {
+        return Err("No outgoing edges for human gate".to_string());
+    }
+
+    let question_type = question_type_for_node(node, choices.is_empty())?;
+    let mut question = Question::new(node.label(), question_type);
+    question.id = Ulid::new().to_string();
+    question.options = choices
+        .iter()
+        .map(|choice| InterviewOption {
+            key:   choice.key.clone(),
+            label: choice.label.clone(),
+        })
+        .collect();
+    question.allow_freeform = freeform_target.is_some();
+    question.stage.clone_from(&node.id);
+    question.timeout_seconds = node.timeout().map(|duration| duration.as_secs_f64());
+
+    if let Some(serde_json::Value::String(last_node)) = context.get(keys::LAST_STAGE) {
+        if let Some(serde_json::Value::String(response)) =
+            context.get(&keys::response_key(&last_node))
+        {
+            let text = response.trim();
+            if !text.is_empty() {
+                question.context_display = Some(text.to_owned());
+            }
+        }
+    }
+
+    Ok(HumanGateQuestion {
+        choices,
+        freeform_target,
+        question,
+    })
 }
 
 /// Refcount of open interviews for this handler's run. Emits `run.blocked`
@@ -206,65 +271,17 @@ impl Handler for HumanHandler {
         _run_dir: &Path,
         services: &EngineServices,
     ) -> Result<Outcome, Error> {
-        // 1. Derive choices from outgoing edges
-        let edges = graph.outgoing_edges(&node.id);
-        let mut freeform_target: Option<String> = None;
-        let mut choices: Vec<Choice> = Vec::new();
-
-        for edge in &edges {
-            if edge.freeform() {
-                freeform_target = Some(edge.to.clone());
-                continue;
-            }
-            let label = edge.label().filter(|l| !l.is_empty()).unwrap_or(&edge.to);
-            let key = parse_accelerator_key(label);
-            choices.push(Choice {
-                key,
-                label: label.to_string(),
-                to: edge.to.clone(),
-            });
-        }
-
-        if choices.is_empty() && freeform_target.is_none() {
-            return Ok(Outcome::fail_deterministic(
-                "No outgoing edges for human gate",
-            ));
-        }
-
-        // 2. Build question
-        let options: Vec<InterviewOption> = choices
-            .iter()
-            .map(|c| InterviewOption {
-                key:   c.key.clone(),
-                label: c.label.clone(),
-            })
-            .collect();
-
-        let question_type = match question_type_for_node(node, choices.is_empty()) {
-            Ok(question_type) => question_type,
+        let HumanGateQuestion {
+            choices,
+            freeform_target,
+            question,
+        } = match build_human_gate_question(node, context, graph) {
+            Ok(question) => question,
             Err(reason) => return Ok(Outcome::fail_deterministic(reason)),
         };
-        let mut question = Question::new(node.label(), question_type);
-        question.id = Ulid::new().to_string();
-        question.options = options;
-        question.allow_freeform = freeform_target.is_some();
-        question.stage.clone_from(&node.id);
-        question.timeout_seconds = node.timeout().map(|duration| duration.as_secs_f64());
 
-        // Look up the prior node's full response
-        if let Some(serde_json::Value::String(last_node)) = context.get(keys::LAST_STAGE) {
-            if let Some(serde_json::Value::String(response)) =
-                context.get(&keys::response_key(&last_node))
-            {
-                let text = response.trim();
-                if !text.is_empty() {
-                    question.context_display = Some(text.to_owned());
-                }
-            }
-        }
-
-        // 3. Present to interviewer
-        let question_text = node.label().to_string();
+        // Present to interviewer
+        let question_text = question.text.clone();
         let question_id = question.id.clone();
         let stage_scope = StageScope::for_handler(context, &node.id);
         self.emit(
@@ -295,7 +312,7 @@ impl Handler for HumanHandler {
         let answer_actor = answer_submission.actor.clone();
         let answer = answer_submission.answer;
 
-        // 4. Handle timeout
+        // Handle timeout
         if answer.value == AnswerValue::Timeout {
             self.emit(
                 &services.run.emitter,
@@ -335,7 +352,7 @@ impl Handler for HumanHandler {
             return Err(Error::Cancelled);
         }
 
-        // 5. Handle unanswered / interrupted interview sessions.
+        // Handle unanswered / interrupted interview sessions.
         if answer.value == AnswerValue::Interrupted {
             if services.run.cancel_token().is_cancelled() {
                 return Err(Error::Cancelled);
@@ -392,7 +409,7 @@ impl Handler for HumanHandler {
         self.tracker
             .interview_resolved(services.run.emitter.as_ref());
 
-        // 6. Try fixed-choice match
+        // Try fixed-choice match
         if let Some(selected) = find_choice_match(&answer, &choices) {
             let mut outcome = make_choice_outcome(
                 &selected.selected_key,
@@ -409,7 +426,7 @@ impl Handler for HumanHandler {
             return Ok(outcome);
         }
 
-        // 7. Freeform fallback
+        // Freeform fallback
         if let Some(freeform_to) = &freeform_target {
             let text = answer_text(&answer);
             let mut outcome = Outcome::success();
@@ -434,7 +451,7 @@ impl Handler for HumanHandler {
             return Ok(outcome);
         }
 
-        // 8. Fallback to first choice
+        // Fallback to first choice
         if let Some(first) = choices.first() {
             let mut outcome = make_choice_outcome(&first.key, &first.label, &first.to);
             add_answer_context(

--- a/lib/crates/fabro-workflow/src/handler/llm/acp.rs
+++ b/lib/crates/fabro-workflow/src/handler/llm/acp.rs
@@ -14,6 +14,7 @@ use super::super::agent::{CodergenBackend, CodergenResult, CodergenRunRequest, O
 use super::changed_files;
 use crate::error::Error;
 use crate::event::{Emitter, Event, RunNoticeCode, RunNoticeLevel, StageScope};
+use crate::handler::NodeTimeoutPolicy;
 
 pub struct AgentAcpBackend {
     tool_env:                     Option<Arc<dyn ToolEnvProvider>>,
@@ -208,6 +209,10 @@ impl CodergenBackend for AgentAcpBackend {
         Err(Error::Validation(
             "backend=\"acp\" is only valid on agent nodes; prompt nodes are API-only".to_string(),
         ))
+    }
+
+    fn node_timeout_policy(&self, _node: &Node) -> NodeTimeoutPolicy {
+        NodeTimeoutPolicy::HandlerManaged
     }
 }
 

--- a/lib/crates/fabro-workflow/src/handler/llm/router.rs
+++ b/lib/crates/fabro-workflow/src/handler/llm/router.rs
@@ -9,6 +9,7 @@ use super::acp::AgentAcpBackend;
 use super::routing;
 use crate::error::Error;
 use crate::event::Emitter;
+use crate::handler::NodeTimeoutPolicy;
 
 /// Routes codergen invocations to API or ACP backends based on node attributes.
 pub struct BackendRouter {
@@ -54,6 +55,14 @@ impl CodergenBackend for BackendRouter {
 
     async fn shutdown(&self, emitter: &Arc<Emitter>) {
         self.api.shutdown(emitter).await;
+    }
+
+    fn node_timeout_policy(&self, node: &Node) -> NodeTimeoutPolicy {
+        match Self::select_backend(node) {
+            Ok(AgentBackend::Api) => self.api.node_timeout_policy(node),
+            Ok(AgentBackend::Acp) => self.acp.node_timeout_policy(node),
+            Err(_) => NodeTimeoutPolicy::ExecutorEnforced,
+        }
     }
 }
 

--- a/lib/crates/fabro-workflow/src/handler/mod.rs
+++ b/lib/crates/fabro-workflow/src/handler/mod.rs
@@ -27,6 +27,12 @@ use crate::outcome::{Outcome, OutcomeExt};
 pub use crate::services::{EngineServices, RunServices};
 
 /// The handler interface for node execution.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NodeTimeoutPolicy {
+    ExecutorEnforced,
+    HandlerManaged,
+}
+
 #[async_trait]
 pub trait Handler: Send + Sync {
     async fn execute(
@@ -55,6 +61,10 @@ pub trait Handler: Send + Sync {
     /// Default implementation retries transient errors only.
     fn should_retry(&self, err: &Error) -> bool {
         err.is_retryable()
+    }
+
+    fn node_timeout_policy(&self, _node: &Node) -> NodeTimeoutPolicy {
+        NodeTimeoutPolicy::ExecutorEnforced
     }
 
     async fn shutdown(&self, _emitter: &Arc<Emitter>) {}

--- a/lib/crates/fabro-workflow/src/handler/mod.rs
+++ b/lib/crates/fabro-workflow/src/handler/mod.rs
@@ -29,7 +29,11 @@ pub use crate::services::{EngineServices, RunServices};
 /// The handler interface for node execution.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum NodeTimeoutPolicy {
+    /// The workflow executor wraps the whole handler future in the node
+    /// timeout.
     ExecutorEnforced,
+    /// The handler consumes the node timeout and is responsible for surfacing
+    /// timeout-specific outcome and events.
     HandlerManaged,
 }
 
@@ -189,8 +193,10 @@ pub fn default_registry(
 #[cfg(test)]
 mod tests {
     use fabro_graphviz::graph::AttrValue;
+    use fabro_interview::AutoApproveInterviewer;
 
     use super::*;
+    use crate::handler::agent::CodergenBackend;
 
     struct TestHandler {
         _name: String,
@@ -269,6 +275,50 @@ mod tests {
         };
         assert!(handler.should_retry(&Error::handler("timeout".to_string())));
         assert!(!handler.should_retry(&Error::Parse("bad".to_string())));
+    }
+
+    #[test]
+    fn timeout_policy_defaults_to_executor_enforced() {
+        let handler = TestHandler {
+            _name: "test".to_string(),
+        };
+        let node = Node::new("work");
+
+        assert_eq!(
+            handler.node_timeout_policy(&node),
+            NodeTimeoutPolicy::ExecutorEnforced
+        );
+    }
+
+    #[test]
+    fn built_in_handlers_that_consume_node_timeout_manage_it_themselves() {
+        let node = Node::new("work");
+        let human = human::HumanHandler::new(Arc::new(AutoApproveInterviewer::engine()));
+        let acp = llm::AgentAcpBackend::new();
+
+        assert_eq!(
+            human.node_timeout_policy(&node),
+            NodeTimeoutPolicy::HandlerManaged
+        );
+        assert_eq!(
+            command::CommandHandler.node_timeout_policy(&node),
+            NodeTimeoutPolicy::HandlerManaged
+        );
+        assert_eq!(
+            acp.node_timeout_policy(&node),
+            NodeTimeoutPolicy::HandlerManaged
+        );
+    }
+
+    #[test]
+    fn agent_handler_delegates_timeout_policy_to_backend() {
+        let node = Node::new("work");
+        let handler = agent::AgentHandler::new(Some(Box::new(llm::AgentAcpBackend::new())));
+
+        assert_eq!(
+            handler.node_timeout_policy(&node),
+            NodeTimeoutPolicy::HandlerManaged
+        );
     }
 
     struct NeverRetryHandler;

--- a/lib/crates/fabro-workflow/src/node_handler.rs
+++ b/lib/crates/fabro-workflow/src/node_handler.rs
@@ -16,7 +16,7 @@ use crate::artifact;
 use crate::context::Context;
 use crate::error::Error;
 use crate::graph::{WorkflowGraph, WorkflowNode};
-use crate::handler::{EngineServices, dispatch_handler, format_panic_message};
+use crate::handler::{EngineServices, NodeTimeoutPolicy, dispatch_handler, format_panic_message};
 use crate::outcome::{FailureDetail, Outcome, StageOutcome};
 use crate::retry::build_retry_policy;
 
@@ -58,7 +58,10 @@ impl NodeHandler<WorkflowGraph> for WorkflowNodeHandler {
         let execution_snapshot = wf_context.snapshot();
 
         // Timeout from the node
-        let node_timeout = gv_node.timeout();
+        let node_timeout = match handler.node_timeout_policy(gv_node) {
+            NodeTimeoutPolicy::ExecutorEnforced => gv_node.timeout(),
+            NodeTimeoutPolicy::HandlerManaged => None,
+        };
 
         // Wrap with panic catch + timeout
         let run_dir = self.run_dir.clone();

--- a/lib/crates/fabro-workflow/tests/it/integration.rs
+++ b/lib/crates/fabro-workflow/tests/it/integration.rs
@@ -846,7 +846,7 @@ struct NeverAnswerInterviewer;
 #[async_trait::async_trait]
 impl Interviewer for NeverAnswerInterviewer {
     async fn ask(&self, _question: fabro_interview::Question) -> fabro_interview::AnswerSubmission {
-        tokio::time::sleep(Duration::from_secs(60)).await;
+        tokio::time::sleep(Duration::from_mins(1)).await;
         fabro_interview::AnswerSubmission::system(
             Answer::interrupted(),
             fabro_types::SystemActorKind::Engine,

--- a/lib/crates/fabro-workflow/tests/it/integration.rs
+++ b/lib/crates/fabro-workflow/tests/it/integration.rs
@@ -841,6 +841,149 @@ async fn human_gate_interrupted_input_fails_closed_without_fail_route() {
     );
 }
 
+struct NeverAnswerInterviewer;
+
+#[async_trait::async_trait]
+impl Interviewer for NeverAnswerInterviewer {
+    async fn ask(&self, _question: fabro_interview::Question) -> fabro_interview::AnswerSubmission {
+        tokio::time::sleep(Duration::from_secs(60)).await;
+        fabro_interview::AnswerSubmission::system(
+            Answer::interrupted(),
+            fabro_types::SystemActorKind::Engine,
+        )
+    }
+}
+
+#[tokio::test]
+async fn human_gate_timeout_routes_to_default_choice_when_unanswered() {
+    let mut graph = Graph::new("HumanGateTimeoutDefaultChoice");
+
+    let mut start = Node::new("start");
+    start.attrs.insert(
+        "shape".to_string(),
+        AttrValue::String("Mdiamond".to_string()),
+    );
+    graph.nodes.insert("start".to_string(), start);
+
+    let mut exit = Node::new("exit");
+    exit.attrs.insert(
+        "shape".to_string(),
+        AttrValue::String("Msquare".to_string()),
+    );
+    graph.nodes.insert("exit".to_string(), exit);
+
+    let mut gate = Node::new("gate");
+    gate.attrs.insert(
+        "shape".to_string(),
+        AttrValue::String("hexagon".to_string()),
+    );
+    gate.attrs
+        .insert("type".to_string(), AttrValue::String("human".to_string()));
+    gate.attrs.insert(
+        "label".to_string(),
+        AttrValue::String("Approve release?".to_string()),
+    );
+    gate.attrs.insert(
+        "question_type".to_string(),
+        AttrValue::String("multiple_choice".to_string()),
+    );
+    gate.attrs.insert(
+        "human.default_choice".to_string(),
+        AttrValue::String("approve".to_string()),
+    );
+    gate.attrs.insert(
+        "timeout".to_string(),
+        AttrValue::Duration(Duration::from_millis(20)),
+    );
+    graph.nodes.insert("gate".to_string(), gate);
+
+    graph
+        .nodes
+        .insert("approve".to_string(), Node::new("approve"));
+    graph
+        .nodes
+        .insert("revise".to_string(), Node::new("revise"));
+
+    graph.edges.push(Edge::new("start", "gate"));
+
+    let mut approve_edge = Edge::new("gate", "approve");
+    approve_edge.attrs.insert(
+        "label".to_string(),
+        AttrValue::String("[A] Approve".to_string()),
+    );
+    graph.edges.push(approve_edge);
+
+    let mut revise_edge = Edge::new("gate", "revise");
+    revise_edge.attrs.insert(
+        "label".to_string(),
+        AttrValue::String("[R] Revise".to_string()),
+    );
+    graph.edges.push(revise_edge);
+
+    graph.edges.push(Edge::new("approve", "exit"));
+    graph.edges.push(Edge::new("revise", "exit"));
+
+    let interviewer = Arc::new(NeverAnswerInterviewer);
+    let emitter = Emitter::default();
+    let events = collect_events(&emitter);
+
+    let dir = tempfile::tempdir().expect("temporary run dir should be created");
+    let mut registry = HandlerRegistry::new(Box::new(StartHandler));
+    registry.register("start", Box::new(StartHandler));
+    registry.register("exit", Box::new(ExitHandler));
+    registry.register("human", Box::new(HumanHandler::new(interviewer)));
+
+    let engine = WorkflowRunner::new(registry, Arc::new(emitter), local_env());
+    let run_options = RunOptions {
+        settings:         WorkflowSettings::default(),
+        run_dir:          dir.path().to_path_buf(),
+        cancel_token:     CancellationToken::new(),
+        run_id:           test_run_id("test-run"),
+        labels:           std::collections::HashMap::new(),
+        workflow_slug:    None,
+        github_app:       None,
+        base_branch:      None,
+        display_base_sha: None,
+        pre_run_git:      None,
+        fork_source_ref:  None,
+        git:              None,
+    };
+    let (outcome, state) = engine
+        .run_with_state(&graph, &run_options)
+        .await
+        .expect("human timeout should route through default choice");
+
+    if outcome.status != StageOutcome::Succeeded {
+        let gate_outcome = state
+            .current_checkpoint()
+            .and_then(|checkpoint| checkpoint.node_outcomes.get("gate"));
+        panic!(
+            "human timeout should have selected default choice; outcome: {outcome:?}; gate outcome: {gate_outcome:?}"
+        );
+    }
+
+    let checkpoint = state
+        .current_checkpoint()
+        .cloned()
+        .expect("checkpoint should be captured");
+    assert!(
+        checkpoint.completed_nodes.contains(&"approve".to_string()),
+        "default choice target should have completed"
+    );
+    assert!(
+        !checkpoint.completed_nodes.contains(&"revise".to_string()),
+        "non-default choice target should not have completed"
+    );
+
+    let captured_events = events.lock().expect("event log lock poisoned");
+    assert!(
+        captured_events
+            .iter()
+            .any(|event| event.event_name() == "interview.timeout"),
+        "interview.timeout should be emitted on human gate timeout"
+    );
+}
+
 #[tokio::test]
 async fn human_gate_interrupted_input_routes_via_outcome_fail_condition() {
     let mut graph = Graph::new("HumanGateInterruptedFailRoute");


### PR DESCRIPTION
## Summary
- add a regression test for unanswered human gate timeouts with `human.default_choice`
- route human gate `timeout` through the interview timeout path so it emits `interview.timeout` and selects the default target
- make timeout ownership explicit for handlers that consume `node.timeout()`, including command and ACP handlers

Fixes #317

## Testing
- cargo nextest run -p fabro-workflow --test it human_gate_timeout_routes_to_default_choice_when_unanswered
- cargo nextest run -p fabro-workflow timeout_policy built_in_handlers_that_consume_node_timeout_manage_it_themselves agent_handler_delegates_timeout_policy_to_backend
- cargo nextest run -p fabro-workflow script_handler_timeout script_handler_timeout_error_includes_output_tails writes_script_timing_json_on_timeout timeout_causes_fail_status_record
- cargo nextest run -p fabro-workflow wait_human
- cargo +nightly-2026-04-14 fmt --check --all
- cargo +nightly-2026-04-14 clippy -p fabro-workflow --all-targets -- -D warnings