### PR TITLE
refactor(hooks): centralize run location handling

### DIFF
--- a/lib/crates/fabro-hooks/src/bridge.rs
+++ b/lib/crates/fabro-hooks/src/bridge.rs
@@ -5,7 +5,7 @@ use fabro_agent::{Sandbox, ToolHookCallback, ToolHookDecision};
 use fabro_types::RunId;
 
 use crate::runner::HookRunner;
-use crate::types::{HookContext, HookDecision, HookEvent};
+use crate::types::{HookContext, HookDecision, HookEvent, HookWorkDirs};
 
 /// Bridge between the workflow hook system and the agent tool-hook callback.
 ///
@@ -16,7 +16,7 @@ pub struct WorkflowToolHookCallback {
     pub sandbox:       Arc<dyn Sandbox>,
     pub run_id:        RunId,
     pub workflow_name: String,
-    pub work_dir:      Option<PathBuf>,
+    pub host_work_dir: Option<PathBuf>,
     pub node_id:       String,
 }
 
@@ -29,8 +29,12 @@ impl WorkflowToolHookCallback {
     }
 
     async fn run_hook(&self, ctx: &HookContext) -> HookDecision {
+        let sandbox_work_dir = std::path::Path::new(self.sandbox.working_directory());
         self.hook_runner
-            .run(ctx, self.sandbox.clone(), self.work_dir.as_deref())
+            .run(ctx, self.sandbox.clone(), HookWorkDirs {
+                host:    self.host_work_dir.as_deref(),
+                sandbox: Some(sandbox_work_dir),
+            })
             .await
     }
 }
