### PR TITLE
fix(workflow): follow symlinked artifact roots

### DIFF
--- a/lib/crates/fabro-workflow/src/artifact_snapshot.rs
+++ b/lib/crates/fabro-workflow/src/artifact_snapshot.rs
@@ -60,7 +60,7 @@ const MAX_TOTAL_SIZE: u64 = 50 * 1024 * 1024;
 /// Globs with `/` are treated as directory patterns: the trailing `/**` (if
 /// any) is stripped and the remainder is matched via `-path '*/{dir}/*'`.
 pub fn build_find_command(root: &str, platform: &str, globs: &[String]) -> String {
-    let mut cmd = format!("find {}", shell_quote(root));
+    let mut cmd = format!("find -H {}", shell_quote(root));
 
     // Prune excluded directories
     let prune_parts: Vec<String> = EXCLUDE_DIRS
@@ -609,7 +609,10 @@ mod tests {
     fn build_find_command_shell_quotes_root_and_globs() {
         let globs = vec!["test result's/**".to_string(), "*.trace zip".to_string()];
         let cmd = build_find_command("/workspace with spaces", "linux", &globs);
-        assert!(cmd.starts_with(&format!("find {}", shell_quote("/workspace with spaces"))));
+        assert!(cmd.starts_with(&format!(
+            "find -H {}",
+            shell_quote("/workspace with spaces")
+        )));
         assert!(cmd.contains(&format!("-path {}", shell_quote("*/test result's/*"))));
         assert!(cmd.contains(&format!("-name {}", shell_quote("*.trace zip"))));
     }

--- a/lib/crates/fabro-workflow/tests/it/integration.rs
+++ b/lib/crates/fabro-workflow/tests/it/integration.rs
@@ -12256,6 +12256,113 @@ async fn asset_collection_local_sandbox_success() {
     assert_eq!(asset_properties["attempt"].as_u64().unwrap(), 1);
 }
 
+/// Local sandbox: artifact collection discovers files when the sandbox
+/// working directory itself is a symlink.
+#[tokio::test]
+#[cfg(unix)]
+async fn asset_collection_local_sandbox_symlink_working_directory() {
+    let work_root = tempfile::tempdir().unwrap();
+    let real_work_dir = work_root.path().join("real-workspace");
+    let symlink_work_dir = work_root.path().join("workspace-link");
+    std::fs::create_dir_all(&real_work_dir).expect("real workspace should create");
+    std::os::unix::fs::symlink(&real_work_dir, &symlink_work_dir)
+        .expect("workspace symlink should create");
+    let run_dir = tempfile::tempdir().unwrap();
+
+    let sandbox: Arc<dyn fabro_agent::Sandbox> =
+        Arc::new(fabro_agent::LocalSandbox::new(symlink_work_dir));
+    sandbox.initialize().await.unwrap();
+
+    let mut registry = HandlerRegistry::new(Box::new(AssetCreatorHandler::success()));
+    registry.register("start", Box::new(StartHandler));
+    registry.register("exit", Box::new(ExitHandler));
+
+    let emitter = Emitter::default();
+    let events = collect_events(&emitter);
+
+    let engine = WorkflowRunner::new(registry, Arc::new(emitter), sandbox.clone());
+
+    let mut graph = Graph::new("AssetCollectionSymlinkTest");
+    graph.attrs.insert(
+        "goal".to_string(),
+        AttrValue::String("Test artifact collection from symlinked workdir".to_string()),
+    );
+
+    let mut start = Node::new("start");
+    start.attrs.insert(
+        "shape".to_string(),
+        AttrValue::String("Mdiamond".to_string()),
+    );
+    graph.nodes.insert("start".to_string(), start);
+
+    let mut create_assets = Node::new("create_assets");
+    create_assets.attrs.insert(
+        "label".to_string(),
+        AttrValue::String("Create Assets".to_string()),
+    );
+    graph
+        .nodes
+        .insert("create_assets".to_string(), create_assets);
+
+    let mut exit = Node::new("exit");
+    exit.attrs.insert(
+        "shape".to_string(),
+        AttrValue::String("Msquare".to_string()),
+    );
+    graph.nodes.insert("exit".to_string(), exit);
+
+    graph.edges.push(Edge::new("start", "create_assets"));
+    graph.edges.push(Edge::new("create_assets", "exit"));
+
+    let run_options = RunOptions {
+        settings:         WorkflowSettings {
+            run: fabro_types::settings::RunNamespace {
+                artifacts: fabro_types::settings::run::ArtifactsSettings {
+                    include: vec!["test-results/**".to_string()],
+                },
+                ..fabro_types::settings::RunNamespace::default()
+            },
+            ..WorkflowSettings::default()
+        },
+        run_dir:          run_dir.path().to_path_buf(),
+        cancel_token:     CancellationToken::new(),
+        run_id:           test_run_id("artifact-test-symlink-workdir"),
+        labels:           std::collections::HashMap::new(),
+        workflow_slug:    None,
+        github_app:       None,
+        base_branch:      None,
+        display_base_sha: None,
+        pre_run_git:      None,
+        fork_source_ref:  None,
+        git:              None,
+    };
+    let outcome = engine
+        .run(&graph, &run_options)
+        .await
+        .expect("run should succeed");
+    assert_eq!(outcome.status, StageOutcome::Succeeded);
+
+    let artifacts = test_artifact_store(run_dir.path())
+        .list_for_run(&run_options.run_id)
+        .await
+        .unwrap();
+
+    assert!(
+        artifacts
+            .iter()
+            .any(|artifact| artifact.filename == "test-results/report.xml"),
+        "expected artifact created under symlinked working directory: {artifacts:?}"
+    );
+    assert!(
+        events
+            .lock()
+            .unwrap()
+            .iter()
+            .any(|event| event.event_name() == "artifact.captured"),
+        "artifact.captured should be emitted for symlinked working directory"
+    );
+}
+
 /// Local sandbox: assets are still collected even when the handler fails.
 #[tokio::test]
 async fn asset_collection_local_sandbox_on_failure() {


### PR DESCRIPTION
Fixes https://github.com/fabro-sh/fabro/issues/335

## Summary
- Run artifact discovery with `find -H` so a symlinked sandbox working-directory root is traversed.
- Keep existing behavior for symlinks discovered inside the tree by preserving the current `-not -type l -type f` filter.
- Add workflow integration coverage for artifact collection when the local sandbox working directory itself is a symlink.

## Test plan
- `cargo nextest run -p fabro-workflow asset_collection_local_sandbox_symlink_working_directory`
- `cargo nextest run -p fabro-workflow artifact_snapshot`
- `cargo nextest run -p fabro-workflow asset_collection_local_sandbox`
- `cargo +nightly-2026-04-14 fmt --check --all`