### PR TITLE
fix(workflow): capture configured artifacts once

### DIFF
--- a/lib/crates/fabro-acp/src/test_support.rs
+++ b/lib/crates/fabro-acp/src/test_support.rs
@@ -107,8 +107,15 @@ for line in sys.stdin:
             print("early boom", file=sys.stderr, flush=True)
             sys.exit(2)
         if mode == "write_file":
-            with open("hello.txt", "w", encoding="utf-8") as file:
-                file.write("hello from sandbox\n")
+            path = os.environ.get("ACP_WRITE_PATH", "hello.txt")
+            parent = os.path.dirname(path)
+            if parent:
+                os.makedirs(parent, exist_ok=True)
+            with open(path, "w", encoding="utf-8") as file:
+                file.write(os.environ.get("ACP_WRITE_CONTENT", "hello from sandbox\n"))
+            if os.environ.get("ACP_WRITE_MTIME_EPOCH"):
+                mtime = float(os.environ["ACP_WRITE_MTIME_EPOCH"])
+                os.utime(path, (mtime, mtime))
         if mode == "cancel":
             send({
                 "jsonrpc": "2.0",

--- a/lib/crates/fabro-cli/tests/it/workflow/acp.rs
+++ b/lib/crates/fabro-cli/tests/it/workflow/acp.rs
@@ -9,7 +9,8 @@ use fabro_test::test_context;
 use fabro_types::EventBody;
 use fabro_vault::{SecretType, Vault};
 
-use super::{find_run_dir, has_event, read_conclusion, run_events, run_state};
+use super::{find_run_dir, has_event, read_conclusion, run_events, run_id_for, run_state};
+use crate::cmd::support::output_stdout;
 
 #[test]
 fn acp_backend_workflow() {
@@ -133,6 +134,125 @@ fn acp_backend_does_not_inject_registered_provider_credentials() {
     )
     .expect("fake ACP environment record should be valid JSON");
     assert_eq!(recorded_env, serde_json::json!({}));
+}
+
+#[test]
+fn acp_artifacts_are_listed_when_touched_file_mtime_precedes_attempt_start() {
+    let mut context = test_context!();
+    context.write_home(
+        ".fabro/settings.toml",
+        "[server.auth]\nmethods = [\"dev-token\"]\n",
+    );
+    context.isolated_server();
+    let fake_agent = write_fake_acp_agent(&context);
+    let acp_config = fake_acp_config_attr_with_env(&fake_agent, vec![
+        serde_json::json!({
+            "name": "ACP_WRITE_PATH",
+            "value": "verification-artifacts/report.md",
+        }),
+        serde_json::json!({
+            "name": "ACP_WRITE_CONTENT",
+            "value": "verified\n",
+        }),
+        serde_json::json!({
+            "name": "ACP_WRITE_MTIME_EPOCH",
+            "value": "946684800",
+        }),
+    ]);
+    context.write_temp(
+        "acp_artifact_collection.fabro",
+        format!(
+            r#"digraph ACPArtifacts {{
+  graph [goal="Capture verification artifacts"]
+  start [shape=Mdiamond]
+  verify [type="agent", backend="acp", prompt="write verification artifact", acp.config={acp_config}]
+  exit [shape=Msquare]
+  start -> verify
+  verify -> exit
+}}"#
+        ),
+    );
+    context.write_temp(
+        "run.toml",
+        r#"_version = 1
+
+[workflow]
+graph = "acp_artifact_collection.fabro"
+
+[run]
+goal = "Capture verification artifacts"
+
+[run.checkpoint]
+exclude_globs = ["verification-artifacts/**"]
+
+[run.artifacts]
+include = ["verification-artifacts/**"]
+"#,
+    );
+    init_git_repo(&context.temp_dir);
+
+    context
+        .run_cmd()
+        .args(["--auto-approve", "--sandbox", "local"])
+        .arg(context.temp_dir.join("run.toml"))
+        .assert()
+        .success();
+
+    let run_dir = find_run_dir(&context);
+    let run_id = run_id_for(&run_dir);
+    let events = run_events(&run_dir);
+    let completed = events
+        .iter()
+        .find_map(|event| match &event.event.body {
+            EventBody::StageCompleted(props)
+                if event.event.node_id.as_deref() == Some("verify") =>
+            {
+                Some(props)
+            }
+            _ => None,
+        })
+        .expect("verify stage should complete");
+    assert!(
+        completed
+            .files_touched
+            .iter()
+            .any(|file| file == "verification-artifacts/report.md"),
+        "files_touched should include the artifact path: {:?}",
+        completed.files_touched
+    );
+
+    let output = context
+        .command()
+        .args(["--json", "artifact", "list", &run_id])
+        .output()
+        .expect("artifact list should execute");
+    assert!(
+        output.status.success(),
+        "artifact list failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let artifacts: Vec<serde_json::Value> =
+        serde_json::from_str(&output_stdout(&output)).expect("artifact list JSON should parse");
+    assert!(
+        artifacts.iter().any(|artifact| {
+            artifact["node_slug"] == "verify"
+                && artifact["relative_path"] == "verification-artifacts/report.md"
+        }),
+        "artifact list should include the touched verification artifact: {artifacts:?}"
+    );
+
+    let completed_run = events
+        .iter()
+        .find_map(|event| match &event.event.body {
+            EventBody::RunCompleted(props) => Some(props),
+            _ => None,
+        })
+        .expect("run.completed should be emitted");
+    assert!(
+        completed_run.artifact_count > 0,
+        "run.completed should report captured artifacts"
+    );
 }
 
 fn write_fake_acp_agent(context: &fabro_test::TestContext) -> std::path::PathBuf {

--- a/lib/crates/fabro-cli/tests/it/workflow/artifacts.rs
+++ b/lib/crates/fabro-cli/tests/it/workflow/artifacts.rs
@@ -1,0 +1,109 @@
+#![expect(
+    clippy::disallowed_methods,
+    reason = "integration test initializes an isolated git repository with the system git binary"
+)]
+
+use fabro_test::test_context;
+
+use super::{find_run_dir, run_id_for};
+use crate::cmd::support::output_stdout;
+
+#[test]
+fn unchanged_matching_artifact_is_captured_once_across_stages() {
+    let mut context = test_context!();
+    context.write_home(
+        ".fabro/settings.toml",
+        "[server.auth]\nmethods = [\"dev-token\"]\n",
+    );
+    context.isolated_server();
+    context.write_temp(
+        "artifact_dedupe.fabro",
+        r#"digraph ArtifactDedupe {
+  graph [goal="Deduplicate unchanged artifacts"]
+  start [shape=Mdiamond]
+  create [shape=parallelogram, script="mkdir -p assets && printf unchanged > assets/report.txt"]
+  inspect [shape=parallelogram, script="test -f assets/report.txt"]
+  exit [shape=Msquare]
+  start -> create -> inspect -> exit
+}
+"#,
+    );
+    context.write_temp(
+        "run.toml",
+        r#"_version = 1
+
+[workflow]
+graph = "artifact_dedupe.fabro"
+
+[run]
+goal = "Deduplicate unchanged artifacts"
+
+[run.checkpoint]
+exclude_globs = ["assets/**"]
+
+[run.artifacts]
+include = ["assets/**"]
+"#,
+    );
+    init_git_repo(&context.temp_dir);
+
+    context
+        .run_cmd()
+        .args(["--auto-approve", "--sandbox", "local"])
+        .arg(context.temp_dir.join("run.toml"))
+        .assert()
+        .success();
+
+    let run_dir = find_run_dir(&context);
+    let run_id = run_id_for(&run_dir);
+    let output = context
+        .command()
+        .args(["--json", "artifact", "list", &run_id])
+        .output()
+        .expect("artifact list should execute");
+    assert!(
+        output.status.success(),
+        "artifact list failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let artifacts: Vec<serde_json::Value> =
+        serde_json::from_str(&output_stdout(&output)).expect("artifact list JSON should parse");
+    let report_entries = artifacts
+        .iter()
+        .filter(|artifact| artifact["relative_path"] == "assets/report.txt")
+        .count();
+
+    assert_eq!(
+        report_entries, 1,
+        "unchanged artifact should be captured once: {artifacts:?}"
+    );
+}
+
+fn init_git_repo(dir: &std::path::Path) {
+    std::process::Command::new("git")
+        .arg("init")
+        .current_dir(dir)
+        .output()
+        .expect("git init should run");
+    std::process::Command::new("git")
+        .args(["config", "user.name", "Test User"])
+        .current_dir(dir)
+        .output()
+        .expect("git config user.name should run");
+    std::process::Command::new("git")
+        .args(["config", "user.email", "test@example.com"])
+        .current_dir(dir)
+        .output()
+        .expect("git config user.email should run");
+    std::process::Command::new("git")
+        .args(["add", "."])
+        .current_dir(dir)
+        .output()
+        .expect("git add should run");
+    std::process::Command::new("git")
+        .args(["commit", "-m", "initial"])
+        .current_dir(dir)
+        .output()
+        .expect("git commit should run");
+}