@@ -72,7 +76,6 @@ impl ToolHookCallback for WorkflowToolHookCallback {
 
 #[cfg(test)]
 mod tests {
-    use std::path::Path;
     use std::sync::Mutex;
 
     use fabro_model::Catalog;
@@ -95,7 +98,7 @@ mod tests {
             _definition: &HookDefinition,
             context: &HookContext,
             _sandbox: Arc<dyn Sandbox>,
-            _work_dir: Option<&Path>,
+            _work_dirs: HookWorkDirs<'_>,
             _llm_source: &dyn fabro_auth::CredentialSource,
             _catalog: Arc<Catalog>,
         ) -> HookResult {
@@ -136,7 +139,7 @@ mod tests {
             sandbox,
             run_id: fixtures::RUN_1,
             workflow_name: "test-wf".into(),
-            work_dir: None,
+            host_work_dir: None,
             node_id: "plan".into(),
         }
     }

--- a/lib/crates/fabro-hooks/src/bridge.rs
+++ b/lib/crates/fabro-hooks/src/bridge.rs
@@ -1,23 +1,22 @@
-use std::path::PathBuf;
 use std::sync::Arc;
 
 use fabro_agent::{Sandbox, ToolHookCallback, ToolHookDecision};
 use fabro_types::RunId;
 
 use crate::runner::HookRunner;
-use crate::types::{HookContext, HookDecision, HookEvent, HookWorkDirs};
+use crate::types::{HookContext, HookDecision, HookEvent, HookExecutionContext};
 
 /// Bridge between the workflow hook system and the agent tool-hook callback.
 ///
 /// Created per-node in the workflow engine, capturing the `HookRunner` and
 /// context needed to build `HookContext` for tool-level events.
 pub struct WorkflowToolHookCallback {
-    pub hook_runner:   Arc<HookRunner>,
-    pub sandbox:       Arc<dyn Sandbox>,
-    pub run_id:        RunId,
-    pub workflow_name: String,
-    pub host_work_dir: Option<PathBuf>,
-    pub node_id:       String,
+    pub hook_runner:            Arc<HookRunner>,
+    pub sandbox:                Arc<dyn Sandbox>,
+    pub run_id:                 RunId,
+    pub workflow_name:          String,
+    pub hook_execution_context: HookExecutionContext,
+    pub node_id:                String,
 }
 
 impl WorkflowToolHookCallback {
@@ -29,12 +28,12 @@ impl WorkflowToolHookCallback {
     }
 
     async fn run_hook(&self, ctx: &HookContext) -> HookDecision {
-        let sandbox_work_dir = std::path::Path::new(self.sandbox.working_directory());
         self.hook_runner
-            .run(ctx, self.sandbox.clone(), HookWorkDirs {
-                host:    self.host_work_dir.as_deref(),
-                sandbox: Some(sandbox_work_dir),
-            })
+            .run(
+                ctx,
+                self.sandbox.clone(),
+                self.hook_execution_context.clone(),
+            )
             .await
     }
 }
@@ -76,6 +75,7 @@ impl ToolHookCallback for WorkflowToolHookCallback {
 
 #[cfg(test)]
 mod tests {
+    use std::path::PathBuf;
     use std::sync::Mutex;
 
     use fabro_model::Catalog;
@@ -87,8 +87,9 @@ mod tests {
     use crate::types::{HookContext, HookResult};
 
     struct CapturingExecutor {
-        captured_contexts: Arc<Mutex<Vec<HookContext>>>,
-        decision:          HookDecision,
+        captured_contexts:           Arc<Mutex<Vec<HookContext>>>,
+        captured_execution_contexts: Arc<Mutex<Vec<HookExecutionContext>>>,
+        decision:                    HookDecision,
     }
 
     #[async_trait::async_trait]
@@ -98,11 +99,15 @@ mod tests {
             _definition: &HookDefinition,
             context: &HookContext,
             _sandbox: Arc<dyn Sandbox>,
-            _work_dirs: HookWorkDirs<'_>,
+            execution_context: &HookExecutionContext,
             _llm_source: &dyn fabro_auth::CredentialSource,
             _catalog: Arc<Catalog>,
         ) -> HookResult {
             self.captured_contexts.lock().unwrap().push(context.clone());
+            self.captured_execution_contexts
+                .lock()
+                .unwrap()
+                .push(execution_context.clone());
             HookResult {
                 hook_name:   None,
                 decision:    self.decision.clone(),
@@ -133,13 +138,14 @@ mod tests {
     fn make_bridge(
         hook_runner: Arc<HookRunner>,
         sandbox: Arc<dyn Sandbox>,
+        hook_execution_context: HookExecutionContext,
     ) -> WorkflowToolHookCallback {
         WorkflowToolHookCallback {
             hook_runner,
             sandbox,
             run_id: fixtures::RUN_1,
             workflow_name: "test-wf".into(),
-            host_work_dir: None,
+            hook_execution_context,
             node_id: "plan".into(),
         }
     }
@@ -148,15 +154,16 @@ mod tests {
     async fn pre_tool_use_builds_correct_context() {
         let captured = Arc::new(Mutex::new(Vec::new()));
         let executor = Arc::new(CapturingExecutor {
-            captured_contexts: captured.clone(),
-            decision:          HookDecision::Proceed,
+            captured_contexts:           captured.clone(),
+            captured_execution_contexts: Arc::new(Mutex::new(Vec::new())),
+            decision:                    HookDecision::Proceed,
         });
         let config = HookSettings {
             hooks: vec![make_hook(HookEvent::PreToolUse)],
         };
         let runner = Arc::new(HookRunner::with_executor(config, executor));
         let sandbox = make_sandbox();
-        let bridge = make_bridge(runner, sandbox);
+        let bridge = make_bridge(runner, sandbox, HookExecutionContext::default());
 
         bridge
             .pre_tool_use("shell", &serde_json::json!({"command": "ls"}))
@@ -177,8 +184,9 @@ mod tests {
     #[tokio::test]
     async fn pre_tool_use_maps_block_decision() {
         let executor = Arc::new(CapturingExecutor {
-            captured_contexts: Arc::new(Mutex::new(Vec::new())),
-            decision:          HookDecision::Block {
+            captured_contexts:           Arc::new(Mutex::new(Vec::new())),
+            captured_execution_contexts: Arc::new(Mutex::new(Vec::new())),
+            decision:                    HookDecision::Block {
                 reason: Some("forbidden".into()),
             },
         });
@@ -187,7 +195,7 @@ mod tests {
         };
         let runner = Arc::new(HookRunner::with_executor(config, executor));
         let sandbox = make_sandbox();
-        let bridge = make_bridge(runner, sandbox);
+        let bridge = make_bridge(runner, sandbox, HookExecutionContext::default());
 
         let decision = bridge.pre_tool_use("shell", &serde_json::json!({})).await;
         assert_eq!(decision, ToolHookDecision::Block {
@@ -198,15 +206,16 @@ mod tests {
     #[tokio::test]
     async fn pre_tool_use_maps_proceed() {
         let executor = Arc::new(CapturingExecutor {
-            captured_contexts: Arc::new(Mutex::new(Vec::new())),
-            decision:          HookDecision::Proceed,
+            captured_contexts:           Arc::new(Mutex::new(Vec::new())),
+            captured_execution_contexts: Arc::new(Mutex::new(Vec::new())),
+            decision:                    HookDecision::Proceed,
         });
         let config = HookSettings {
             hooks: vec![make_hook(HookEvent::PreToolUse)],
         };
         let runner = Arc::new(HookRunner::with_executor(config, executor));
         let sandbox = make_sandbox();
-        let bridge = make_bridge(runner, sandbox);
+        let bridge = make_bridge(runner, sandbox, HookExecutionContext::default());
 
         let decision = bridge.pre_tool_use("shell", &serde_json::json!({})).await;
         assert_eq!(decision, ToolHookDecision::Proceed);
@@ -216,15 +225,16 @@ mod tests {
     async fn post_tool_use_builds_context_with_output() {
         let captured = Arc::new(Mutex::new(Vec::new()));
         let executor = Arc::new(CapturingExecutor {
-            captured_contexts: captured.clone(),
-            decision:          HookDecision::Proceed,
+            captured_contexts:           captured.clone(),
+            captured_execution_contexts: Arc::new(Mutex::new(Vec::new())),
+            decision:                    HookDecision::Proceed,
         });
         let config = HookSettings {
             hooks: vec![make_hook(HookEvent::PostToolUse)],
         };
         let runner = Arc::new(HookRunner::with_executor(config, executor));
         let sandbox = make_sandbox();
-        let bridge = make_bridge(runner, sandbox);
+        let bridge = make_bridge(runner, sandbox, HookExecutionContext::default());
 
         bridge
             .post_tool_use("shell", "call_1", "file1.txt\nfile2.txt")
@@ -245,15 +255,16 @@ mod tests {
     async fn post_tool_use_failure_builds_context_with_error() {
         let captured = Arc::new(Mutex::new(Vec::new()));
         let executor = Arc::new(CapturingExecutor {
-            captured_contexts: captured.clone(),
-            decision:          HookDecision::Proceed,
+            captured_contexts:           captured.clone(),
+            captured_execution_contexts: Arc::new(Mutex::new(Vec::new())),
+            decision:                    HookDecision::Proceed,
         });
         let config = HookSettings {
             hooks: vec![make_hook(HookEvent::PostToolUseFailure)],
         };
         let runner = Arc::new(HookRunner::with_executor(config, executor));
         let sandbox = make_sandbox();
-        let bridge = make_bridge(runner, sandbox);
+        let bridge = make_bridge(runner, sandbox, HookExecutionContext::default());
 
         bridge
             .post_tool_use_failure("shell", "call_1", "command not found")
@@ -268,5 +279,32 @@ mod tests {
             contexts[0].error_message.as_deref(),
             Some("command not found")
         );
+    }
+
+    #[tokio::test]
+    async fn pre_tool_use_passes_supplied_hook_execution_context() {
+        let captured_contexts = Arc::new(Mutex::new(Vec::new()));
+        let captured_execution_contexts = Arc::new(Mutex::new(Vec::new()));
+        let executor = Arc::new(CapturingExecutor {
+            captured_contexts,
+            captured_execution_contexts: Arc::clone(&captured_execution_contexts),
+            decision: HookDecision::Proceed,
+        });
+        let config = HookSettings {
+            hooks: vec![make_hook(HookEvent::PreToolUse)],
+        };
+        let runner = Arc::new(HookRunner::with_executor(config, executor));
+        let sandbox = make_sandbox();
+        let hook_execution_context = HookExecutionContext {
+            host_source_dir:  Some(PathBuf::from("/host/source")),
+            sandbox_work_dir: Some(PathBuf::from("/supplied/sandbox")),
+        };
+        let bridge = make_bridge(runner, sandbox, hook_execution_context.clone());
+
+        bridge.pre_tool_use("shell", &serde_json::json!({})).await;
+
+        assert_eq!(captured_execution_contexts.lock().unwrap().as_slice(), &[
+            hook_execution_context
+        ]);
     }
 }

--- a/lib/crates/fabro-hooks/src/executor.rs
+++ b/lib/crates/fabro-hooks/src/executor.rs
@@ -1,7 +1,6 @@
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::fmt;
-use std::path::Path;
 use std::sync::{Arc, LazyLock};
 use std::time::Instant;
 
@@ -21,7 +20,7 @@ use tokio::time::timeout as tokio_timeout;
 use tokio_util::sync::CancellationToken;
 
 use crate::config::{HookDefinition, HookType, TlsMode};
-use crate::types::{HookContext, HookDecision, HookResult, PromptHookResponse};
+use crate::types::{HookContext, HookDecision, HookResult, HookWorkDirs, PromptHookResponse};
 
 const HOOK_EVALUATOR_SYSTEM_PROMPT: &str = "You are a hook evaluator for a workflow engine. Given context about a workflow event, evaluate the condition.";
 
@@ -49,7 +48,7 @@ pub trait HookExecutor: Send + Sync {
         definition: &HookDefinition,
         context: &HookContext,
         sandbox: Arc<dyn Sandbox>,
-        work_dir: Option<&Path>,
+        work_dirs: HookWorkDirs<'_>,
         llm_source: &dyn CredentialSource,
         catalog: Arc<Catalog>,
     ) -> HookResult;
@@ -142,7 +141,7 @@ impl HookExecutorImpl {
         command: &str,
         context: &HookContext,
         sandbox: &Arc<dyn Sandbox>,
-        work_dir: Option<&Path>,
+        work_dirs: HookWorkDirs<'_>,
         env: &E,
     ) -> HookDecision
     where
@@ -178,8 +177,17 @@ impl HookExecutorImpl {
             if sandbox.write_file(&ctx_path, &context_json).await.is_ok() {
                 env_vars.insert("FABRO_HOOK_CONTEXT".to_string(), ctx_path.clone());
             }
+            let sandbox_work_dir = work_dirs
+                .sandbox
+                .map(|path| path.to_string_lossy().to_string());
             match sandbox
-                .exec_command(&command, timeout_ms, None, Some(&env_vars), None)
+                .exec_command(
+                    &command,
+                    timeout_ms,
+                    sandbox_work_dir.as_deref(),
+                    Some(&env_vars),
+                    None,
+                )
                 .await
             {
                 Ok(result) => Self::parse_decision(result.exit_code.unwrap_or(-1), &result.stdout),
@@ -190,7 +198,7 @@ impl HookExecutorImpl {
         } else {
             let mut cmd = TokioCommand::new("sh");
             cmd.arg("-c").arg(&command);
-            if let Some(wd) = work_dir {
+            if let Some(wd) = work_dirs.host {
                 cmd.current_dir(wd);
             }
             for (k, v) in &env_vars {
@@ -619,7 +627,7 @@ impl HookExecutor for HookExecutorImpl {
         definition: &HookDefinition,
         context: &HookContext,
         sandbox: Arc<dyn Sandbox>,
-        work_dir: Option<&Path>,
+        work_dirs: HookWorkDirs<'_>,
         llm_source: &dyn CredentialSource,
         catalog: Arc<Catalog>,
     ) -> HookResult {
@@ -634,7 +642,7 @@ impl HookExecutor for HookExecutorImpl {
                 Cow::Borrowed(HookType::Command { ref command })
                 | Cow::Owned(HookType::Command { ref command }),
             ) => {
-                Self::execute_command(definition, command, context, &sandbox, work_dir, &env).await
+                Self::execute_command(definition, command, context, &sandbox, work_dirs, &env).await
             }
             Some(
                 Cow::Borrowed(HookType::Http {
@@ -833,7 +841,14 @@ mod tests {
         let sandbox = make_sandbox();
         let source = test_llm_source();
         let result = executor
-            .execute(&def, &ctx, sandbox, None, source.as_ref(), test_catalog())
+            .execute(
+                &def,
+                &ctx,
+                sandbox,
+                HookWorkDirs::default(),
+                source.as_ref(),
+                test_catalog(),
+            )
             .await;
         assert_eq!(result.decision, HookDecision::Proceed);
         assert_eq!(result.hook_name.as_deref(), Some("test-hook"));
@@ -847,7 +862,14 @@ mod tests {
         let sandbox = make_sandbox();
         let source = test_llm_source();
         let result = executor
-            .execute(&def, &ctx, sandbox, None, source.as_ref(), test_catalog())
+            .execute(
+                &def,
+                &ctx,
+                sandbox,
+                HookWorkDirs::default(),
+                source.as_ref(),
+                test_catalog(),
+            )
             .await;
         assert!(matches!(result.decision, HookDecision::Block { .. }));
     }
@@ -860,7 +882,14 @@ mod tests {
         let sandbox = make_sandbox();
         let source = test_llm_source();
         let result = executor
-            .execute(&def, &ctx, sandbox, None, source.as_ref(), test_catalog())
+            .execute(
+                &def,
+                &ctx,
+                sandbox,
+                HookWorkDirs::default(),
+                source.as_ref(),
+                test_catalog(),
+            )
             .await;
         assert!(matches!(result.decision, HookDecision::Block { .. }));
     }
@@ -873,7 +902,14 @@ mod tests {
         let sandbox = make_sandbox();
         let source = test_llm_source();
         let result = executor
-            .execute(&def, &ctx, sandbox, None, source.as_ref(), test_catalog())
+            .execute(
+                &def,
+                &ctx,
+                sandbox,
+                HookWorkDirs::default(),
+                source.as_ref(),
+                test_catalog(),
+            )
             .await;
         assert_eq!(result.decision, HookDecision::Skip {
             reason: Some("test skip".into()),
@@ -890,7 +926,14 @@ mod tests {
         let sandbox = make_sandbox();
         let source = test_llm_source();
         let result = executor
-            .execute(&def, &ctx, sandbox, None, source.as_ref(), test_catalog())
+            .execute(
+                &def,
+                &ctx,
+                sandbox,
+                HookWorkDirs::default(),
+                source.as_ref(),
+                test_catalog(),
+            )
             .await;
         assert_eq!(result.decision, HookDecision::Proceed);
     }
@@ -912,7 +955,14 @@ mod tests {
         let sandbox = make_sandbox();
         let source = test_llm_source();
         let result = executor
-            .execute(&def, &ctx, sandbox, None, source.as_ref(), test_catalog())
+            .execute(
+                &def,
+                &ctx,
+                sandbox,
+                HookWorkDirs::default(),
+                source.as_ref(),
+                test_catalog(),
+            )
             .await;
         assert!(matches!(result.decision, HookDecision::Block { .. }));
     }
@@ -1307,7 +1357,14 @@ mod tests {
         let sandbox = make_sandbox();
         let source = test_llm_source();
         let result = executor
-            .execute(&def, &ctx, sandbox, None, source.as_ref(), test_catalog())
+            .execute(
+                &def,
+                &ctx,
+                sandbox,
+                HookWorkDirs::default(),
+                source.as_ref(),
+                test_catalog(),
+            )
             .await;
 
         mock.assert_async().await;
@@ -1323,7 +1380,7 @@ mod tests {
             "echo {{ env.MISSING_HOOK_VALUE }}",
             &make_context(),
             &sandbox,
-            None,
+            HookWorkDirs::default(),
             &test_env(&[]),
         )
         .await;

--- a/lib/crates/fabro-hooks/src/executor.rs
+++ b/lib/crates/fabro-hooks/src/executor.rs
@@ -20,7 +20,9 @@ use tokio::time::timeout as tokio_timeout;
 use tokio_util::sync::CancellationToken;
 
 use crate::config::{HookDefinition, HookType, TlsMode};
-use crate::types::{HookContext, HookDecision, HookResult, HookWorkDirs, PromptHookResponse};
+use crate::types::{
+    HookContext, HookDecision, HookExecutionContext, HookResult, PromptHookResponse,
+};
 
 const HOOK_EVALUATOR_SYSTEM_PROMPT: &str = "You are a hook evaluator for a workflow engine. Given context about a workflow event, evaluate the condition.";
 
@@ -48,7 +50,7 @@ pub trait HookExecutor: Send + Sync {
         definition: &HookDefinition,
         context: &HookContext,
         sandbox: Arc<dyn Sandbox>,
-        work_dirs: HookWorkDirs<'_>,
+        execution_context: &HookExecutionContext,
         llm_source: &dyn CredentialSource,
         catalog: Arc<Catalog>,
     ) -> HookResult;
@@ -141,7 +143,7 @@ impl HookExecutorImpl {
         command: &str,
         context: &HookContext,
         sandbox: &Arc<dyn Sandbox>,
-        work_dirs: HookWorkDirs<'_>,
+        execution_context: &HookExecutionContext,
         env: &E,
     ) -> HookDecision
     where
@@ -177,8 +179,8 @@ impl HookExecutorImpl {
             if sandbox.write_file(&ctx_path, &context_json).await.is_ok() {
                 env_vars.insert("FABRO_HOOK_CONTEXT".to_string(), ctx_path.clone());
             }
-            let sandbox_work_dir = work_dirs
-                .sandbox
+            let sandbox_work_dir = execution_context
+                .command_cwd_for(definition)
                 .map(|path| path.to_string_lossy().to_string());
             match sandbox
                 .exec_command(
@@ -198,7 +200,7 @@ impl HookExecutorImpl {
         } else {
             let mut cmd = TokioCommand::new("sh");
             cmd.arg("-c").arg(&command);
-            if let Some(wd) = work_dirs.host {
+            if let Some(wd) = execution_context.command_cwd_for(definition) {
                 cmd.current_dir(wd);
             }
             for (k, v) in &env_vars {
@@ -627,7 +629,7 @@ impl HookExecutor for HookExecutorImpl {
         definition: &HookDefinition,
         context: &HookContext,
         sandbox: Arc<dyn Sandbox>,
-        work_dirs: HookWorkDirs<'_>,
+        execution_context: &HookExecutionContext,
         llm_source: &dyn CredentialSource,
         catalog: Arc<Catalog>,
     ) -> HookResult {
@@ -642,7 +644,15 @@ impl HookExecutor for HookExecutorImpl {
                 Cow::Borrowed(HookType::Command { ref command })
                 | Cow::Owned(HookType::Command { ref command }),
             ) => {
-                Self::execute_command(definition, command, context, &sandbox, work_dirs, &env).await
+                Self::execute_command(
+                    definition,
+                    command,
+                    context,
+                    &sandbox,
+                    execution_context,
+                    &env,
+                )
+                .await
             }
             Some(
                 Cow::Borrowed(HookType::Http {
@@ -845,7 +855,7 @@ mod tests {
                 &def,
                 &ctx,
                 sandbox,
-                HookWorkDirs::default(),
+                &HookExecutionContext::default(),
                 source.as_ref(),
                 test_catalog(),
             )
@@ -866,7 +876,7 @@ mod tests {
                 &def,
                 &ctx,
                 sandbox,
-                HookWorkDirs::default(),
+                &HookExecutionContext::default(),
                 source.as_ref(),
                 test_catalog(),
             )
@@ -886,7 +896,7 @@ mod tests {
                 &def,
                 &ctx,
                 sandbox,
-                HookWorkDirs::default(),
+                &HookExecutionContext::default(),
                 source.as_ref(),
                 test_catalog(),
             )
@@ -906,7 +916,7 @@ mod tests {
                 &def,
                 &ctx,
                 sandbox,
-                HookWorkDirs::default(),
+                &HookExecutionContext::default(),
                 source.as_ref(),
                 test_catalog(),
             )
@@ -930,7 +940,7 @@ mod tests {
                 &def,
                 &ctx,
                 sandbox,
-                HookWorkDirs::default(),
+                &HookExecutionContext::default(),
                 source.as_ref(),
                 test_catalog(),
             )
@@ -959,7 +969,7 @@ mod tests {
                 &def,
                 &ctx,
                 sandbox,
-                HookWorkDirs::default(),
+                &HookExecutionContext::default(),
                 source.as_ref(),
                 test_catalog(),
             )
@@ -1361,7 +1371,7 @@ mod tests {
                 &def,
                 &ctx,
                 sandbox,
-                HookWorkDirs::default(),
+                &HookExecutionContext::default(),
                 source.as_ref(),
                 test_catalog(),
             )
@@ -1380,7 +1390,7 @@ mod tests {
             "echo {{ env.MISSING_HOOK_VALUE }}",
             &make_context(),
             &sandbox,
-            HookWorkDirs::default(),
+            &HookExecutionContext::default(),
             &test_env(&[]),
         )
         .await;

--- a/lib/crates/fabro-hooks/src/lib.rs
+++ b/lib/crates/fabro-hooks/src/lib.rs
@@ -7,4 +7,4 @@ pub mod types;
 pub use bridge::WorkflowToolHookCallback;
 pub use config::{HookDefinition, HookSettings, HookType, TlsMode};
 pub use runner::HookRunner;
-pub use types::{HookContext, HookDecision, HookEvent, HookWorkDirs};
+pub use types::{HookContext, HookDecision, HookEvent, HookExecutionContext};

--- a/lib/crates/fabro-hooks/src/lib.rs
+++ b/lib/crates/fabro-hooks/src/lib.rs
@@ -7,4 +7,4 @@ pub mod types;
 pub use bridge::WorkflowToolHookCallback;
 pub use config::{HookDefinition, HookSettings, HookType, TlsMode};
 pub use runner::HookRunner;
-pub use types::{HookContext, HookDecision, HookEvent};
+pub use types::{HookContext, HookDecision, HookEvent, HookWorkDirs};

--- a/lib/crates/fabro-hooks/src/runner.rs
+++ b/lib/crates/fabro-hooks/src/runner.rs
@@ -9,7 +9,7 @@ use fabro_model::Catalog;
 
 use crate::config::{HookDefinition, HookSettings};
 use crate::executor::{HookExecutor, HookExecutorImpl};
-use crate::types::{HookContext, HookDecision, HookWorkDirs};
+use crate::types::{HookContext, HookDecision, HookExecutionContext};
 
 /// Central orchestrator: filters matching hooks, executes them, merges
 /// decisions.
@@ -72,7 +72,7 @@ impl HookRunner {
         &self,
         context: &HookContext,
         sandbox: Arc<dyn Sandbox>,
-        work_dirs: HookWorkDirs<'_>,
+        execution_context: HookExecutionContext,
     ) -> HookDecision {
         let matching = self.filter_hooks(context);
         if matching.is_empty() {
@@ -90,11 +90,11 @@ impl HookRunner {
 
         let decision = if any_blocking {
             // Sequential execution for blocking hooks, short-circuit on first Block
-            self.run_sequential(&matching, context, sandbox, work_dirs)
+            self.run_sequential(&matching, context, sandbox, &execution_context)
                 .await
         } else {
             // Non-blocking: run all, ignore decisions
-            self.run_non_blocking(&matching, context, sandbox, work_dirs)
+            self.run_non_blocking(&matching, context, sandbox, &execution_context)
                 .await
         };
 
@@ -142,7 +142,7 @@ impl HookRunner {
         hooks: &[&HookDefinition],
         context: &HookContext,
         sandbox: Arc<dyn Sandbox>,
-        work_dirs: HookWorkDirs<'_>,
+        execution_context: &HookExecutionContext,
     ) -> HookDecision {
         let mut merged = HookDecision::Proceed;
         for hook in hooks {
@@ -157,7 +157,7 @@ impl HookRunner {
                     hook,
                     context,
                     sandbox.clone(),
-                    work_dirs,
+                    execution_context,
                     self.llm_source.as_ref(),
                     Arc::clone(&self.catalog),
                 )
@@ -198,7 +198,7 @@ impl HookRunner {
         hooks: &[&HookDefinition],
         context: &HookContext,
         sandbox: Arc<dyn Sandbox>,
-        work_dirs: HookWorkDirs<'_>,
+        execution_context: &HookExecutionContext,
     ) -> HookDecision {
         for hook in hooks {
             tracing::debug!(
@@ -212,7 +212,7 @@ impl HookRunner {
                     hook,
                     context,
                     sandbox.clone(),
-                    work_dirs,
+                    execution_context,
                     self.llm_source.as_ref(),
                     Arc::clone(&self.catalog),
                 )
@@ -256,7 +256,7 @@ mod tests {
             definition: &HookDefinition,
             _context: &HookContext,
             _sandbox: Arc<dyn Sandbox>,
-            _work_dirs: HookWorkDirs<'_>,
+            _execution_context: &HookExecutionContext,
             _llm_source: &dyn CredentialSource,
             _catalog: Arc<Catalog>,
         ) -> HookResult {
@@ -305,7 +305,7 @@ mod tests {
         let ctx = make_context(HookEvent::RunStart);
         let sandbox = make_sandbox();
         let decision = runner
-            .run(&ctx, sandbox.clone(), HookWorkDirs::default())
+            .run(&ctx, sandbox.clone(), HookExecutionContext::default())
             .await;
         assert_eq!(decision, HookDecision::Proceed);
     }
@@ -417,7 +417,7 @@ mod tests {
         let ctx = make_context(HookEvent::RunStart);
         let sandbox = make_sandbox();
         let decision = runner
-            .run(&ctx, sandbox.clone(), HookWorkDirs::default())
+            .run(&ctx, sandbox.clone(), HookExecutionContext::default())
             .await;
         assert!(matches!(decision, HookDecision::Block { .. }));
     }
@@ -438,7 +438,7 @@ mod tests {
         let ctx = make_context(HookEvent::StageStart);
         let sandbox = make_sandbox();
         let decision = runner
-            .run(&ctx, sandbox.clone(), HookWorkDirs::default())
+            .run(&ctx, sandbox.clone(), HookExecutionContext::default())
             .await;
         assert!(matches!(decision, HookDecision::Skip { .. }));
     }
@@ -459,7 +459,7 @@ mod tests {
         let ctx = make_context(HookEvent::StageComplete);
         let sandbox = make_sandbox();
         let decision = runner
-            .run(&ctx, sandbox.clone(), HookWorkDirs::default())
+            .run(&ctx, sandbox.clone(), HookExecutionContext::default())
             .await;
         // Non-blocking hooks don't affect the decision
         assert_eq!(decision, HookDecision::Proceed);
@@ -478,7 +478,7 @@ mod tests {
         let ctx = make_context(HookEvent::RunStart);
         let sandbox = make_sandbox();
         let decision = runner
-            .run(&ctx, sandbox.clone(), HookWorkDirs::default())
+            .run(&ctx, sandbox.clone(), HookExecutionContext::default())
             .await;
         assert_eq!(decision, HookDecision::Proceed);
     }
@@ -496,7 +496,7 @@ mod tests {
         let ctx = make_context(HookEvent::RunStart);
         let sandbox = make_sandbox();
         let decision = runner
-            .run(&ctx, sandbox.clone(), HookWorkDirs::default())
+            .run(&ctx, sandbox.clone(), HookExecutionContext::default())
             .await;
         assert!(matches!(decision, HookDecision::Block { .. }));
     }

--- a/lib/crates/fabro-hooks/src/runner.rs
+++ b/lib/crates/fabro-hooks/src/runner.rs
@@ -1,5 +1,4 @@
 use std::collections::HashMap;
-use std::path::Path;
 use std::sync::Arc;
 
 use fabro_agent::Sandbox;
@@ -10,7 +9,7 @@ use fabro_model::Catalog;
 
 use crate::config::{HookDefinition, HookSettings};
 use crate::executor::{HookExecutor, HookExecutorImpl};
-use crate::types::{HookContext, HookDecision};
+use crate::types::{HookContext, HookDecision, HookWorkDirs};
 
 /// Central orchestrator: filters matching hooks, executes them, merges
 /// decisions.
@@ -73,7 +72,7 @@ impl HookRunner {
         &self,
         context: &HookContext,
         sandbox: Arc<dyn Sandbox>,
-        work_dir: Option<&Path>,
+        work_dirs: HookWorkDirs<'_>,
     ) -> HookDecision {
         let matching = self.filter_hooks(context);
         if matching.is_empty() {
@@ -91,11 +90,11 @@ impl HookRunner {
 
         let decision = if any_blocking {
             // Sequential execution for blocking hooks, short-circuit on first Block
-            self.run_sequential(&matching, context, sandbox, work_dir)
+            self.run_sequential(&matching, context, sandbox, work_dirs)
                 .await
         } else {
             // Non-blocking: run all, ignore decisions
-            self.run_non_blocking(&matching, context, sandbox, work_dir)
+            self.run_non_blocking(&matching, context, sandbox, work_dirs)
                 .await
         };
 
@@ -143,7 +142,7 @@ impl HookRunner {
         hooks: &[&HookDefinition],
         context: &HookContext,
         sandbox: Arc<dyn Sandbox>,
-        work_dir: Option<&Path>,
+        work_dirs: HookWorkDirs<'_>,
     ) -> HookDecision {
         let mut merged = HookDecision::Proceed;
         for hook in hooks {
@@ -158,7 +157,7 @@ impl HookRunner {
                     hook,
                     context,
                     sandbox.clone(),
-                    work_dir,
+                    work_dirs,
                     self.llm_source.as_ref(),
                     Arc::clone(&self.catalog),
                 )
@@ -199,7 +198,7 @@ impl HookRunner {
         hooks: &[&HookDefinition],
         context: &HookContext,
         sandbox: Arc<dyn Sandbox>,
-        work_dir: Option<&Path>,
+        work_dirs: HookWorkDirs<'_>,
     ) -> HookDecision {
         for hook in hooks {
             tracing::debug!(
@@ -213,7 +212,7 @@ impl HookRunner {
                     hook,
                     context,
                     sandbox.clone(),
-                    work_dir,
+                    work_dirs,
                     self.llm_source.as_ref(),
                     Arc::clone(&self.catalog),
                 )
@@ -257,7 +256,7 @@ mod tests {
             definition: &HookDefinition,
             _context: &HookContext,
             _sandbox: Arc<dyn Sandbox>,
-            _work_dir: Option<&Path>,
+            _work_dirs: HookWorkDirs<'_>,
             _llm_source: &dyn CredentialSource,
             _catalog: Arc<Catalog>,
         ) -> HookResult {
@@ -305,7 +304,9 @@ mod tests {
         let runner = HookRunner::new(HookSettings::default(), test_llm_source(), test_catalog());
         let ctx = make_context(HookEvent::RunStart);
         let sandbox = make_sandbox();
-        let decision = runner.run(&ctx, sandbox.clone(), None).await;
+        let decision = runner
+            .run(&ctx, sandbox.clone(), HookWorkDirs::default())
+            .await;
         assert_eq!(decision, HookDecision::Proceed);
     }
 
@@ -415,7 +416,9 @@ mod tests {
         );
         let ctx = make_context(HookEvent::RunStart);
         let sandbox = make_sandbox();
-        let decision = runner.run(&ctx, sandbox.clone(), None).await;
+        let decision = runner
+            .run(&ctx, sandbox.clone(), HookWorkDirs::default())
+            .await;
         assert!(matches!(decision, HookDecision::Block { .. }));
     }
 
@@ -434,7 +437,9 @@ mod tests {
         );
         let ctx = make_context(HookEvent::StageStart);
         let sandbox = make_sandbox();
-        let decision = runner.run(&ctx, sandbox.clone(), None).await;
+        let decision = runner
+            .run(&ctx, sandbox.clone(), HookWorkDirs::default())
+            .await;
         assert!(matches!(decision, HookDecision::Skip { .. }));
     }
 
@@ -453,7 +458,9 @@ mod tests {
         );
         let ctx = make_context(HookEvent::StageComplete);
         let sandbox = make_sandbox();
-        let decision = runner.run(&ctx, sandbox.clone(), None).await;
+        let decision = runner
+            .run(&ctx, sandbox.clone(), HookWorkDirs::default())
+            .await;
         // Non-blocking hooks don't affect the decision
         assert_eq!(decision, HookDecision::Proceed);
     }
@@ -470,7 +477,9 @@ mod tests {
         let runner = HookRunner::new(config, test_llm_source(), test_catalog());
         let ctx = make_context(HookEvent::RunStart);
         let sandbox = make_sandbox();
-        let decision = runner.run(&ctx, sandbox.clone(), None).await;
+        let decision = runner
+            .run(&ctx, sandbox.clone(), HookWorkDirs::default())
+            .await;
         assert_eq!(decision, HookDecision::Proceed);
     }
 
@@ -486,7 +495,9 @@ mod tests {
         let runner = HookRunner::new(config, test_llm_source(), test_catalog());
         let ctx = make_context(HookEvent::RunStart);
         let sandbox = make_sandbox();
-        let decision = runner.run(&ctx, sandbox.clone(), None).await;
+        let decision = runner
+            .run(&ctx, sandbox.clone(), HookWorkDirs::default())
+            .await;
         assert!(matches!(decision, HookDecision::Block { .. }));
     }
 }

--- a/lib/crates/fabro-hooks/src/types.rs
+++ b/lib/crates/fabro-hooks/src/types.rs
@@ -1,8 +1,9 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use fabro_types::RunId;
 use serde::{Deserialize, Serialize};
 
+use crate::config::HookDefinition;
 pub use crate::config::HookEvent;
 
 /// Rich JSON payload sent to hooks.
@@ -118,13 +119,22 @@ impl HookDecision {
     }
 }
 
-/// Working directories available to hook execution.
-///
-/// Host hooks must only use `host`; sandbox hooks may use `sandbox`.
-#[derive(Clone, Copy, Debug, Default)]
-pub struct HookWorkDirs<'a> {
-    pub host:    Option<&'a Path>,
-    pub sandbox: Option<&'a Path>,
+/// Realm-specific locations available to hook execution.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct HookExecutionContext {
+    pub host_source_dir:  Option<PathBuf>,
+    pub sandbox_work_dir: Option<PathBuf>,
+}
+
+impl HookExecutionContext {
+    #[must_use]
+    pub fn command_cwd_for(&self, definition: &HookDefinition) -> Option<&Path> {
+        if definition.runs_in_sandbox() {
+            self.sandbox_work_dir.as_deref()
+        } else {
+            self.host_source_dir.as_deref()
+        }
+    }
 }
 
 /// Result from executing a single hook.
@@ -137,9 +147,24 @@ pub struct HookResult {
 
 #[cfg(test)]
 mod tests {
+    use std::path::{Path, PathBuf};
+
     use fabro_types::fixtures;
 
     use super::*;
+
+    fn command_hook(sandbox: bool) -> HookDefinition {
+        HookDefinition {
+            name:       Some("cwd-test".into()),
+            event:      HookEvent::RunStart,
+            command:    Some("pwd".into()),
+            hook_type:  None,
+            matcher:    None,
+            blocking:   None,
+            timeout_ms: None,
+            sandbox:    Some(sandbox),
+        }
+    }
 
     #[test]
     fn hook_context_serde_round_trip() {
@@ -177,6 +202,42 @@ mod tests {
         let json = serde_json::to_string(&ctx).unwrap();
         assert!(!json.contains("node_id"));
         assert!(!json.contains("failure_reason"));
+    }
+
+    #[test]
+    fn hook_execution_context_returns_host_source_dir_for_host_command() {
+        let context = HookExecutionContext {
+            host_source_dir:  Some(PathBuf::from("/host/project")),
+            sandbox_work_dir: Some(PathBuf::from("/workspace/project")),
+        };
+
+        assert_eq!(
+            context.command_cwd_for(&command_hook(false)),
+            Some(Path::new("/host/project"))
+        );
+    }
+
+    #[test]
+    fn hook_execution_context_returns_sandbox_work_dir_for_sandbox_command() {
+        let context = HookExecutionContext {
+            host_source_dir:  Some(PathBuf::from("/host/project")),
+            sandbox_work_dir: Some(PathBuf::from("/workspace/project")),
+        };
+
+        assert_eq!(
+            context.command_cwd_for(&command_hook(true)),
+            Some(Path::new("/workspace/project"))
+        );
+    }
+
+    #[test]
+    fn hook_execution_context_returns_none_when_matching_dir_is_missing() {
+        let context = HookExecutionContext {
+            host_source_dir:  Some(PathBuf::from("/host/project")),
+            sandbox_work_dir: None,
+        };
+
+        assert_eq!(context.command_cwd_for(&command_hook(true)), None);
     }
 
     #[test]

--- a/lib/crates/fabro-hooks/src/types.rs
+++ b/lib/crates/fabro-hooks/src/types.rs
@@ -1,3 +1,5 @@
+use std::path::Path;
+
 use fabro_types::RunId;
 use serde::{Deserialize, Serialize};
 
@@ -114,6 +116,15 @@ impl HookDecision {
     pub fn is_proceed(&self) -> bool {
         matches!(self, Self::Proceed)
     }
+}
+
+/// Working directories available to hook execution.
+///
+/// Host hooks must only use `host`; sandbox hooks may use `sandbox`.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct HookWorkDirs<'a> {
+    pub host:    Option<&'a Path>,
+    pub sandbox: Option<&'a Path>,
 }
 
 /// Result from executing a single hook.

--- a/lib/crates/fabro-hooks/tests/host_command_hooks.rs
+++ b/lib/crates/fabro-hooks/tests/host_command_hooks.rs
@@ -1,0 +1,80 @@
+use std::path::Path;
+use std::sync::Arc;
+
+use fabro_agent::{LocalSandbox, Sandbox};
+use fabro_auth::{CredentialSource, EnvCredentialSource};
+use fabro_hooks::{
+    HookContext, HookDecision, HookDefinition, HookEvent, HookRunner, HookSettings, HookWorkDirs,
+};
+use fabro_model::Catalog;
+use fabro_types::RunId;
+use tokio::fs;
+
+fn test_llm_source() -> Arc<dyn CredentialSource> {
+    Arc::new(EnvCredentialSource::new())
+}
+
+fn test_catalog() -> Arc<Catalog> {
+    Arc::new(Catalog::from_builtin().expect("default catalog should build"))
+}
+
+fn local_sandbox() -> Arc<dyn Sandbox> {
+    Arc::new(LocalSandbox::new(
+        std::env::current_dir().expect("test process should have a cwd"),
+    ))
+}
+
+#[tokio::test]
+async fn host_command_hook_uses_host_workdir_not_sandbox_workdir() {
+    let host_work_dir =
+        std::env::temp_dir().join(format!("fabro-host-hook-cwd-{}", std::process::id()));
+    let _ = fs::remove_dir_all(&host_work_dir).await;
+    fs::create_dir_all(&host_work_dir)
+        .await
+        .expect("test should create host hook cwd");
+    let container_only_work_dir = Path::new("/workspace/fabro-host-hook-repro-missing");
+    assert!(
+        !container_only_work_dir.exists(),
+        "reproduction requires a container-only cwd that does not exist on the host"
+    );
+
+    let runner = HookRunner::new(
+        HookSettings {
+            hooks: vec![HookDefinition {
+                name:       Some("host-marker".to_string()),
+                event:      HookEvent::RunStart,
+                command:    Some("printf ran > marker.txt".to_string()),
+                hook_type:  None,
+                matcher:    None,
+                blocking:   Some(true),
+                timeout_ms: Some(5000),
+                sandbox:    Some(false),
+            }],
+        },
+        test_llm_source(),
+        test_catalog(),
+    );
+    let context = HookContext::new(
+        HookEvent::RunStart,
+        RunId::new(),
+        "host-hook-cwd".to_string(),
+    );
+
+    let decision = runner
+        .run(&context, local_sandbox(), HookWorkDirs {
+            host:    Some(&host_work_dir),
+            sandbox: Some(container_only_work_dir),
+        })
+        .await;
+
+    assert_eq!(decision, HookDecision::Proceed);
+    assert_eq!(
+        fs::read_to_string(host_work_dir.join("marker.txt"))
+            .await
+            .expect("host hook should create marker file"),
+        "ran"
+    );
+    fs::remove_dir_all(&host_work_dir)
+        .await
+        .expect("test should clean up host hook cwd");
+}

--- a/lib/crates/fabro-hooks/tests/host_command_hooks.rs
+++ b/lib/crates/fabro-hooks/tests/host_command_hooks.rs
@@ -4,7 +4,8 @@ use std::sync::Arc;
 use fabro_agent::{LocalSandbox, Sandbox};
 use fabro_auth::{CredentialSource, EnvCredentialSource};
 use fabro_hooks::{
-    HookContext, HookDecision, HookDefinition, HookEvent, HookRunner, HookSettings, HookWorkDirs,
+    HookContext, HookDecision, HookDefinition, HookEvent, HookExecutionContext, HookRunner,
+    HookSettings,
 };
 use fabro_model::Catalog;
 use fabro_types::RunId;
@@ -61,9 +62,9 @@ async fn host_command_hook_uses_host_workdir_not_sandbox_workdir() {
     );
 
     let decision = runner
-        .run(&context, local_sandbox(), HookWorkDirs {
-            host:    Some(&host_work_dir),
-            sandbox: Some(container_only_work_dir),
+        .run(&context, local_sandbox(), HookExecutionContext {
+            host_source_dir:  Some(host_work_dir.clone()),
+            sandbox_work_dir: Some(container_only_work_dir.to_path_buf()),
         })
         .await;
 

--- a/lib/crates/fabro-workflow/src/handler/agent.rs
+++ b/lib/crates/fabro-workflow/src/handler/agent.rs
@@ -279,7 +279,7 @@ impl Handler for AgentHandler {
                     sandbox: Arc::clone(&services.run.sandbox),
                     run_id,
                     workflow_name: graph.name.clone(),
-                    host_work_dir: services.run.host_hook_work_dir.clone(),
+                    hook_execution_context: services.run.locations.hook_execution_context(),
                     node_id: node.id.clone(),
                 }) as Arc<dyn fabro_agent::ToolHookCallback>
             });

--- a/lib/crates/fabro-workflow/src/handler/agent.rs
+++ b/lib/crates/fabro-workflow/src/handler/agent.rs
@@ -279,7 +279,7 @@ impl Handler for AgentHandler {
                     sandbox: Arc::clone(&services.run.sandbox),
                     run_id,
                     workflow_name: graph.name.clone(),
-                    work_dir: None,
+                    host_work_dir: services.run.host_hook_work_dir.clone(),
                     node_id: node.id.clone(),
                 }) as Arc<dyn fabro_agent::ToolHookCallback>
             });

--- a/lib/crates/fabro-workflow/src/lifecycle/git.rs
+++ b/lib/crates/fabro-workflow/src/lifecycle/git.rs
@@ -1201,6 +1201,7 @@ mod tests {
                 repo_dir.path().to_path_buf(),
             )),
             None,
+            None,
             tokio_util::sync::CancellationToken::new(),
             fabro_model::ProviderId::anthropic(),
             "claude-sonnet-4-6".to_string(),

--- a/lib/crates/fabro-workflow/src/lifecycle/git.rs
+++ b/lib/crates/fabro-workflow/src/lifecycle/git.rs
@@ -1194,14 +1194,20 @@ mod tests {
             .on_checkpoint(&node, &result, Some("exit"), &checkpoint_state)
             .await
             .unwrap();
+        let finalize_sandbox: Arc<dyn fabro_agent::Sandbox> = Arc::new(
+            fabro_agent::LocalSandbox::new(repo_dir.path().to_path_buf()),
+        );
+        let finalize_locations = crate::services::RunLocations::for_sandbox(
+            None,
+            finalize_sandbox.as_ref(),
+            repo_dir.path().join(".fabro/run"),
+        );
         let finalize_services = RunServices::new(
             RunStoreHandle::new(Arc::new(FailingStateStore)),
             Arc::clone(&lifecycle.emitter),
-            Arc::new(fabro_agent::LocalSandbox::new(
-                repo_dir.path().to_path_buf(),
-            )),
+            finalize_sandbox,
             None,
-            None,
+            finalize_locations,
             tokio_util::sync::CancellationToken::new(),
             fabro_model::ProviderId::anthropic(),
             "claude-sonnet-4-6".to_string(),

--- a/lib/crates/fabro-workflow/src/lifecycle/hook.rs
+++ b/lib/crates/fabro-workflow/src/lifecycle/hook.rs
@@ -8,7 +8,7 @@ use fabro_core::lifecycle::{
 };
 use fabro_core::outcome::NodeResult;
 use fabro_core::state::ExecutionState;
-use fabro_hooks::{HookContext, HookDecision, HookEvent, HookRunner};
+use fabro_hooks::{HookContext, HookDecision, HookEvent, HookRunner, HookWorkDirs};
 use fabro_sandbox::Sandbox;
 use fabro_types::RunId;
 
@@ -22,11 +22,12 @@ type WfNodeDecision = NodeDecision<Option<BilledModelUsage>>;
 
 /// Sub-lifecycle responsible for running workflow hooks.
 pub(crate) struct HookLifecycle {
-    pub hook_runner:   Option<Arc<HookRunner>>,
-    pub sandbox:       Arc<dyn Sandbox>,
-    pub hook_work_dir: Option<PathBuf>,
-    pub run_id:        RunId,
-    pub graph_name:    String,
+    pub hook_runner:           Option<Arc<HookRunner>>,
+    pub sandbox:               Arc<dyn Sandbox>,
+    pub sandbox_hook_work_dir: Option<PathBuf>,
+    pub host_hook_work_dir:    Option<PathBuf>,
+    pub run_id:                RunId,
+    pub graph_name:            String,
 }
 
 impl HookLifecycle {
@@ -35,11 +36,10 @@ impl HookLifecycle {
             return HookDecision::Proceed;
         };
         runner
-            .run(
-                hook_ctx,
-                self.sandbox.clone(),
-                self.hook_work_dir.as_deref(),
-            )
+            .run(hook_ctx, self.sandbox.clone(), HookWorkDirs {
+                host:    self.host_hook_work_dir.as_deref(),
+                sandbox: self.sandbox_hook_work_dir.as_deref(),
+            })
             .await
     }
 }
@@ -65,7 +65,7 @@ impl RunLifecycle<WorkflowGraph> for HookLifecycle {
         let mut hook_ctx =
             HookContext::new(HookEvent::StageStart, self.run_id, self.graph_name.clone());
         hook_ctx.cwd = self
-            .hook_work_dir
+            .sandbox_hook_work_dir
             .as_ref()
             .map(|path| path.display().to_string());
         set_hook_node(&mut hook_ctx, gv);

--- a/lib/crates/fabro-workflow/src/lifecycle/hook.rs
+++ b/lib/crates/fabro-workflow/src/lifecycle/hook.rs
@@ -1,4 +1,3 @@
-use std::path::PathBuf;
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -8,7 +7,7 @@ use fabro_core::lifecycle::{
 };
 use fabro_core::outcome::NodeResult;
 use fabro_core::state::ExecutionState;
-use fabro_hooks::{HookContext, HookDecision, HookEvent, HookRunner, HookWorkDirs};
+use fabro_hooks::{HookContext, HookDecision, HookEvent, HookExecutionContext, HookRunner};
 use fabro_sandbox::Sandbox;
 use fabro_types::RunId;
 
@@ -22,12 +21,11 @@ type WfNodeDecision = NodeDecision<Option<BilledModelUsage>>;
 
 /// Sub-lifecycle responsible for running workflow hooks.
 pub(crate) struct HookLifecycle {
-    pub hook_runner:           Option<Arc<HookRunner>>,
-    pub sandbox:               Arc<dyn Sandbox>,
-    pub sandbox_hook_work_dir: Option<PathBuf>,
-    pub host_hook_work_dir:    Option<PathBuf>,
-    pub run_id:                RunId,
-    pub graph_name:            String,
+    pub hook_runner:            Option<Arc<HookRunner>>,
+    pub sandbox:                Arc<dyn Sandbox>,
+    pub hook_execution_context: HookExecutionContext,
+    pub run_id:                 RunId,
+    pub graph_name:             String,
 }
 
 impl HookLifecycle {
@@ -36,10 +34,11 @@ impl HookLifecycle {
             return HookDecision::Proceed;
         };
         runner
-            .run(hook_ctx, self.sandbox.clone(), HookWorkDirs {
-                host:    self.host_hook_work_dir.as_deref(),
-                sandbox: self.sandbox_hook_work_dir.as_deref(),
-            })
+            .run(
+                hook_ctx,
+                self.sandbox.clone(),
+                self.hook_execution_context.clone(),
+            )
             .await
     }
 }
@@ -65,7 +64,8 @@ impl RunLifecycle<WorkflowGraph> for HookLifecycle {
         let mut hook_ctx =
             HookContext::new(HookEvent::StageStart, self.run_id, self.graph_name.clone());
         hook_ctx.cwd = self
-            .sandbox_hook_work_dir
+            .hook_execution_context
+            .sandbox_work_dir
             .as_ref()
             .map(|path| path.display().to_string());
         set_hook_node(&mut hook_ctx, gv);

--- a/lib/crates/fabro-workflow/src/lifecycle/mod.rs
+++ b/lib/crates/fabro-workflow/src/lifecycle/mod.rs
@@ -7,7 +7,7 @@ pub(crate) mod git;
 pub(crate) mod hook;
 
 use std::collections::HashMap;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
@@ -43,6 +43,7 @@ use crate::run_metadata::{RunMetadataRuntime, RunMetadataWriterHandle};
 use crate::run_options::RunOptions;
 use crate::runtime_store::RunStoreHandle;
 use crate::sandbox_git_runtime::SandboxGitRuntime;
+use crate::services::RunLocations;
 
 type WfRunState = ExecutionState<Option<BilledModelUsage>>;
 type WfNodeResult = NodeResult<Option<BilledModelUsage>>;
@@ -72,7 +73,7 @@ pub(crate) struct WorkflowLifecycle {
     // Config needed for context seeding
     graph:                 Arc<GvGraph>,
     run_id:                RunId,
-    working_directory:     Option<String>,
+    sandbox_work_dir:      Option<String>,
 }
 
 impl WorkflowLifecycle {
@@ -88,7 +89,7 @@ impl WorkflowLifecycle {
         run_dir: &Path,
         run_store: &RunStoreHandle,
         artifact_sink: Option<ArtifactSink>,
-        host_hook_work_dir: Option<PathBuf>,
+        locations: &RunLocations,
         run_options: &Arc<RunOptions>,
         sandbox_git: Arc<SandboxGitRuntime>,
         metadata_runtime: Arc<RunMetadataRuntime>,
@@ -110,8 +111,11 @@ impl WorkflowLifecycle {
             .as_ref()
             .and_then(|g| g.run_branch.as_ref())
             .is_some();
-        let sandbox_working_directory = if has_run_branch {
-            Some(sandbox.working_directory().to_string())
+        let run_branch_sandbox_work_dir = if has_run_branch {
+            locations
+                .sandbox_work_dir
+                .as_ref()
+                .map(|path| path.display().to_string())
         } else {
             None
         };
@@ -125,7 +129,7 @@ impl WorkflowLifecycle {
             base_branch:           run_options.base_branch.clone(),
             base_sha:              run_options.git.as_ref().and_then(|g| g.base_sha.clone()),
             run_branch:            run_options.git.as_ref().and_then(|g| g.run_branch.clone()),
-            worktree_dir:          sandbox_working_directory.clone(),
+            worktree_dir:          run_branch_sandbox_work_dir.clone(),
             goal:                  (!graph.goal().is_empty()).then(|| graph.goal().to_string()),
             checkpoint_git_result: Arc::clone(&checkpoint_git_result),
             circuit_breaker:       Arc::clone(&circuit_breaker),
@@ -134,8 +138,7 @@ impl WorkflowLifecycle {
         let hook = HookLifecycle {
             hook_runner,
             sandbox: Arc::clone(sandbox),
-            sandbox_hook_work_dir: sandbox_working_directory.clone().map(PathBuf::from),
-            host_hook_work_dir,
+            hook_execution_context: locations.hook_execution_context(),
             run_id: run_options.run_id,
             graph_name: graph.name.clone(),
         };
@@ -188,7 +191,7 @@ impl WorkflowLifecycle {
             is_initial_resume: AtomicBool::new(is_resume),
             graph,
             run_id: run_options.run_id,
-            working_directory: sandbox_working_directory,
+            sandbox_work_dir: run_branch_sandbox_work_dir,
         }
     }
 
@@ -234,7 +237,7 @@ impl RunLifecycle<WorkflowGraph> for WorkflowLifecycle {
             context::keys::INTERNAL_RUN_ID,
             serde_json::json!(self.run_id),
         );
-        if let Some(ref wd) = self.working_directory {
+        if let Some(ref wd) = self.sandbox_work_dir {
             state
                 .context
                 .set(context::keys::INTERNAL_WORK_DIR, serde_json::json!(wd));

--- a/lib/crates/fabro-workflow/src/lifecycle/mod.rs
+++ b/lib/crates/fabro-workflow/src/lifecycle/mod.rs
@@ -88,6 +88,7 @@ impl WorkflowLifecycle {
         run_dir: &Path,
         run_store: &RunStoreHandle,
         artifact_sink: Option<ArtifactSink>,
+        host_hook_work_dir: Option<PathBuf>,
         run_options: &Arc<RunOptions>,
         sandbox_git: Arc<SandboxGitRuntime>,
         metadata_runtime: Arc<RunMetadataRuntime>,
@@ -109,7 +110,7 @@ impl WorkflowLifecycle {
             .as_ref()
             .and_then(|g| g.run_branch.as_ref())
             .is_some();
-        let working_directory = if has_run_branch {
+        let sandbox_working_directory = if has_run_branch {
             Some(sandbox.working_directory().to_string())
         } else {
             None
@@ -124,7 +125,7 @@ impl WorkflowLifecycle {
             base_branch:           run_options.base_branch.clone(),
             base_sha:              run_options.git.as_ref().and_then(|g| g.base_sha.clone()),
             run_branch:            run_options.git.as_ref().and_then(|g| g.run_branch.clone()),
-            worktree_dir:          working_directory.clone(),
+            worktree_dir:          sandbox_working_directory.clone(),
             goal:                  (!graph.goal().is_empty()).then(|| graph.goal().to_string()),
             checkpoint_git_result: Arc::clone(&checkpoint_git_result),
             circuit_breaker:       Arc::clone(&circuit_breaker),
@@ -133,7 +134,8 @@ impl WorkflowLifecycle {
         let hook = HookLifecycle {
             hook_runner,
             sandbox: Arc::clone(sandbox),
-            hook_work_dir: working_directory.clone().map(PathBuf::from),
+            sandbox_hook_work_dir: sandbox_working_directory.clone().map(PathBuf::from),
+            host_hook_work_dir,
             run_id: run_options.run_id,
             graph_name: graph.name.clone(),
         };
@@ -186,7 +188,7 @@ impl WorkflowLifecycle {
             is_initial_resume: AtomicBool::new(is_resume),
             graph,
             run_id: run_options.run_id,
-            working_directory,
+            working_directory: sandbox_working_directory,
         }
     }
 

--- a/lib/crates/fabro-workflow/src/pipeline/execute.rs
+++ b/lib/crates/fabro-workflow/src/pipeline/execute.rs
@@ -83,7 +83,7 @@ pub async fn execute(init: Initialized) -> Executed {
         &run_options.run_dir,
         &engine.run.run_store,
         artifact_sink,
-        engine.run.host_hook_work_dir.clone(),
+        &engine.run.locations,
         &settings_arc,
         Arc::clone(&engine.run.sandbox_git),
         Arc::clone(&engine.run.metadata_runtime),

--- a/lib/crates/fabro-workflow/src/pipeline/execute.rs
+++ b/lib/crates/fabro-workflow/src/pipeline/execute.rs
@@ -83,6 +83,7 @@ pub async fn execute(init: Initialized) -> Executed {
         &run_options.run_dir,
         &engine.run.run_store,
         artifact_sink,
+        engine.run.host_hook_work_dir.clone(),
         &settings_arc,
         Arc::clone(&engine.run.sandbox_git),
         Arc::clone(&engine.run.metadata_runtime),

--- a/lib/crates/fabro-workflow/src/pipeline/finalize.rs
+++ b/lib/crates/fabro-workflow/src/pipeline/finalize.rs
@@ -1024,6 +1024,7 @@ mod tests {
             emitter,
             sandbox,
             None,
+            None,
             tokio_util::sync::CancellationToken::new(),
             fabro_model::ProviderId::anthropic(),
             "claude-sonnet-4-6".to_string(),
@@ -1051,6 +1052,7 @@ mod tests {
             Arc::new(fabro_agent::LocalSandbox::new(
                 std::env::current_dir().unwrap(),
             )),
+            None,
             None,
             tokio_util::sync::CancellationToken::new(),
             fabro_model::ProviderId::anthropic(),

--- a/lib/crates/fabro-workflow/src/pipeline/finalize.rs
+++ b/lib/crates/fabro-workflow/src/pipeline/finalize.rs
@@ -1019,12 +1019,17 @@ mod tests {
         metadata_runtime: Arc<RunMetadataRuntime>,
         metadata_writer: Option<RunMetadataWriterHandle>,
     ) -> Arc<RunServices> {
+        let locations = crate::services::RunLocations::for_sandbox(
+            None,
+            sandbox.as_ref(),
+            Path::new(".").to_path_buf(),
+        );
         RunServices::new(
             run_store,
             emitter,
             sandbox,
             None,
-            None,
+            locations,
             tokio_util::sync::CancellationToken::new(),
             fabro_model::ProviderId::anthropic(),
             "claude-sonnet-4-6".to_string(),
@@ -1046,14 +1051,17 @@ mod tests {
         let emitter = Arc::new(Emitter::new(test_run_id()));
         let store_logger = StoreProgressLogger::new(run_store.clone());
         store_logger.register(&emitter);
+        let sandbox: Arc<dyn fabro_agent::Sandbox> = Arc::new(fabro_agent::LocalSandbox::new(
+            std::env::current_dir().unwrap(),
+        ));
+        let locations =
+            crate::services::RunLocations::for_sandbox(None, sandbox.as_ref(), run_dir.clone());
         let services = RunServices::new(
             run_store.clone().into(),
             Arc::clone(&emitter),
-            Arc::new(fabro_agent::LocalSandbox::new(
-                std::env::current_dir().unwrap(),
-            )),
+            sandbox,
             None,
-            None,
+            locations,
             tokio_util::sync::CancellationToken::new(),
             fabro_model::ProviderId::anthropic(),
             "claude-sonnet-4-6".to_string(),

--- a/lib/crates/fabro-workflow/src/pipeline/initialize.rs
+++ b/lib/crates/fabro-workflow/src/pipeline/initialize.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -8,7 +8,7 @@ use fabro_auth::{
     CredentialSource, EnvCredentialSource, VaultCredentialSource, auth_issue_message,
 };
 use fabro_graphviz::graph;
-use fabro_hooks::{HookContext, HookDecision, HookEvent, HookRunner};
+use fabro_hooks::{HookContext, HookDecision, HookEvent, HookRunner, HookWorkDirs};
 use fabro_model::Catalog;
 use fabro_sandbox::{
     GitSetupIntent, ReadBeforeWriteSandbox, SandboxEventCallback, SandboxSpec,
@@ -42,12 +42,12 @@ async fn run_hooks(
     hook_runner: Option<&HookRunner>,
     hook_context: &HookContext,
     sandbox: Arc<dyn Sandbox>,
-    work_dir: Option<&Path>,
+    work_dirs: HookWorkDirs<'_>,
 ) -> HookDecision {
     let Some(runner) = hook_runner else {
         return HookDecision::Proceed;
     };
-    runner.run(hook_context, sandbox, work_dir).await
+    runner.run(hook_context, sandbox, work_dirs).await
 }
 
 fn git_setup_intent(run_options: &RunOptions) -> GitSetupIntent {
@@ -325,7 +325,8 @@ pub async fn initialize(
     persisted: Persisted,
     mut options: InitOptions,
 ) -> Result<Initialized, Error> {
-    let (graph, source, _diagnostics, run_dir, _run_spec) = persisted.into_parts();
+    let (graph, source, _diagnostics, run_dir, run_spec) = persisted.into_parts();
+    let host_hook_work_dir = run_spec.source_directory.as_deref().map(PathBuf::from);
     options.run_options.run_dir = run_dir.clone();
     options.run_options.git = options.git.clone();
 
@@ -444,7 +445,10 @@ pub async fn initialize(
         hook_runner.as_deref(),
         &hook_ctx,
         Arc::clone(&sandbox),
-        None,
+        HookWorkDirs {
+            host:    host_hook_work_dir.as_deref(),
+            sandbox: Some(Path::new(sandbox.working_directory())),
+        },
     )
     .await;
     if let HookDecision::Block { reason } = decision {
@@ -650,6 +654,7 @@ pub async fn initialize(
         Arc::clone(&options.emitter),
         Arc::clone(&sandbox),
         hook_runner.clone(),
+        host_hook_work_dir,
         options.run_options.cancel_token.clone(),
         options.llm.provider_id.clone(),
         options.llm.model.clone(),

--- a/lib/crates/fabro-workflow/src/pipeline/initialize.rs
+++ b/lib/crates/fabro-workflow/src/pipeline/initialize.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -8,7 +8,7 @@ use fabro_auth::{
     CredentialSource, EnvCredentialSource, VaultCredentialSource, auth_issue_message,
 };
 use fabro_graphviz::graph;
-use fabro_hooks::{HookContext, HookDecision, HookEvent, HookRunner, HookWorkDirs};
+use fabro_hooks::{HookContext, HookDecision, HookEvent, HookExecutionContext, HookRunner};
 use fabro_model::Catalog;
 use fabro_sandbox::{
     GitSetupIntent, ReadBeforeWriteSandbox, SandboxEventCallback, SandboxSpec,
@@ -33,7 +33,7 @@ use crate::handler::{HandlerRegistry, default_registry};
 use crate::run_metadata::{RunMetadataRuntime, build_metadata_writer, metadata_branch_name};
 use crate::run_options::{GitCheckpointOptions, RunOptions};
 use crate::sandbox_git_runtime::SandboxGitRuntime;
-use crate::services::{EngineServices, RunServices, WorkflowToolEnvProvider};
+use crate::services::{EngineServices, RunLocations, RunServices, WorkflowToolEnvProvider};
 use crate::steering_hub::SteeringHub;
 
 type BuiltSandboxEnv = (HashMap<String, String>, Option<Arc<GitHubTokenSource>>);
@@ -42,12 +42,12 @@ async fn run_hooks(
     hook_runner: Option<&HookRunner>,
     hook_context: &HookContext,
     sandbox: Arc<dyn Sandbox>,
-    work_dirs: HookWorkDirs<'_>,
+    execution_context: HookExecutionContext,
 ) -> HookDecision {
     let Some(runner) = hook_runner else {
         return HookDecision::Proceed;
     };
-    runner.run(hook_context, sandbox, work_dirs).await
+    runner.run(hook_context, sandbox, execution_context).await
 }
 
 fn git_setup_intent(run_options: &RunOptions) -> GitSetupIntent {
@@ -326,7 +326,7 @@ pub async fn initialize(
     mut options: InitOptions,
 ) -> Result<Initialized, Error> {
     let (graph, source, _diagnostics, run_dir, run_spec) = persisted.into_parts();
-    let host_hook_work_dir = run_spec.source_directory.as_deref().map(PathBuf::from);
+    let host_source_dir = run_spec.source_directory.as_deref().map(PathBuf::from);
     options.run_options.run_dir = run_dir.clone();
     options.run_options.git = options.git.clone();
 
@@ -436,6 +436,8 @@ pub async fn initialize(
             .map_err(|e| Error::engine_with_source("Failed to initialize sandbox", e))?;
     }
 
+    let locations = RunLocations::for_sandbox(host_source_dir, sandbox.as_ref(), run_dir.clone());
+
     let hook_ctx = HookContext::new(
         HookEvent::SandboxReady,
         options.run_options.run_id,
@@ -445,10 +447,7 @@ pub async fn initialize(
         hook_runner.as_deref(),
         &hook_ctx,
         Arc::clone(&sandbox),
-        HookWorkDirs {
-            host:    host_hook_work_dir.as_deref(),
-            sandbox: Some(Path::new(sandbox.working_directory())),
-        },
+        locations.hook_execution_context(),
     )
     .await;
     if let HookDecision::Block { reason } = decision {
@@ -654,7 +653,7 @@ pub async fn initialize(
         Arc::clone(&options.emitter),
         Arc::clone(&sandbox),
         hook_runner.clone(),
-        host_hook_work_dir,
+        locations,
         options.run_options.cancel_token.clone(),
         options.llm.provider_id.clone(),
         options.llm.model.clone(),
@@ -967,6 +966,18 @@ mod tests {
         assert_eq!(initialized.run_options.run_dir, run_dir);
         assert_eq!(initialized.source, source);
         assert!(initialized.engine.run.hook_runner.is_none());
+        assert_eq!(
+            initialized.engine.run.locations.host_source_dir.as_deref(),
+            Some(std::env::current_dir().unwrap().as_path())
+        );
+        assert_eq!(
+            initialized.engine.run.locations.sandbox_work_dir.as_deref(),
+            Some(std::env::current_dir().unwrap().as_path())
+        );
+        assert_eq!(
+            initialized.engine.run.locations.run_scratch_dir.as_path(),
+            run_dir.as_path()
+        );
         assert_eq!(
             initialized
                 .engine

--- a/lib/crates/fabro-workflow/src/services.rs
+++ b/lib/crates/fabro-workflow/src/services.rs
@@ -1,6 +1,5 @@
 use std::collections::HashMap;
-#[cfg(test)]
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 #[cfg(test)]
 use std::time::Duration;
@@ -9,7 +8,7 @@ use fabro_agent::{Sandbox, ToolEnvProvider};
 use fabro_auth::CredentialSource;
 #[cfg(test)]
 use fabro_auth::ResolvedCredentials;
-use fabro_hooks::{HookContext, HookDecision, HookRunner};
+use fabro_hooks::{HookContext, HookDecision, HookRunner, HookWorkDirs};
 use fabro_model::{Catalog, ProviderId};
 use fabro_types::ManifestPath;
 use tokio_util::sync::CancellationToken;
@@ -37,6 +36,7 @@ pub struct RunServices {
     pub emitter:                 Arc<Emitter>,
     pub sandbox:                 Arc<dyn Sandbox>,
     pub hook_runner:             Option<Arc<HookRunner>>,
+    pub host_hook_work_dir:      Option<PathBuf>,
     pub(crate) cancel_token:     CancellationToken,
     pub provider_id:             ProviderId,
     pub model:                   String,
@@ -54,6 +54,7 @@ impl RunServices {
         emitter: Arc<Emitter>,
         sandbox: Arc<dyn Sandbox>,
         hook_runner: Option<Arc<HookRunner>>,
+        host_hook_work_dir: Option<PathBuf>,
         cancel_token: CancellationToken,
         provider_id: ProviderId,
         model: String,
@@ -68,6 +69,7 @@ impl RunServices {
             emitter,
             sandbox,
             hook_runner,
+            host_hook_work_dir,
             cancel_token,
             provider_id,
             model,
@@ -92,8 +94,12 @@ impl RunServices {
         let Some(ref runner) = self.hook_runner else {
             return HookDecision::Proceed;
         };
+        let sandbox_work_dir = Path::new(self.sandbox.working_directory());
         runner
-            .run(hook_context, Arc::clone(&self.sandbox), None)
+            .run(hook_context, Arc::clone(&self.sandbox), HookWorkDirs {
+                host:    self.host_hook_work_dir.as_deref(),
+                sandbox: Some(sandbox_work_dir),
+            })
             .await
     }
 
@@ -247,6 +253,7 @@ impl EngineServices {
                 Arc::new(fabro_agent::LocalSandbox::new(
                     std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")),
                 )),
+                None,
                 None,
                 CancellationToken::new(),
                 ProviderId::anthropic(),

--- a/lib/crates/fabro-workflow/src/services.rs
+++ b/lib/crates/fabro-workflow/src/services.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::sync::Arc;
 #[cfg(test)]
 use std::time::Duration;
@@ -8,7 +8,7 @@ use fabro_agent::{Sandbox, ToolEnvProvider};
 use fabro_auth::CredentialSource;
 #[cfg(test)]
 use fabro_auth::ResolvedCredentials;
-use fabro_hooks::{HookContext, HookDecision, HookRunner, HookWorkDirs};
+use fabro_hooks::{HookContext, HookDecision, HookExecutionContext, HookRunner};
 use fabro_model::{Catalog, ProviderId};
 use fabro_types::ManifestPath;
 use tokio_util::sync::CancellationToken;
@@ -21,6 +21,57 @@ use crate::runtime_store::RunStoreHandle;
 use crate::sandbox_git::GitState;
 use crate::sandbox_git_runtime::SandboxGitRuntime;
 use crate::workflow_bundle::WorkflowBundle;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RunLocations {
+    pub host_source_dir:  Option<PathBuf>,
+    pub sandbox_work_dir: Option<PathBuf>,
+    pub run_scratch_dir:  PathBuf,
+}
+
+impl RunLocations {
+    #[must_use]
+    pub fn new(
+        host_source_dir: Option<PathBuf>,
+        sandbox_work_dir: Option<PathBuf>,
+        run_scratch_dir: PathBuf,
+    ) -> Self {
+        Self {
+            host_source_dir,
+            sandbox_work_dir,
+            run_scratch_dir,
+        }
+    }
+
+    #[must_use]
+    pub fn for_sandbox(
+        host_source_dir: Option<PathBuf>,
+        sandbox: &dyn Sandbox,
+        run_scratch_dir: PathBuf,
+    ) -> Self {
+        Self::new(
+            host_source_dir,
+            Some(PathBuf::from(sandbox.working_directory())),
+            run_scratch_dir,
+        )
+    }
+
+    #[must_use]
+    pub fn hook_execution_context(&self) -> HookExecutionContext {
+        HookExecutionContext {
+            host_source_dir:  self.host_source_dir.clone(),
+            sandbox_work_dir: self.sandbox_work_dir.clone(),
+        }
+    }
+
+    #[must_use]
+    pub fn with_sandbox_work_dir(&self, sandbox_work_dir: Option<PathBuf>) -> Self {
+        Self {
+            sandbox_work_dir,
+            ..self.clone()
+        }
+    }
+}
 
 /// Services shared across workflow phases.
 ///
@@ -36,7 +87,7 @@ pub struct RunServices {
     pub emitter:                 Arc<Emitter>,
     pub sandbox:                 Arc<dyn Sandbox>,
     pub hook_runner:             Option<Arc<HookRunner>>,
-    pub host_hook_work_dir:      Option<PathBuf>,
+    pub locations:               RunLocations,
     pub(crate) cancel_token:     CancellationToken,
     pub provider_id:             ProviderId,
     pub model:                   String,
@@ -54,7 +105,7 @@ impl RunServices {
         emitter: Arc<Emitter>,
         sandbox: Arc<dyn Sandbox>,
         hook_runner: Option<Arc<HookRunner>>,
-        host_hook_work_dir: Option<PathBuf>,
+        locations: RunLocations,
         cancel_token: CancellationToken,
         provider_id: ProviderId,
         model: String,
@@ -69,7 +120,7 @@ impl RunServices {
             emitter,
             sandbox,
             hook_runner,
-            host_hook_work_dir,
+            locations,
             cancel_token,
             provider_id,
             model,
@@ -94,12 +145,12 @@ impl RunServices {
         let Some(ref runner) = self.hook_runner else {
             return HookDecision::Proceed;
         };
-        let sandbox_work_dir = Path::new(self.sandbox.working_directory());
         runner
-            .run(hook_context, Arc::clone(&self.sandbox), HookWorkDirs {
-                host:    self.host_hook_work_dir.as_deref(),
-                sandbox: Some(sandbox_work_dir),
-            })
+            .run(
+                hook_context,
+                Arc::clone(&self.sandbox),
+                self.locations.hook_execution_context(),
+            )
             .await
     }
 
@@ -121,8 +172,12 @@ impl RunServices {
 
     #[must_use]
     pub fn with_sandbox(self: &Arc<Self>, sandbox: Arc<dyn Sandbox>) -> Arc<Self> {
+        let locations = self
+            .locations
+            .with_sandbox_work_dir(Some(PathBuf::from(sandbox.working_directory())));
         Arc::new(Self {
             sandbox,
+            locations,
             ..self.as_ref().clone()
         })
     }
@@ -245,16 +300,18 @@ impl EngineServices {
         })
         .join()
         .expect("test run store thread should join");
+        let sandbox: Arc<dyn Sandbox> = Arc::new(fabro_agent::LocalSandbox::new(
+            std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")),
+        ));
+        let locations = RunLocations::for_sandbox(None, sandbox.as_ref(), PathBuf::from("."));
 
         Self {
             run:             RunServices::new(
                 run_store.into(),
                 Arc::new(Emitter::default()),
-                Arc::new(fabro_agent::LocalSandbox::new(
-                    std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")),
-                )),
+                sandbox,
                 None,
-                None,
+                locations,
                 CancellationToken::new(),
                 ProviderId::anthropic(),
                 "claude-sonnet-4-6".to_string(),

--- a/lib/crates/fabro-workflow/src/test_support.rs
+++ b/lib/crates/fabro-workflow/src/test_support.rs
@@ -161,6 +161,7 @@ async fn initialized(
                     emitter,
                     sandbox,
                     options.hook_runner,
+                    None,
                     run_options.cancel_token.clone(),
                     fabro_model::ProviderId::anthropic(),
                     "claude-sonnet-4-6".to_string(),

--- a/lib/crates/fabro-workflow/src/test_support.rs
+++ b/lib/crates/fabro-workflow/src/test_support.rs
@@ -23,7 +23,7 @@ use crate::records::Checkpoint;
 use crate::run_metadata::RunMetadataRuntime;
 use crate::run_options::RunOptions;
 use crate::sandbox_git_runtime::SandboxGitRuntime;
-use crate::services::{EngineServices, RunServices};
+use crate::services::{EngineServices, RunLocations, RunServices};
 
 /// These helpers stop at EXECUTE, so they emit the terminal event here to
 /// keep test consumers seeing the same end-of-run signal as production
@@ -145,6 +145,7 @@ async fn initialized(
         ),
         "artifacts",
     );
+    let locations = RunLocations::for_sandbox(None, sandbox.as_ref(), run_options.run_dir.clone());
     InitializedState {
         initialized: Initialized {
             graph:         graph.clone(),
@@ -161,7 +162,7 @@ async fn initialized(
                     emitter,
                     sandbox,
                     options.hook_runner,
-                    None,
+                    locations,
                     run_options.cancel_token.clone(),
                     fabro_model::ProviderId::anthropic(),
                     "claude-sonnet-4-6".to_string(),


### PR DESCRIPTION
## Summary
- Fix host command hooks to use the submitter/source directory instead of a sandbox-only working directory.
- Introduce `HookExecutionContext` and `RunLocations` so host source, sandbox work, and run scratch paths are explicit.
- Route lifecycle hooks and tool hooks through the shared hook execution context instead of rebuilding cwd pairs at call sites.

## Test Plan
- `cargo nextest run -p fabro-hooks`
- `cargo check -p fabro-workflow --tests`
- `cargo +nightly-2026-04-14 fmt --package fabro-hooks --package fabro-workflow --check`
- `cargo +nightly-2026-04-14 clippy -p fabro-hooks -p fabro-workflow --all-targets -- -D warnings`