--- a/lib/crates/fabro-cli/tests/it/workflow/mod.rs
+++ b/lib/crates/fabro-cli/tests/it/workflow/mod.rs
@@ -5,6 +5,7 @@
 
 mod acp;
 mod agent_linear;
+mod artifacts;
 mod command_agent_mixed;
 mod command_pipeline;
 mod conditional_branching;

--- a/lib/crates/fabro-workflow/src/artifact_snapshot.rs
+++ b/lib/crates/fabro-workflow/src/artifact_snapshot.rs
@@ -175,19 +175,14 @@ fn parse_find_output_darwin(output: &str) -> Vec<DiscoveredFile> {
     files
 }
 
-/// Select which files should be collected based on timing and size budgets.
+/// Select which files should be collected based on size budgets.
 pub fn select_files_to_collect(
     discovered: &[DiscoveredFile],
-    command_start_epoch: f64,
+    _command_start_epoch: f64,
 ) -> Vec<DiscoveredFile> {
     let mut candidates: Vec<DiscoveredFile> = discovered
         .iter()
         .filter(|f| {
-            // Skip files older than command start
-            if f.mtime_epoch_secs < command_start_epoch {
-                return false;
-            }
-
             // Skip oversized files
             if f.size > MAX_FILE_SIZE {
                 return false;
@@ -287,6 +282,19 @@ pub async fn collect_artifacts(
         .exec_command(&cmd, FIND_TIMEOUT_MS, None, None, None)
         .await
         .map_err(|e| e.display_with_causes())?;
+    if !result.is_success() {
+        let stderr = result.stderr.trim();
+        let status = format!(
+            "exit code {}, termination {}",
+            result.display_exit_code(),
+            result.termination.as_str()
+        );
+        return if stderr.is_empty() {
+            Err(format!("find command failed ({status})"))
+        } else {
+            Err(format!("find command failed ({status}): {stderr}"))
+        };
+    }
 
     let discovered = parse_find_output(&result.stdout, platform);
     let discovered = normalize_paths(discovered, root);
@@ -377,6 +385,11 @@ mod tests {
                 working_dir: "/home/test",
                 platform_str: platform,
             }
+        }
+
+        fn with_exec_result(mut self, exec_result: ExecResult) -> Self {
+            self.exec_result = exec_result;
+            self
         }
     }
 
@@ -500,14 +513,15 @@ mod tests {
     }
 
     #[test]
-    fn select_files_skips_old_mtime() {
+    fn select_files_collects_old_mtime() {
         let discovered = vec![DiscoveredFile {
             relative_path:    "test-results/old.xml".to_string(),
             size:             1024,
             mtime_epoch_secs: 500.0,
         }];
         let selected = select_files_to_collect(&discovered, 1000.0);
-        assert_eq!(selected.len(), 0);
+        assert_eq!(selected.len(), 1);
+        assert_eq!(selected[0].relative_path, "test-results/old.xml");
     }
 
     #[test]
@@ -674,7 +688,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn collect_assets_skips_old_files() {
+    async fn collect_assets_collects_old_mtime_files() {
         let stage_dir = tempfile::tempdir().unwrap();
 
         let mut files = HashMap::new();
@@ -688,7 +702,29 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(summary.files_copied, 0);
+        assert_eq!(summary.files_copied, 1);
+        assert_eq!(summary.captured_assets[0].path, "test-results/r.xml");
+    }
+
+    #[tokio::test]
+    async fn collect_assets_returns_error_when_find_fails() {
+        let stage_dir = tempfile::tempdir().unwrap();
+        let mock =
+            AssetMockSandbox::new(HashMap::new(), "", "linux").with_exec_result(ExecResult {
+                stdout:      String::new(),
+                stderr:      "find: /workspace: Permission denied\n".to_string(),
+                exit_code:   Some(1),
+                termination: CommandTermination::Exited,
+                duration_ms: 10,
+            });
+
+        let globs = vec!["test-results/**".to_string()];
+        let error = collect_artifacts(&mock, stage_dir.path(), &globs, 1000.0)
+            .await
+            .expect_err("nonzero find exit should fail artifact collection");
+
+        assert!(error.contains("find command failed"), "{error}");
+        assert!(error.contains("Permission denied"), "{error}");
     }
 
     #[tokio::test]

--- a/lib/crates/fabro-workflow/src/lifecycle/artifact.rs
+++ b/lib/crates/fabro-workflow/src/lifecycle/artifact.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -9,7 +10,7 @@ use fabro_core::lifecycle::{AttemptContext, AttemptResultContext, NodeDecision, 
 use fabro_core::outcome::NodeResult;
 use fabro_core::state::ExecutionState;
 use fabro_store::{ArtifactKey, ArtifactStore};
-use fabro_types::{ArtifactUpload, RunId, StageId};
+use fabro_types::{ArtifactUpload, EventBody, RunId, StageId};
 use tokio::fs;
 use tokio::time::sleep;
 
@@ -25,6 +26,7 @@ use crate::runtime_store::RunStoreHandle;
 type WfRunState = ExecutionState<Option<BilledModelUsage>>;
 type WfNodeResult = NodeResult<Option<BilledModelUsage>>;
 type WfNodeDecision = NodeDecision<Option<BilledModelUsage>>;
+type ArtifactIdentity = (String, String);
 
 const ARTIFACT_UPLOAD_RETRY_DELAYS: [Duration; 3] = [
     Duration::from_millis(100),
@@ -42,6 +44,7 @@ pub(crate) struct ArtifactLifecycle {
     pub artifact_sink:   Option<ArtifactSink>,
     /// Per-attempt state: epoch seconds when the attempt started.
     attempt_start_epoch: std::sync::Mutex<Option<f64>>,
+    captured_artifacts:  std::sync::Mutex<HashSet<ArtifactIdentity>>,
 }
 
 impl ArtifactLifecycle {
@@ -61,6 +64,7 @@ impl ArtifactLifecycle {
             artifact_globs,
             artifact_sink,
             attempt_start_epoch: std::sync::Mutex::new(None),
+            captured_artifacts: std::sync::Mutex::new(HashSet::new()),
         }
     }
 }
@@ -69,6 +73,16 @@ impl ArtifactLifecycle {
 impl RunLifecycle<WorkflowGraph> for ArtifactLifecycle {
     async fn on_run_start(&self, _graph: &WorkflowGraph, _state: &WfRunState) -> CoreResult<()> {
         *self.attempt_start_epoch.lock().unwrap() = None;
+        let ledger = self
+            .rebuild_captured_artifact_ledger()
+            .await
+            .map_err(|err| {
+                let rendered = fabro_util::error::collect_chain(err.as_ref()).join(": ");
+                CoreError::Other(format!(
+                    "failed to rebuild captured artifact ledger: {rendered}"
+                ))
+            })?;
+        *self.captured_artifacts.lock().unwrap() = ledger;
         Ok(())
     }
 
@@ -112,14 +126,20 @@ impl RunLifecycle<WorkflowGraph> for ArtifactLifecycle {
         )
         .await
         {
-            Ok(summary) if summary.files_copied > 0 => {
+            Ok(summary) => {
+                self.emit_collection_problem_notice(node_id, &summary);
+                let new_assets = self.new_captured_assets(&summary.captured_assets);
+                if new_assets.is_empty() {
+                    return Ok(());
+                }
+
                 let stage_id = StageId::new(node_id.to_string(), visit);
                 if let Err(err) = self
                     .persist_artifacts(
                         &stage_id,
                         ctx.attempt,
                         artifact_capture_dir.path(),
-                        &summary.captured_assets,
+                        &new_assets,
                     )
                     .await
                 {
@@ -130,8 +150,9 @@ impl RunLifecycle<WorkflowGraph> for ArtifactLifecycle {
                     );
                     return Ok(());
                 }
+                self.record_captured_assets(&new_assets);
                 let scope = stage_scope_for(state, node_id);
-                for asset in &summary.captured_assets {
+                for asset in &new_assets {
                     self.emitter.emit_scoped(
                         &Event::ArtifactCaptured {
                             node_id:        node_id.to_string(),
@@ -147,7 +168,6 @@ impl RunLifecycle<WorkflowGraph> for ArtifactLifecycle {
                     );
                 }
             }
-            Ok(_) => {} // no files collected
             Err(e) => {
                 self.emitter.notice(
                     RunNoticeLevel::Warn,
@@ -197,6 +217,63 @@ impl RunLifecycle<WorkflowGraph> for ArtifactLifecycle {
 }
 
 impl ArtifactLifecycle {
+    async fn rebuild_captured_artifact_ledger(&self) -> Result<HashSet<ArtifactIdentity>> {
+        let events = self
+            .run_store
+            .list_events()
+            .await
+            .context("failed to list run events")?;
+        Ok(events
+            .into_iter()
+            .filter_map(|envelope| match envelope.event.body {
+                EventBody::ArtifactCaptured(props) => Some((props.path, props.content_sha256)),
+                _ => None,
+            })
+            .collect())
+    }
+
+    fn emit_collection_problem_notice(
+        &self,
+        node_id: &str,
+        summary: &crate::artifact_snapshot::ArtifactCollectionSummary,
+    ) {
+        if summary.download_errors == 0 && summary.hash_errors == 0 {
+            return;
+        }
+
+        let mut parts = Vec::new();
+        if summary.download_errors > 0 {
+            parts.push(format!("{} download error(s)", summary.download_errors));
+        }
+        if summary.hash_errors > 0 {
+            parts.push(format!("{} hash/read error(s)", summary.hash_errors));
+        }
+        self.emitter.notice(
+            RunNoticeLevel::Warn,
+            RunNoticeCode::ArtifactCollectionFailed,
+            format!(
+                "[node: {node_id}] artifact collection completed with {}",
+                parts.join(", ")
+            ),
+        );
+    }
+
+    fn new_captured_assets(&self, artifacts: &[ArtifactUpload]) -> Vec<ArtifactUpload> {
+        let ledger = self.captured_artifacts.lock().unwrap();
+        artifacts
+            .iter()
+            .filter(|artifact| !ledger.contains(&artifact_identity(artifact)))
+            .cloned()
+            .collect()
+    }
+
+    fn record_captured_assets(&self, artifacts: &[ArtifactUpload]) {
+        let mut ledger = self.captured_artifacts.lock().unwrap();
+        for artifact in artifacts {
+            ledger.insert(artifact_identity(artifact));
+        }
+    }
+
     async fn persist_artifacts(
         &self,
         stage_id: &StageId,
@@ -271,4 +348,8 @@ impl ArtifactLifecycle {
         }
         Ok(())
     }
+}
+
+fn artifact_identity(artifact: &ArtifactUpload) -> ArtifactIdentity {
+    (artifact.path.clone(), artifact.content_sha256.clone())
 }

--- a/lib/crates/fabro-workflow/src/lifecycle/artifact.rs
+++ b/lib/crates/fabro-workflow/src/lifecycle/artifact.rs
@@ -11,11 +11,12 @@ use fabro_core::outcome::NodeResult;
 use fabro_core::state::ExecutionState;
 use fabro_store::{ArtifactKey, ArtifactStore};
 use fabro_types::{ArtifactUpload, EventBody, RunId, StageId};
+use fabro_util::error::collect_chain;
 use tokio::fs;
 use tokio::time::sleep;
 
 use crate::artifact::{normalize_durable_updates, offload_large_values, sync_artifacts_to_env};
-use crate::artifact_snapshot::collect_artifacts;
+use crate::artifact_snapshot::{ArtifactCollectionSummary, collect_artifacts};
 use crate::artifact_upload::ArtifactSink;
 use crate::event::{Emitter, Event, RunNoticeCode, RunNoticeLevel};
 use crate::graph::{WorkflowGraph, WorkflowNode};
@@ -77,7 +78,7 @@ impl RunLifecycle<WorkflowGraph> for ArtifactLifecycle {
             .rebuild_captured_artifact_ledger()
             .await
             .map_err(|err| {
-                let rendered = fabro_util::error::collect_chain(err.as_ref()).join(": ");
+                let rendered = collect_chain(err.as_ref()).join(": ");
                 CoreError::Other(format!(
                     "failed to rebuild captured artifact ledger: {rendered}"
                 ))
@@ -232,11 +233,7 @@ impl ArtifactLifecycle {
             .collect())
     }
 
-    fn emit_collection_problem_notice(
-        &self,
-        node_id: &str,
-        summary: &crate::artifact_snapshot::ArtifactCollectionSummary,
-    ) {
+    fn emit_collection_problem_notice(&self, node_id: &str, summary: &ArtifactCollectionSummary) {
         if summary.download_errors == 0 && summary.hash_errors == 0 {
             return;
         }


### PR DESCRIPTION
## Summary

Fixes artifact promotion for configured `[run.artifacts].include` globs by collecting matching files after each stage regardless of mtime and surfacing failed discovery commands as collection failures.

The workflow lifecycle now keeps a per-run ledger keyed by `(path, content_sha256)`, rebuilt from existing `artifact.captured` events, so unchanged files are persisted and emitted once while changed content at the same path can still be captured again.

Fixes fabro-sh/fabro#335.

## Tests

- `cargo +nightly-2026-04-14 fmt --check --all`
- `cargo nextest run -p fabro-workflow artifact_snapshot`
- `cargo nextest run -p fabro-cli unchanged_matching_artifact_is_captured_once_across_stages`
- `cargo nextest run -p fabro-cli acp_artifacts_are_listed_when_touched_file_mtime_precedes_attempt_start`

---

[![Compound Engineering](https://img.shields.io/badge/Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with GPT-5 via [Codex](https://openai.com/codex)