### PR TITLE
feat(agent): make OpenAI apply_patch Codex-compatible

### DIFF
--- a/lib/crates/fabro-agent/README.md
+++ b/lib/crates/fabro-agent/README.md
@@ -74,7 +74,7 @@ pub trait AgentProfile: Send + Sync {
 
 Built-in profiles:
 - **`AnthropicProfile`** -- 200K context, extended thinking beta headers, tools: `read_file`, `write_file`, `edit_file`, `shell`, `grep`, `glob`
-- **`OpenAiProfile`** -- 128K context, reasoning effort support, tools: `read_file`, `write_file`, `shell`, `grep`, `glob`, `apply_patch` (v4a format)
+- **`OpenAiProfile`** -- 128K context, reasoning effort support, tools: `read_file`, `write_file`, `shell`, `grep`, `glob`, `apply_patch` (Codex apply_patch format)
 - **`GeminiProfile`** -- 1M context, safety settings, tools: all Anthropic tools plus `read_many_files`, `list_dir`, `web_search`, `web_fetch`
 
 ### `Sandbox`

--- a/lib/crates/fabro-agent/src/apply_patch.lark
+++ b/lib/crates/fabro-agent/src/apply_patch.lark
@@ -1,0 +1,22 @@
+// Copyright 2026 OpenAI
+// SPDX-License-Identifier: Apache-2.0
+// Ported from openai/codex codex-rs/core/src/tools/handlers/apply_patch.lark at 932f72c225.
+start: begin_patch hunk+ end_patch
+begin_patch: "*** Begin Patch" LF
+end_patch: "*** End Patch" LF?
+
+hunk: add_hunk | delete_hunk | update_hunk
+add_hunk: "*** Add File: " filename LF add_line+
+delete_hunk: "*** Delete File: " filename LF
+update_hunk: "*** Update File: " filename LF change_move? change?
+
+filename: /(.+)/
+add_line: "+" /(.*)/ LF -> line
+
+change_move: "*** Move to: " filename LF
+change: (change_context | change_line)+ eof_line?
+change_context: ("@@" | "@@ " /(.+)/) LF
+change_line: ("+" | "-" | " ") /(.*)/ LF
+eof_line: "*** End of File" LF
+
+%import common.LF

--- a/lib/crates/fabro-agent/src/apply_patch.rs
+++ b/lib/crates/fabro-agent/src/apply_patch.rs
@@ -63,11 +63,11 @@ fn extract_context_line(line: &str) -> String {
     }
 }
 
-/// Parses a v4a format patch string into a list of patch operations.
+/// Parses Codex apply_patch text into a list of patch operations.
 ///
 /// # Errors
 /// Returns an error if the patch format is invalid.
-pub fn parse_v4a_patch(text: &str) -> Result<Vec<PatchOperation>, String> {
+pub fn parse_apply_patch(text: &str) -> Result<Vec<PatchOperation>, String> {
     let lines: Vec<&str> = text.trim().lines().collect();
     let lines = patch_lines_with_valid_boundaries(&lines)?;
     let mut ops = Vec::new();
@@ -490,7 +490,7 @@ pub fn make_apply_patch_tool() -> RegisteredTool {
                     .as_str()
                     .ok_or_else(|| "apply_patch expects raw patch text".to_string())?;
 
-                let ops = parse_v4a_patch(patch_text)?;
+                let ops = parse_apply_patch(patch_text)?;
                 apply_patch_operations(&ops, ctx.env.as_ref()).await
             })
         }),
@@ -511,7 +511,7 @@ mod tests {
     use crate::tool_registry::ToolContext;
 
     #[test]
-    fn parse_v4a_add_file() {
+    fn parse_apply_patch_add_file() {
         let patch = "\
 *** Begin Patch
 *** Add File: src/new_file.rs
@@ -520,7 +520,7 @@ mod tests {
 +}
 *** End Patch";
 
-        let ops = parse_v4a_patch(patch).unwrap();
+        let ops = parse_apply_patch(patch).unwrap();
         assert_eq!(ops.len(), 1);
         assert_eq!(ops[0], PatchOperation::Add {
             path:    "src/new_file.rs".into(),
@@ -529,13 +529,13 @@ mod tests {
     }
 
     #[test]
-    fn parse_v4a_delete_file() {
+    fn parse_apply_patch_delete_file() {
         let patch = "\
 *** Begin Patch
 *** Delete File: src/old_file.rs
 *** End Patch";
 
-        let ops = parse_v4a_patch(patch).unwrap();
+        let ops = parse_apply_patch(patch).unwrap();
         assert_eq!(ops.len(), 1);
         assert_eq!(ops[0], PatchOperation::Delete {
             path: "src/old_file.rs".into(),
@@ -543,7 +543,7 @@ mod tests {
     }
 
     #[test]
-    fn parse_v4a_update_file() {
+    fn parse_apply_patch_update_file() {
         let patch = "\
 *** Begin Patch
 *** Update File: src/lib.rs
@@ -552,7 +552,7 @@ mod tests {
 +    println!(\"new\");
 *** End Patch";
 
-        let ops = parse_v4a_patch(patch).unwrap();
+        let ops = parse_apply_patch(patch).unwrap();
         assert_eq!(ops.len(), 1);
         match &ops[0] {
             PatchOperation::Update {
@@ -580,7 +580,7 @@ mod tests {
     }
 
     #[test]
-    fn parse_v4a_multi_operation() {
+    fn parse_apply_patch_multi_operation() {
         let patch = "\
 *** Begin Patch
 *** Add File: src/a.rs
@@ -592,7 +592,7 @@ mod tests {
 +    new_call();
 *** End Patch";
 
-        let ops = parse_v4a_patch(patch).unwrap();
+        let ops = parse_apply_patch(patch).unwrap();
         assert_eq!(ops.len(), 3);
         assert!(matches!(&ops[0], PatchOperation::Add { .. }));
         assert!(matches!(&ops[1], PatchOperation::Delete { .. }));
@@ -600,7 +600,7 @@ mod tests {
     }
 
     #[test]
-    fn parse_v4a_bare_at_at_hunk() {
+    fn parse_apply_patch_bare_at_at_hunk() {
         let patch = "\
 *** Begin Patch
 *** Update File: src/game.py
@@ -609,7 +609,7 @@ mod tests {
 +from src.cards import Card, Suit
 *** End Patch";
 
-        let ops = parse_v4a_patch(patch).unwrap();
+        let ops = parse_apply_patch(patch).unwrap();
         assert_eq!(ops.len(), 1);
         match &ops[0] {
             PatchOperation::Update { path, hunks, .. } => {
@@ -623,7 +623,7 @@ mod tests {
     }
 
     #[test]
-    fn parse_v4a_multiple_bare_at_at_hunks() {
+    fn parse_apply_patch_multiple_bare_at_at_hunks() {
         let patch = "\
 *** Begin Patch
 *** Update File: src/game.py
@@ -635,7 +635,7 @@ mod tests {
 +    stock: list[Card] = field(default_factory=list)
 *** End Patch";
 
-        let ops = parse_v4a_patch(patch).unwrap();
+        let ops = parse_apply_patch(patch).unwrap();
         match &ops[0] {
             PatchOperation::Update { hunks, .. } => {
                 assert_eq!(hunks.len(), 2);
@@ -692,7 +692,7 @@ mod tests {
     }
 
     #[test]
-    fn parse_v4a_mixed_bare_and_contextual_hunks() {
+    fn parse_apply_patch_mixed_bare_and_contextual_hunks() {
         let patch = "\
 *** Begin Patch
 *** Update File: src/lib.rs
@@ -704,7 +704,7 @@ mod tests {
 +    new_teardown();
 *** End Patch";
 
-        let ops = parse_v4a_patch(patch).unwrap();
+        let ops = parse_apply_patch(patch).unwrap();
         match &ops[0] {
             PatchOperation::Update { hunks, .. } => {
                 assert_eq!(hunks.len(), 2);
@@ -716,7 +716,7 @@ mod tests {
     }
 
     #[test]
-    fn parse_v4a_bare_at_at_with_context_lines() {
+    fn parse_apply_patch_bare_at_at_with_context_lines() {
         let patch = "\
 *** Begin Patch
 *** Update File: src/lib.rs
@@ -727,7 +727,7 @@ mod tests {
  }
 *** End Patch";
 
-        let ops = parse_v4a_patch(patch).unwrap();
+        let ops = parse_apply_patch(patch).unwrap();
         match &ops[0] {
             PatchOperation::Update { hunks, .. } => {
                 assert_eq!(hunks.len(), 1);
@@ -749,7 +749,7 @@ mod tests {
     }
 
     #[test]
-    fn parse_v4a_bare_at_at_add_only_appends_to_file() {
+    fn parse_apply_patch_bare_at_at_add_only_appends_to_file() {
         let patch = "\
 *** Begin Patch
 *** Update File: src/lib.rs
@@ -758,7 +758,7 @@ mod tests {
 *** End Patch";
 
         // Parsing succeeds — the hunk is structurally valid
-        let ops = parse_v4a_patch(patch).unwrap();
+        let ops = parse_apply_patch(patch).unwrap();
         match &ops[0] {
             PatchOperation::Update { hunks, .. } => {
                 assert_eq!(hunks[0].context_line, "");
@@ -952,7 +952,7 @@ mod tests {
 +new content
 *** End Patch";
 
-        let ops = parse_v4a_patch(patch).unwrap();
+        let ops = parse_apply_patch(patch).unwrap();
         let result = apply_patch_operations(&ops, &env).await.unwrap();
 
         assert_eq!(
@@ -972,7 +972,7 @@ mod tests {
 *** Update File: empty.txt
 *** End Patch";
 
-        let err = parse_v4a_patch(patch).expect_err("empty update hunk should be rejected");
+        let err = parse_apply_patch(patch).expect_err("empty update hunk should be rejected");
 
         assert!(err.contains("Update file hunk for path 'empty.txt' is empty"));
     }
@@ -989,7 +989,7 @@ mod tests {
 +inserted
 *** End Patch";
 
-        let ops = parse_v4a_patch(patch).unwrap();
+        let ops = parse_apply_patch(patch).unwrap();
         let result = apply_patch_operations(&ops, &env).await.unwrap();
 
         assert_eq!(
@@ -1018,7 +1018,7 @@ mod tests {
 +has newline now
 *** End Patch";
 
-        let ops = parse_v4a_patch(patch).unwrap();
+        let ops = parse_apply_patch(patch).unwrap();
         apply_patch_operations(&ops, &env).await.unwrap();
 
         assert_eq!(
@@ -1036,7 +1036,7 @@ please apply this
 +hello
 *** End Patch";
 
-        let err = parse_v4a_patch(patch).expect_err("patch envelope must start on first line");
+        let err = parse_apply_patch(patch).expect_err("patch envelope must start on first line");
 
         assert!(err.contains("The first line of the patch must be '*** Begin Patch'"));
     }
@@ -1081,7 +1081,7 @@ please apply this
 +new
 *** End Patch";
 
-        let ops = parse_v4a_patch(patch).unwrap();
+        let ops = parse_apply_patch(patch).unwrap();
         let err = apply_patch_operations(&ops, &env).await.unwrap_err();
 
         assert!(err.contains("Failed to read file to update missing.txt"));
@@ -1095,7 +1095,7 @@ please apply this
 *** Delete File: missing.txt
 *** End Patch";
 
-        let ops = parse_v4a_patch(patch).unwrap();
+        let ops = parse_apply_patch(patch).unwrap();
         let err = apply_patch_operations(&ops, &env).await.unwrap_err();
 
         assert_eq!(
@@ -1136,7 +1136,7 @@ please apply this
     // Phase 1: Context without trailing @@
 
     #[test]
-    fn parse_v4a_context_without_trailing_markers() {
+    fn parse_apply_patch_context_without_trailing_markers() {
         let patch = "\
 *** Begin Patch
 *** Update File: src/hello.py
@@ -1145,7 +1145,7 @@ please apply this
 +    print(\"new\")
 *** End Patch";
 
-        let ops = parse_v4a_patch(patch).unwrap();
+        let ops = parse_apply_patch(patch).unwrap();
         match &ops[0] {
             PatchOperation::Update { hunks, .. } => {
                 assert_eq!(hunks[0].context_line, "def hello():");
@@ -1157,7 +1157,7 @@ please apply this
     // Phase 2: Stacked @@ anchors
 
     #[test]
-    fn parse_v4a_stacked_context_uses_last() {
+    fn parse_apply_patch_stacked_context_uses_last() {
         let patch = "\
 *** Begin Patch
 *** Update File: src/foo.py
@@ -1167,7 +1167,7 @@ please apply this
 +        return 42
 *** End Patch";
 
-        let ops = parse_v4a_patch(patch).unwrap();
+        let ops = parse_apply_patch(patch).unwrap();
         match &ops[0] {
             PatchOperation::Update { hunks, .. } => {
                 assert_eq!(hunks.len(), 1);
@@ -1180,7 +1180,7 @@ please apply this
     // Phase 3: *** End of File
 
     #[test]
-    fn parse_v4a_end_of_file_marker() {
+    fn parse_apply_patch_end_of_file_marker() {
         let patch = "\
 *** Begin Patch
 *** Update File: src/lib.py
@@ -1190,7 +1190,7 @@ please apply this
 *** End of File
 *** End Patch";
 
-        let ops = parse_v4a_patch(patch).unwrap();
+        let ops = parse_apply_patch(patch).unwrap();
         match &ops[0] {
             PatchOperation::Update { hunks, .. } => {
                 assert_eq!(hunks.len(), 1);
@@ -1223,7 +1223,7 @@ please apply this
     // Phase 4: *** Move to:
 
     #[test]
-    fn parse_v4a_move_to() {
+    fn parse_apply_patch_move_to() {
         let patch = "\
 *** Begin Patch
 *** Update File: src/old.py
@@ -1233,7 +1233,7 @@ please apply this
 +    return 1
 *** End Patch";
 
-        let ops = parse_v4a_patch(patch).unwrap();
+        let ops = parse_apply_patch(patch).unwrap();
         match &ops[0] {
             PatchOperation::Update {
                 path,
@@ -1315,7 +1315,7 @@ please apply this
     // Phase 6: Heredoc stripping
 
     #[test]
-    fn parse_v4a_strips_heredoc_wrapper() {
+    fn parse_apply_patch_strips_heredoc_wrapper() {
         let patch = "\
 <<'EOF'
 *** Begin Patch
@@ -1326,7 +1326,7 @@ please apply this
 *** End Patch
 EOF";
 
-        let ops = parse_v4a_patch(patch).unwrap();
+        let ops = parse_apply_patch(patch).unwrap();
         assert_eq!(ops.len(), 1);
         match &ops[0] {
             PatchOperation::Update { hunks, .. } => {
@@ -1337,7 +1337,7 @@ EOF";
     }
 
     #[test]
-    fn parse_v4a_strips_heredoc_unquoted() {
+    fn parse_apply_patch_strips_heredoc_unquoted() {
         let patch = "\
 <<EOF
 *** Begin Patch
@@ -1346,13 +1346,13 @@ EOF";
 *** End Patch
 EOF";
 
-        let ops = parse_v4a_patch(patch).unwrap();
+        let ops = parse_apply_patch(patch).unwrap();
         assert_eq!(ops.len(), 1);
         assert!(matches!(&ops[0], PatchOperation::Add { .. }));
     }
 
     #[test]
-    fn parse_v4a_strips_heredoc_double_quoted() {
+    fn parse_apply_patch_strips_heredoc_double_quoted() {
         let patch = "\
 <<\"EOF\"
 *** Begin Patch
@@ -1360,7 +1360,7 @@ EOF";
 *** End Patch
 EOF";
 
-        let ops = parse_v4a_patch(patch).unwrap();
+        let ops = parse_apply_patch(patch).unwrap();
         assert_eq!(ops.len(), 1);
         assert!(matches!(&ops[0], PatchOperation::Delete { .. }));
     }
@@ -1418,7 +1418,7 @@ class GameState:
 +            self.waste.append(card)
 *** End Patch";
 
-        let ops = parse_v4a_patch(patch).unwrap();
+        let ops = parse_apply_patch(patch).unwrap();
         apply_patch_operations(&ops, &env).await.unwrap();
 
         let content = env.read_file("src/game.py", None, None).await.unwrap();
@@ -1471,7 +1471,7 @@ def main():
 +    print(f\"result: {result}\")
 *** End Patch";
 
-        let ops = parse_v4a_patch(patch).unwrap();
+        let ops = parse_apply_patch(patch).unwrap();
         let result = apply_patch_operations(&ops, &env).await.unwrap();
 
         assert!(result.contains("A src/new_util.py"));
@@ -1532,7 +1532,7 @@ class User:
 *** End Patch
 EOF";
 
-        let ops = parse_v4a_patch(patch).unwrap();
+        let ops = parse_apply_patch(patch).unwrap();
         let result = apply_patch_operations(&ops, &env).await.unwrap();
 
         assert!(result.contains("M src/models/account.py"));
@@ -1593,7 +1593,7 @@ def gamma():
 +    return \"c\"
 *** End Patch";
 
-        let ops = parse_v4a_patch(patch).unwrap();
+        let ops = parse_apply_patch(patch).unwrap();
         apply_patch_operations(&ops, &env).await.unwrap();
 
         let content = env.read_file("src/stubs.py", None, None).await.unwrap();
@@ -1621,7 +1621,7 @@ def gamma():
 +    println!(\"world\");
 *** End Patch";
 
-        let ops = parse_v4a_patch(patch).unwrap();
+        let ops = parse_apply_patch(patch).unwrap();
         apply_patch_operations(&ops, &env).await.unwrap();
 
         let content = env.read_file("src/lib.rs", None, None).await.unwrap();

--- a/lib/crates/fabro-agent/src/file_tracker.rs
+++ b/lib/crates/fabro-agent/src/file_tracker.rs
@@ -82,9 +82,9 @@ impl FileTracker {
                     };
                     for line in content.lines() {
                         let line = line.trim();
-                        if let Some(path) = line.strip_prefix("Added file: ") {
+                        if let Some(path) = line.strip_prefix("A ") {
                             self.record_write(path.trim());
-                        } else if let Some(path) = line.strip_prefix("Updated file: ") {
+                        } else if let Some(path) = line.strip_prefix("M ") {
                             self.record_edit(path.trim());
                         }
                     }
@@ -189,7 +189,9 @@ mod tests {
         )];
         let results = vec![ToolResult::success(
             "tc1",
-            serde_json::json!("Added file: src/new.rs\nUpdated file: src/old.rs"),
+            serde_json::json!(
+                "Success. Updated the following files:\nA src/new.rs\nM src/old.rs\n"
+            ),
         )];
         tracker.record_from_tool_calls(&tool_calls, &results);
         assert_eq!(

--- a/lib/crates/fabro-agent/src/lib.rs
+++ b/lib/crates/fabro-agent/src/lib.rs
@@ -2,6 +2,7 @@
 pub mod docker_sandbox;
 
 pub mod agent_profile;
+pub mod apply_patch;
 pub mod cli;
 pub mod compaction;
 pub mod config;
@@ -25,7 +26,6 @@ pub mod tool_registry;
 pub mod tools;
 pub mod truncation;
 pub mod types;
-pub mod v4a_patch;
 
 pub use agent_profile::AgentProfile;
 pub use config::{SessionOptions, ToolApprovalAdapter, ToolHookCallback, ToolHookDecision};

--- a/lib/crates/fabro-agent/src/profiles/openai.rs
+++ b/lib/crates/fabro-agent/src/profiles/openai.rs
@@ -141,8 +141,8 @@ If completing the task requires writing or modifying files:
 and focused on the task.
 - Use `git log` and `git blame` to search the history of the codebase if additional context is needed.
 - NEVER add copyright or license headers unless specifically requested.
-- When apply_patch fails, the error includes the current file contents — use them to construct \
-a corrected patch without re-reading the file.
+- When apply_patch fails, use the error text to construct a corrected patch. Re-read the target \
+file if you need fresh context.
 - Do not `git commit` your changes or create new git branches unless explicitly requested.
 
 # Validating Your Work
@@ -159,12 +159,12 @@ Use the provided tools to interact with the codebase and environment.
 Read files to understand code before modifying. Use offset/limit for large files.
 
 ## apply_patch
-Use the v4a patch format for all file modifications. The format uses `*** Begin Patch` / \
+Use the `apply_patch` tool for all file modifications. This is a freeform tool: pass the raw \
+patch text directly, never wrap it in JSON. The format uses `*** Begin Patch` / \
 `*** End Patch` delimiters with `*** Add File:`, `*** Delete File:`, `*** Update File:` \
-operations. Update hunks use `@@ context line text` headers — place a line of \
-existing code after `@@ ` to anchor each hunk. Use `-` for \
-removals, `+` for additions, and space-prefix for unchanged context lines. Show 3 lines \
-of context around each change. NEVER use `applypatch` or `apply-patch`, only `apply_patch`.
+operations. Use `-` for removals, `+` for additions, and space-prefix for unchanged context \
+lines. Show 3 lines of context around each change. NEVER use `applypatch` or `apply-patch`, \
+only `apply_patch`.
 
 Example:
 ```
@@ -243,7 +243,7 @@ mod tests {
         assert!(prompt.contains("You are a coding agent powered by openai"));
         assert!(prompt.contains("<environment>"));
         assert!(prompt.contains("linux"));
-        assert!(prompt.contains("v4a patch format"));
+        assert!(prompt.contains("freeform tool"));
         assert!(prompt.contains("*** Begin Patch"));
     }
 
@@ -319,6 +319,9 @@ mod tests {
         assert!(names.contains(&"apply_patch".to_string()));
         assert!(names.contains(&"web_search".to_string()));
         assert!(names.contains(&"web_fetch".to_string()));
+
+        let apply_patch = profile.tool_registry().get("apply_patch").unwrap();
+        assert!(apply_patch.definition.is_custom());
     }
 
     #[test]

--- a/lib/crates/fabro-agent/src/profiles/openai.rs
+++ b/lib/crates/fabro-agent/src/profiles/openai.rs
@@ -4,13 +4,13 @@ use fabro_model::{AgentProfileKind, Catalog, ProviderId};
 
 use super::EnvContext;
 use crate::agent_profile::AgentProfile;
+use crate::apply_patch;
 use crate::config::SessionOptions;
 use crate::profiles::{BaseProfile, assemble_system_prompt};
 use crate::sandbox::Sandbox;
 use crate::skills::Skill;
 use crate::tool_registry::ToolRegistry;
 use crate::tools::{WebFetchSummarizer, register_core_tools};
-use crate::v4a_patch::make_apply_patch_tool;
 
 pub struct OpenAiProfile {
     base: BaseProfile,
@@ -31,7 +31,7 @@ impl OpenAiProfile {
         let mut registry = ToolRegistry::new();
 
         register_core_tools(&mut registry, &config, summarizer);
-        registry.register(make_apply_patch_tool());
+        registry.register(apply_patch::make_apply_patch_tool());
 
         Self {
             base: BaseProfile {

--- a/lib/crates/fabro-agent/src/tool_execution.rs
+++ b/lib/crates/fabro-agent/src/tool_execution.rs
@@ -274,10 +274,12 @@ async fn execute_one_tool(
 ) -> ToolResult {
     match registered_tool {
         Some(tool) => {
-            if let Err(validation_error) =
-                validate_tool_args(&tool.definition.parameters, &tc.arguments)
-            {
-                return ToolResult::error(&tc.id, validation_error);
+            if tc.tool_type != "custom" {
+                if let Err(validation_error) =
+                    validate_tool_args(&tool.definition.parameters, &tc.arguments)
+                {
+                    return ToolResult::error(&tc.id, validation_error);
+                }
             }
 
             let ctx = ToolContext {

--- a/lib/crates/fabro-agent/src/v4a_patch.rs
+++ b/lib/crates/fabro-agent/src/v4a_patch.rs
@@ -1,10 +1,24 @@
+// Copyright 2026 OpenAI
+// SPDX-License-Identifier: Apache-2.0
+// Ported from openai/codex codex-rs/apply-patch at 932f72c225.
+
+use std::fmt::Write as _;
 use std::sync::Arc;
 
 use fabro_llm::types::ToolDefinition;
 
-use crate::sandbox::{Sandbox, format_lines_numbered};
+use crate::sandbox::Sandbox;
 use crate::tool_registry::RegisteredTool;
-use crate::truncation::{TruncationMode, truncate_output};
+
+const APPLY_PATCH_LARK_GRAMMAR: &str = include_str!("apply_patch.lark");
+
+fn apply_patch_lark_grammar_definition() -> String {
+    APPLY_PATCH_LARK_GRAMMAR
+        .lines()
+        .filter(|line| !line.trim_start().starts_with("//"))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Change {
@@ -54,28 +68,12 @@ fn extract_context_line(line: &str) -> String {
 /// # Errors
 /// Returns an error if the patch format is invalid.
 pub fn parse_v4a_patch(text: &str) -> Result<Vec<PatchOperation>, String> {
-    let mut lines: Vec<&str> = text.lines().collect();
+    let lines: Vec<&str> = text.trim().lines().collect();
+    let lines = patch_lines_with_valid_boundaries(&lines)?;
     let mut ops = Vec::new();
     let mut i = 0;
 
-    // Strip heredoc wrapper
-    if let Some(first) = lines.first() {
-        let trimmed = first.trim();
-        if (trimmed == "<<EOF" || trimmed == "<<'EOF'" || trimmed == "<<\"EOF\"")
-            && lines.last().map(|l| l.trim()) == Some("EOF")
-        {
-            lines = lines[1..lines.len() - 1].to_vec();
-        }
-    }
-
-    // Find "*** Begin Patch"
-    while i < lines.len() {
-        if lines[i].trim() == "*** Begin Patch" {
-            i += 1;
-            break;
-        }
-        i += 1;
-    }
+    i += 1;
 
     while i < lines.len() {
         let line = lines[i].trim();
@@ -88,20 +86,23 @@ pub fn parse_v4a_patch(text: &str) -> Result<Vec<PatchOperation>, String> {
             let path = path.to_string();
             i += 1;
             let mut content = String::new();
+            let mut add_lines = 0;
             while i < lines.len() {
                 let l = lines[i];
                 if l.starts_with("*** ") {
                     break;
                 }
                 if let Some(text_line) = l.strip_prefix('+') {
-                    if !content.is_empty() {
-                        content.push('\n');
-                    }
                     content.push_str(text_line);
+                    content.push('\n');
+                    add_lines += 1;
                 } else {
                     return Err(format!("Expected '+' prefix in Add File block, got: {l}"));
                 }
                 i += 1;
+            }
+            if add_lines == 0 {
+                return Err(format!("Add file hunk for path '{path}' is empty"));
             }
             ops.push(PatchOperation::Add { path, content });
         } else if let Some(path) = line.strip_prefix("*** Delete File: ") {
@@ -179,6 +180,9 @@ pub fn parse_v4a_patch(text: &str) -> Result<Vec<PatchOperation>, String> {
                     return Err(format!("Expected @@ context line, got: {l}"));
                 }
             }
+            if hunks.is_empty() {
+                return Err(format!("Update file hunk for path '{path}' is empty"));
+            }
             ops.push(PatchOperation::Update {
                 path,
                 new_path,
@@ -192,6 +196,38 @@ pub fn parse_v4a_patch(text: &str) -> Result<Vec<PatchOperation>, String> {
     Ok(ops)
 }
 
+fn patch_lines_with_valid_boundaries<'a>(lines: &'a [&'a str]) -> Result<&'a [&'a str], String> {
+    match check_patch_boundaries_strict(lines) {
+        Ok(()) => Ok(lines),
+        Err(original_error) => {
+            if let [first, .., last] = lines {
+                if (*first == "<<EOF" || *first == "<<'EOF'" || *first == "<<\"EOF\"")
+                    && last.ends_with("EOF")
+                    && lines.len() >= 4
+                {
+                    let inner = &lines[1..lines.len() - 1];
+                    check_patch_boundaries_strict(inner)?;
+                    return Ok(inner);
+                }
+            }
+            Err(original_error)
+        }
+    }
+}
+
+fn check_patch_boundaries_strict(lines: &[&str]) -> Result<(), String> {
+    let first_line = lines.first().map(|line| line.trim());
+    let last_line = lines.last().map(|line| line.trim());
+
+    match (first_line, last_line) {
+        (Some("*** Begin Patch"), Some("*** End Patch")) => Ok(()),
+        (Some(first), _) if first != "*** Begin Patch" => {
+            Err("The first line of the patch must be '*** Begin Patch'".to_string())
+        }
+        _ => Err("The last line of the patch must be '*** End Patch'".to_string()),
+    }
+}
+
 /// Applies a list of patch operations using the given sandbox.
 ///
 /// # Errors
@@ -200,50 +236,63 @@ pub async fn apply_patch_operations(
     ops: &[PatchOperation],
     env: &dyn Sandbox,
 ) -> Result<String, String> {
-    let mut results = Vec::new();
+    if ops.is_empty() {
+        return Err("No files were modified.".to_string());
+    }
+
+    let mut added = Vec::new();
+    let mut modified = Vec::new();
+    let mut deleted = Vec::new();
 
     for op in ops {
         match op {
             PatchOperation::Add { path, content } => {
-                env.write_file(path, content)
-                    .await
-                    .map_err(|e| e.display_with_causes())?;
-                results.push(format!("Added file: {path}"));
+                env.write_file(path, content).await.map_err(|e| {
+                    format!("Failed to write file {path}: {}", e.display_with_causes())
+                })?;
+                added.push(path.clone());
             }
             PatchOperation::Delete { path } => {
-                env.delete_file(path)
-                    .await
-                    .map_err(|e| e.display_with_causes())?;
-                results.push(format!("Deleted file: {path}"));
+                if !env.file_exists(path).await.map_err(|e| {
+                    format!("Failed to delete file {path}: {}", e.display_with_causes())
+                })? {
+                    return Err(format!("Failed to delete file {path}: file does not exist"));
+                }
+                env.delete_file(path).await.map_err(|e| {
+                    format!("Failed to delete file {path}: {}", e.display_with_causes())
+                })?;
+                deleted.push(path.clone());
             }
             PatchOperation::Update {
                 path,
                 new_path,
                 hunks,
             } => {
-                let original = env
-                    .read_file(path, None, None)
-                    .await
-                    .map_err(|e| e.display_with_causes())?;
-                let updated = apply_hunks(&original, hunks)
-                    .map_err(|err| format_patch_error(&err, path, &original))?;
+                let original = env.read_file(path, None, None).await.map_err(|e| {
+                    format!(
+                        "Failed to read file to update {path}: {}",
+                        e.display_with_causes()
+                    )
+                })?;
+                let updated = apply_hunks(path, &original, hunks)?;
                 let dest = new_path.as_deref().unwrap_or(path);
-                env.write_file(dest, &updated)
-                    .await
-                    .map_err(|e| e.display_with_causes())?;
+                env.write_file(dest, &updated).await.map_err(|e| {
+                    format!("Failed to write file {dest}: {}", e.display_with_causes())
+                })?;
                 if new_path.is_some() {
-                    env.delete_file(path)
-                        .await
-                        .map_err(|e| e.display_with_causes())?;
-                    results.push(format!("Moved file: {path} → {dest}"));
-                } else {
-                    results.push(format!("Updated file: {path}"));
+                    env.delete_file(path).await.map_err(|e| {
+                        format!(
+                            "Failed to remove original {path}: {}",
+                            e.display_with_causes()
+                        )
+                    })?;
                 }
+                modified.push(dest.to_string());
             }
         }
     }
 
-    Ok(results.join("\n"))
+    Ok(format_summary(&added, &modified, &deleted))
 }
 
 fn normalize_char(c: char) -> char {
@@ -252,186 +301,194 @@ fn normalize_char(c: char) -> char {
         '\u{201C}' | '\u{201D}' | '\u{201E}' | '\u{201F}' => '"',
         '\u{2010}' | '\u{2011}' | '\u{2012}' | '\u{2013}' | '\u{2014}' | '\u{2015}'
         | '\u{2212}' => '-',
-        '\u{00A0}' | '\u{2007}' | '\u{202F}' => ' ',
+        '\u{00A0}' | '\u{2002}' | '\u{2003}' | '\u{2004}' | '\u{2005}' | '\u{2006}'
+        | '\u{2007}' | '\u{2008}' | '\u{2009}' | '\u{200A}' | '\u{202F}' | '\u{205F}'
+        | '\u{3000}' => ' ',
         other => other,
     }
 }
 
 fn normalize_unicode(s: &str) -> String {
-    s.chars().map(normalize_char).collect()
+    s.trim().chars().map(normalize_char).collect()
 }
 
-fn find_line_match(lines: &[String], target: &str, start: usize) -> Option<usize> {
-    let slice = &lines[start..];
+fn seek_sequence(lines: &[String], pattern: &[String], start: usize, eof: bool) -> Option<usize> {
+    if pattern.is_empty() {
+        return Some(start);
+    }
+    if pattern.len() > lines.len() {
+        return None;
+    }
 
-    // Pass 1: exact
-    if let Some(pos) = slice.iter().position(|l| l.as_str() == target) {
-        return Some(start + pos);
+    let search_start = if eof && lines.len() >= pattern.len() {
+        lines.len() - pattern.len()
+    } else {
+        start
+    };
+
+    for i in search_start..=lines.len().saturating_sub(pattern.len()) {
+        if lines[i..i + pattern.len()] == *pattern {
+            return Some(i);
+        }
     }
-    // Pass 2: trim_end
-    let target_te = target.trim_end();
-    if let Some(pos) = slice.iter().position(|l| l.trim_end() == target_te) {
-        return Some(start + pos);
+    for i in search_start..=lines.len().saturating_sub(pattern.len()) {
+        if pattern
+            .iter()
+            .enumerate()
+            .all(|(offset, pat)| lines[i + offset].trim_end() == pat.trim_end())
+        {
+            return Some(i);
+        }
     }
-    // Pass 3: trim
-    let target_t = target.trim();
-    if let Some(pos) = slice.iter().position(|l| l.trim() == target_t) {
-        return Some(start + pos);
+    for i in search_start..=lines.len().saturating_sub(pattern.len()) {
+        if pattern
+            .iter()
+            .enumerate()
+            .all(|(offset, pat)| lines[i + offset].trim() == pat.trim())
+        {
+            return Some(i);
+        }
     }
-    // Pass 4: unicode normalization
-    let target_n = normalize_unicode(target_t);
-    slice
-        .iter()
-        .position(|l| normalize_unicode(l.trim()) == target_n)
-        .map(|p| start + p)
+
+    (search_start..=lines.len().saturating_sub(pattern.len())).find(|&i| {
+        pattern
+            .iter()
+            .enumerate()
+            .all(|(offset, pat)| normalize_unicode(&lines[i + offset]) == normalize_unicode(pat))
+    })
 }
 
-fn find_line_match_reverse(lines: &[String], target: &str) -> Option<usize> {
-    // Pass 1: exact
-    if let Some(pos) = lines.iter().rposition(|l| l.as_str() == target) {
-        return Some(pos);
+fn apply_hunks(path: &str, content: &str, hunks: &[Hunk]) -> Result<String, String> {
+    let mut original_lines: Vec<String> = content.split('\n').map(String::from).collect();
+    if original_lines.last().is_some_and(String::is_empty) {
+        original_lines.pop();
     }
-    // Pass 2: trim_end
-    let target_te = target.trim_end();
-    if let Some(pos) = lines.iter().rposition(|l| l.trim_end() == target_te) {
-        return Some(pos);
+
+    let replacements = compute_replacements(&original_lines, path, hunks)?;
+    let mut new_lines = apply_replacements(original_lines, &replacements);
+    if !new_lines.last().is_some_and(String::is_empty) {
+        new_lines.push(String::new());
     }
-    // Pass 3: trim
-    let target_t = target.trim();
-    if let Some(pos) = lines.iter().rposition(|l| l.trim() == target_t) {
-        return Some(pos);
-    }
-    // Pass 4: unicode normalization
-    let target_n = normalize_unicode(target_t);
-    lines
-        .iter()
-        .rposition(|l| normalize_unicode(l.trim()) == target_n)
+    Ok(new_lines.join("\n"))
 }
 
-fn apply_hunks(content: &str, hunks: &[Hunk]) -> Result<String, String> {
-    let mut lines: Vec<String> = content.lines().map(String::from).collect();
-    let mut cursor = 0;
+fn compute_replacements(
+    original_lines: &[String],
+    path: &str,
+    hunks: &[Hunk],
+) -> Result<Vec<(usize, usize, Vec<String>)>, String> {
+    let mut replacements = Vec::new();
+    let mut line_index = 0;
 
     for hunk in hunks {
-        let has_explicit_context = !hunk.context_line.is_empty();
-
-        let context_pos = if hunk.end_of_file {
-            if has_explicit_context {
-                find_line_match_reverse(&lines, &hunk.context_line)
+        if !hunk.context_line.is_empty() {
+            if let Some(index) = seek_sequence(
+                original_lines,
+                std::slice::from_ref(&hunk.context_line),
+                line_index,
+                false,
+            ) {
+                line_index = index + 1;
             } else {
-                let first_match_text = hunk
-                    .changes
-                    .iter()
-                    .find_map(|c| match c {
-                        Change::Remove(t) | Change::Context(t) => Some(t.as_str()),
-                        Change::Add(_) => None,
-                    })
-                    .ok_or("Hunk with bare @@ has no remove or context lines to locate position")?;
-                find_line_match_reverse(&lines, first_match_text)
-            }
-            .ok_or_else(|| {
-                let target = if has_explicit_context {
-                    &hunk.context_line
-                } else {
-                    "first change line"
-                };
-                format!("Could not find context line in file: '{target}'")
-            })?
-        } else if has_explicit_context {
-            find_line_match(&lines, &hunk.context_line, cursor).ok_or_else(|| {
-                format!(
-                    "Could not find context line in file: '{}'",
+                return Err(format!(
+                    "Failed to find context '{}' in {path}",
                     hunk.context_line
-                )
-            })?
-        } else {
-            // Bare @@ — locate position from the first remove or context line
-            let first_match_text = hunk
-                .changes
-                .iter()
-                .find_map(|c| match c {
-                    Change::Remove(t) | Change::Context(t) => Some(t.as_str()),
-                    Change::Add(_) => None,
-                })
-                .ok_or("Hunk with bare @@ has no remove or context lines to locate position")?;
-            find_line_match(&lines, first_match_text, cursor)
-                .ok_or_else(|| format!("Could not find line in file: '{first_match_text}'"))?
-        };
-
-        // Build what we expect to find and what to replace with
-        let mut new_lines: Vec<String> = Vec::new();
-
-        let mut file_idx = context_pos;
-        if has_explicit_context {
-            // The context line itself is preserved
-            new_lines.push(lines[context_pos].clone());
-            file_idx = context_pos + 1;
+                ));
+            }
         }
 
+        let mut old_lines = Vec::new();
+        let mut new_lines = Vec::new();
         for change in &hunk.changes {
             match change {
-                Change::Remove(_) => {
-                    file_idx += 1;
-                }
-                Change::Add(text) => {
-                    new_lines.push(text.clone());
-                }
-                Change::Context(_) => {
-                    if file_idx < lines.len() {
-                        new_lines.push(lines[file_idx].clone());
-                    }
-                    file_idx += 1;
+                Change::Remove(line) => old_lines.push(line.clone()),
+                Change::Add(line) => new_lines.push(line.clone()),
+                Change::Context(line) => {
+                    old_lines.push(line.clone());
+                    new_lines.push(line.clone());
                 }
             }
         }
 
-        // Calculate total lines consumed from original
-        let explicit_context_count = usize::from(has_explicit_context);
-        let total_original_lines = explicit_context_count
-            + hunk
-                .changes
-                .iter()
-                .filter(|c| matches!(c, Change::Remove(_) | Change::Context(_)))
-                .count();
+        if old_lines.is_empty() {
+            let insertion_index = original_lines.len();
+            replacements.push((insertion_index, 0, new_lines));
+            continue;
+        }
 
-        // Replace the range
-        let end = (context_pos + total_original_lines).min(lines.len());
-        let replacement_len = new_lines.len();
-        lines.splice(context_pos..end, new_lines);
-        cursor = context_pos + replacement_len;
+        let mut pattern: &[String] = &old_lines;
+        let mut new_slice: &[String] = &new_lines;
+        let mut found = seek_sequence(original_lines, pattern, line_index, hunk.end_of_file);
+        if found.is_none() && pattern.last().is_some_and(String::is_empty) {
+            pattern = &pattern[..pattern.len() - 1];
+            if new_slice.last().is_some_and(String::is_empty) {
+                new_slice = &new_slice[..new_slice.len() - 1];
+            }
+            found = seek_sequence(original_lines, pattern, line_index, hunk.end_of_file);
+        }
+
+        if let Some(start_index) = found {
+            replacements.push((start_index, pattern.len(), new_slice.to_vec()));
+            line_index = start_index + pattern.len();
+        } else {
+            return Err(format!(
+                "Failed to find expected lines in {path}:\n{}",
+                old_lines.join("\n")
+            ));
+        }
     }
 
-    Ok(lines.join("\n"))
+    replacements.sort_by_key(|(start_index, _, _)| *start_index);
+    Ok(replacements)
 }
 
-fn format_patch_error(error: &str, path: &str, content: &str) -> String {
-    let numbered = format_lines_numbered(content, None, None);
-    let truncated = truncate_output(&numbered, 9_000, TruncationMode::HeadTail);
-    format!("{error}\n\nCurrent contents of {path}:\n{truncated}")
+fn apply_replacements(
+    mut lines: Vec<String>,
+    replacements: &[(usize, usize, Vec<String>)],
+) -> Vec<String> {
+    for (start_index, old_len, new_segment) in replacements.iter().rev() {
+        for _ in 0..*old_len {
+            if *start_index < lines.len() {
+                lines.remove(*start_index);
+            }
+        }
+        for (offset, new_line) in new_segment.iter().enumerate() {
+            lines.insert(*start_index + offset, new_line.clone());
+        }
+    }
+    lines
+}
+
+fn format_summary(added: &[String], modified: &[String], deleted: &[String]) -> String {
+    let mut output = String::from("Success. Updated the following files:\n");
+    for path in added {
+        let _ = writeln!(output, "A {path}");
+    }
+    for path in modified {
+        let _ = writeln!(output, "M {path}");
+    }
+    for path in deleted {
+        let _ = writeln!(output, "D {path}");
+    }
+    output
 }
 
 pub fn make_apply_patch_tool() -> RegisteredTool {
     RegisteredTool {
-        definition: ToolDefinition {
-            name:        "apply_patch".into(),
-            description: "Apply a v4a format patch to modify files".into(),
-            parameters:  serde_json::json!({
-                "type": "object",
-                "properties": {
-                    "patch": {
-                        "type": "string",
-                        "description": "The patch content in v4a format"
-                    }
-                },
-                "required": ["patch"]
+        definition: ToolDefinition::custom(
+            "apply_patch",
+            "Use the `apply_patch` tool to edit files. This is a FREEFORM tool, so do not wrap the patch in JSON.",
+            serde_json::json!({
+                "type": "grammar",
+                "syntax": "lark",
+                "definition": apply_patch_lark_grammar_definition(),
             }),
-        },
+        ),
         executor:   Arc::new(|args, ctx| {
             Box::pin(async move {
                 let patch_text = args
-                    .get("patch")
-                    .and_then(|v| v.as_str())
-                    .ok_or_else(|| "Missing required parameter: patch".to_string())?;
+                    .as_str()
+                    .ok_or_else(|| "apply_patch expects raw patch text".to_string())?;
 
                 let ops = parse_v4a_patch(patch_text)?;
                 apply_patch_operations(&ops, ctx.env.as_ref()).await
@@ -444,8 +501,14 @@ pub fn make_apply_patch_tool() -> RegisteredTool {
 mod tests {
     use std::collections::HashMap;
 
+    use fabro_llm::types::{
+        ContentPart, FinishReason, Message as LlmMessage, Response, Role, TokenCounts, ToolCall,
+    };
+    use tokio_util::sync::CancellationToken;
+
     use super::*;
     use crate::test_support::MutableMockSandbox;
+    use crate::tool_registry::ToolContext;
 
     #[test]
     fn parse_v4a_add_file() {
@@ -461,7 +524,7 @@ mod tests {
         assert_eq!(ops.len(), 1);
         assert_eq!(ops[0], PatchOperation::Add {
             path:    "src/new_file.rs".into(),
-            content: "fn main() {\n    println!(\"hello\");\n}".into(),
+            content: "fn main() {\n    println!(\"hello\");\n}\n".into(),
         });
     }
 
@@ -618,7 +681,7 @@ mod tests {
         }];
 
         let result = apply_patch_operations(&ops, &env).await.unwrap();
-        assert!(result.contains("Updated file: src/game.py"));
+        assert!(result.contains("M src/game.py"));
 
         let content = env.read_file("src/game.py", None, None).await.unwrap();
         assert!(content.contains("from src.cards import Card, Suit"));
@@ -686,7 +749,7 @@ mod tests {
     }
 
     #[test]
-    fn parse_v4a_bare_at_at_add_only_errors_on_apply() {
+    fn parse_v4a_bare_at_at_add_only_appends_to_file() {
         let patch = "\
 *** Begin Patch
 *** Update File: src/lib.rs
@@ -705,12 +768,10 @@ mod tests {
             _ => panic!("Expected Update operation"),
         }
 
-        // Applying fails — no remove/context line to locate position
         match &ops[0] {
             PatchOperation::Update { hunks, .. } => {
-                let result = apply_hunks("fn main() {}\n", hunks);
-                assert!(result.is_err());
-                assert!(result.unwrap_err().contains("no remove or context lines"));
+                let result = apply_hunks("src/lib.rs", "fn main() {}\n", hunks).unwrap();
+                assert_eq!(result, "fn main() {}\nnew_line();\n");
             }
             _ => panic!("Expected Update operation"),
         }
@@ -741,10 +802,10 @@ mod tests {
         }];
 
         let result = apply_patch_operations(&ops, &env).await.unwrap();
-        assert!(result.contains("Updated file: src/lib.rs"));
+        assert!(result.contains("M src/lib.rs"));
 
         let content = env.read_file("src/lib.rs", None, None).await.unwrap();
-        assert_eq!(content, "fn unchanged() {\n    new_line();\n}");
+        assert_eq!(content, "fn unchanged() {\n    new_line();\n}\n");
     }
 
     #[tokio::test]
@@ -780,7 +841,7 @@ mod tests {
         }];
 
         let result = apply_patch_operations(&ops, &env).await.unwrap();
-        assert!(result.contains("Updated file: src/lib.rs"));
+        assert!(result.contains("M src/lib.rs"));
 
         let content = env.read_file("src/lib.rs", None, None).await.unwrap();
         assert!(content.contains("new_setup()"));
@@ -798,7 +859,7 @@ mod tests {
         }];
 
         let result = apply_patch_operations(&ops, &env).await.unwrap();
-        assert!(result.contains("Added file: src/new.rs"));
+        assert!(result.contains("A src/new.rs"));
 
         let content = env.read_file("src/new.rs", None, None).await.unwrap();
         assert_eq!(content, "fn new() {}");
@@ -827,7 +888,7 @@ mod tests {
         }];
 
         let result = apply_patch_operations(&ops, &env).await.unwrap();
-        assert!(result.contains("Updated file: src/lib.rs"));
+        assert!(result.contains("M src/lib.rs"));
 
         let content = env.read_file("src/lib.rs", None, None).await.unwrap();
         assert!(content.contains("println!(\"new\")"));
@@ -835,30 +896,153 @@ mod tests {
     }
 
     #[test]
-    fn format_patch_error_includes_numbered_contents() {
-        let result = format_patch_error(
-            "Could not find context line in file: 'fn missing()'",
-            "src/lib.rs",
-            "fn hello() {\n    println!(\"hi\");\n}",
-        );
-        assert!(result.contains("Could not find context line in file: 'fn missing()'"));
-        assert!(result.contains("Current contents of src/lib.rs:"));
-        assert!(result.contains("1 | fn hello() {"));
-        assert!(result.contains("2 |     println!(\"hi\");"));
-        assert!(result.contains("3 | }"));
-    }
+    fn apply_patch_tool_definition_is_custom_freeform() {
+        let tool = make_apply_patch_tool();
 
-    #[test]
-    fn format_patch_error_truncates_large_files() {
-        let lines: Vec<String> = (1..=1_000).map(|i| format!("line number {i:04}")).collect();
-        let content = lines.join("\n");
-        let result = format_patch_error("some error", "big.txt", &content);
-        assert!(result.len() < 10_000);
-        assert!(result.contains("truncated") || result.contains("removed"));
+        assert_eq!(tool.definition.name, "apply_patch");
+        assert!(tool.definition.is_custom());
+        assert_eq!(
+            tool.definition
+                .custom_format()
+                .and_then(|format| format.get("type")),
+            Some(&serde_json::json!("grammar"))
+        );
+        assert_eq!(
+            tool.definition
+                .custom_format()
+                .and_then(|format| format.get("syntax")),
+            Some(&serde_json::json!("lark"))
+        );
     }
 
     #[tokio::test]
-    async fn apply_patch_error_includes_file_contents() {
+    async fn apply_patch_tool_executor_accepts_raw_patch_string() {
+        let env = Arc::new(MutableMockSandbox::new(HashMap::new()));
+        let tool = make_apply_patch_tool();
+        let patch = "\
+*** Begin Patch
+*** Add File: hello.txt
++hello
+*** End Patch
+";
+        let ctx = ToolContext {
+            env,
+            cancel: CancellationToken::new(),
+            tool_env_provider: None,
+        };
+
+        let output = (tool.executor)(serde_json::json!(patch), ctx)
+            .await
+            .expect("raw custom patch should apply");
+
+        assert_eq!(
+            output,
+            "Success. Updated the following files:\nA hello.txt\n"
+        );
+    }
+
+    #[tokio::test]
+    async fn apply_patch_add_overwrites_existing_file_with_codex_summary() {
+        let mut files = HashMap::new();
+        files.insert("duplicate.txt".to_string(), "old content\n".to_string());
+        let env = MutableMockSandbox::new(files);
+        let patch = "\
+*** Begin Patch
+*** Add File: duplicate.txt
++new content
+*** End Patch";
+
+        let ops = parse_v4a_patch(patch).unwrap();
+        let result = apply_patch_operations(&ops, &env).await.unwrap();
+
+        assert_eq!(
+            result,
+            "Success. Updated the following files:\nA duplicate.txt\n"
+        );
+        assert_eq!(
+            env.read_file("duplicate.txt", None, None).await.unwrap(),
+            "new content\n"
+        );
+    }
+
+    #[test]
+    fn parse_update_file_hunk_rejects_empty_update() {
+        let patch = "\
+*** Begin Patch
+*** Update File: empty.txt
+*** End Patch";
+
+        let err = parse_v4a_patch(patch).expect_err("empty update hunk should be rejected");
+
+        assert!(err.contains("Update file hunk for path 'empty.txt' is empty"));
+    }
+
+    #[tokio::test]
+    async fn pure_addition_update_hunk_appends_before_final_newline() {
+        let mut files = HashMap::new();
+        files.insert("insert_only.txt".to_string(), "alpha\nomega\n".to_string());
+        let env = MutableMockSandbox::new(files);
+        let patch = "\
+*** Begin Patch
+*** Update File: insert_only.txt
+@@
++inserted
+*** End Patch";
+
+        let ops = parse_v4a_patch(patch).unwrap();
+        let result = apply_patch_operations(&ops, &env).await.unwrap();
+
+        assert_eq!(
+            result,
+            "Success. Updated the following files:\nM insert_only.txt\n"
+        );
+        assert_eq!(
+            env.read_file("insert_only.txt", None, None).await.unwrap(),
+            "alpha\nomega\ninserted\n"
+        );
+    }
+
+    #[tokio::test]
+    async fn update_normalizes_missing_trailing_newline() {
+        let mut files = HashMap::new();
+        files.insert(
+            "no_newline.txt".to_string(),
+            "no newline at end".to_string(),
+        );
+        let env = MutableMockSandbox::new(files);
+        let patch = "\
+*** Begin Patch
+*** Update File: no_newline.txt
+@@
+-no newline at end
++has newline now
+*** End Patch";
+
+        let ops = parse_v4a_patch(patch).unwrap();
+        apply_patch_operations(&ops, &env).await.unwrap();
+
+        assert_eq!(
+            env.read_file("no_newline.txt", None, None).await.unwrap(),
+            "has newline now\n"
+        );
+    }
+
+    #[test]
+    fn parse_rejects_text_before_patch_envelope() {
+        let patch = "\
+please apply this
+*** Begin Patch
+*** Add File: hello.txt
++hello
+*** End Patch";
+
+        let err = parse_v4a_patch(patch).expect_err("patch envelope must start on first line");
+
+        assert!(err.contains("The first line of the patch must be '*** Begin Patch'"));
+    }
+
+    #[tokio::test]
+    async fn apply_patch_error_reports_failed_context() {
         let mut files = HashMap::new();
         files.insert(
             "src/game.py".to_string(),
@@ -880,9 +1064,44 @@ mod tests {
         }];
 
         let err = apply_patch_operations(&ops, &env).await.unwrap_err();
-        assert!(err.contains("Could not find context line"));
-        assert!(err.contains("Current contents of src/game.py:"));
-        assert!(err.contains("1 | def real_fn():"));
+        assert_eq!(
+            err,
+            "Failed to find context 'def nonexistent():' in src/game.py"
+        );
+    }
+
+    #[tokio::test]
+    async fn update_missing_target_file_rejected() {
+        let env = MutableMockSandbox::new(HashMap::new());
+        let patch = "\
+*** Begin Patch
+*** Update File: missing.txt
+@@
+-old
++new
+*** End Patch";
+
+        let ops = parse_v4a_patch(patch).unwrap();
+        let err = apply_patch_operations(&ops, &env).await.unwrap_err();
+
+        assert!(err.contains("Failed to read file to update missing.txt"));
+    }
+
+    #[tokio::test]
+    async fn delete_missing_target_file_rejected() {
+        let env = MutableMockSandbox::new(HashMap::new());
+        let patch = "\
+*** Begin Patch
+*** Delete File: missing.txt
+*** End Patch";
+
+        let ops = parse_v4a_patch(patch).unwrap();
+        let err = apply_patch_operations(&ops, &env).await.unwrap_err();
+
+        assert_eq!(
+            err,
+            "Failed to delete file missing.txt: file does not exist"
+        );
     }
 
     // Phase 0: Forward-order hunk application
@@ -908,7 +1127,7 @@ mod tests {
                 ],
             },
         ];
-        let result = apply_hunks(content, &hunks).unwrap();
+        let result = apply_hunks("example.py", content, &hunks).unwrap();
         assert!(result.contains("return 1"));
         assert!(result.contains("return 2"));
         assert!(!result.contains("    pass"));
@@ -993,9 +1212,12 @@ mod tests {
                 Change::Add("    return 99".into()),
             ],
         }];
-        let result = apply_hunks(content, &hunks).unwrap();
+        let result = apply_hunks("example.py", content, &hunks).unwrap();
         // First "pass" should be untouched, second should be replaced
-        assert_eq!(result, "def foo():\n    pass\n\ndef bar():\n    return 99");
+        assert_eq!(
+            result,
+            "def foo():\n    pass\n\ndef bar():\n    return 99\n"
+        );
     }
 
     // Phase 4: *** Move to:
@@ -1049,11 +1271,11 @@ mod tests {
         }];
 
         let result = apply_patch_operations(&ops, &env).await.unwrap();
-        assert!(result.contains("Moved file"));
+        assert!(result.contains("M src/new.py"));
 
         // New path exists with updated content
         let content = env.read_file("src/new.py", None, None).await.unwrap();
-        assert_eq!(content, "def hello():\n    return 1");
+        assert_eq!(content, "def hello():\n    return 1\n");
 
         // Old path is deleted
         let old = env.read_file("src/old.py", None, None).await;
@@ -1071,9 +1293,9 @@ mod tests {
             end_of_file:  false,
             changes:      vec![Change::Add("extra".into())],
         }];
-        let result = apply_hunks(content, &hunks).unwrap();
+        let result = apply_hunks("example.txt", content, &hunks).unwrap();
         // Should match line 1 (exact), so "extra" inserted after "indented" (line 1)
-        assert_eq!(result, "  indented\nindented\nextra");
+        assert_eq!(result, "  indented\nindented\nextra\n");
     }
 
     #[test]
@@ -1084,7 +1306,7 @@ mod tests {
             end_of_file:  false,
             changes:      vec![Change::Add("print(\"world\")".into())],
         }];
-        let result = apply_hunks(content, &hunks).unwrap();
+        let result = apply_hunks("example.py", content, &hunks).unwrap();
         // Original line preserved, new line added after
         assert!(result.contains("print(\u{201C}hello\u{201D})"));
         assert!(result.contains("print(\"world\")"));
@@ -1240,7 +1462,7 @@ def main():
 +    return 42
 *** Delete File: src/old_util.py
 *** Update File: src/main.py
-@@ from old_util import old_helper
+@@
 -from old_util import old_helper
 +from new_util import new_helper
 @@ def main():
@@ -1252,12 +1474,12 @@ def main():
         let ops = parse_v4a_patch(patch).unwrap();
         let result = apply_patch_operations(&ops, &env).await.unwrap();
 
-        assert!(result.contains("Added file: src/new_util.py"));
-        assert!(result.contains("Deleted file: src/old_util.py"));
-        assert!(result.contains("Updated file: src/main.py"));
+        assert!(result.contains("A src/new_util.py"));
+        assert!(result.contains("D src/old_util.py"));
+        assert!(result.contains("M src/main.py"));
 
         let new_util = env.read_file("src/new_util.py", None, None).await.unwrap();
-        assert_eq!(new_util, "def new_helper():\n    return 42");
+        assert_eq!(new_util, "def new_helper():\n    return 42\n");
 
         assert!(env.read_file("src/old_util.py", None, None).await.is_err());
 
@@ -1313,7 +1535,7 @@ EOF";
         let ops = parse_v4a_patch(patch).unwrap();
         let result = apply_patch_operations(&ops, &env).await.unwrap();
 
-        assert!(result.contains("Moved file"));
+        assert!(result.contains("M src/models/account.py"));
 
         // Old path gone
         assert!(
@@ -1411,9 +1633,7 @@ def gamma():
     async fn e2e_through_tool_executor() {
         use crate::config::SessionOptions;
         use crate::session::Session;
-        use crate::test_support::{
-            MockLlmProvider, TestProfile, make_client, text_response, tool_call_response,
-        };
+        use crate::test_support::{MockLlmProvider, TestProfile, make_client, text_response};
         use crate::tool_registry::ToolRegistry;
 
         // Set up sandbox with a file
@@ -1429,6 +1649,10 @@ def farewell(name):
 "
             .to_string(),
         );
+        files.insert(
+            "src/obsolete.py".to_string(),
+            "def old():\n    pass\n".to_string(),
+        );
         let env = Arc::new(MutableMockSandbox::new(files));
 
         // Register apply_patch tool
@@ -1438,6 +1662,9 @@ def farewell(name):
         // The patch an LLM would produce (canonical format)
         let patch_text = "\
 *** Begin Patch
+*** Add File: src/created.py
++def created():
++    return \"created\"
 *** Update File: src/app.py
 @@ def greet(name):
 -    return f\"Hi, {name}\"
@@ -1445,14 +1672,29 @@ def farewell(name):
 @@ def farewell(name):
 -    return f\"Bye, {name}\"
 +    return f\"Goodbye, {name}!\"
+*** Delete File: src/obsolete.py
 *** End Patch";
 
+        let mut tool_call = ToolCall::new("call_1", "apply_patch", serde_json::json!(patch_text));
+        tool_call.tool_type = "custom".to_string();
+        tool_call.raw_arguments = Some(patch_text.to_string());
         let responses = vec![
-            tool_call_response(
-                "apply_patch",
-                "call_1",
-                serde_json::json!({"patch": patch_text}),
-            ),
+            Response {
+                id:            "resp_call_1".to_string(),
+                model:         "mock-model".to_string(),
+                provider:      "mock".to_string(),
+                message:       LlmMessage {
+                    role:         Role::Assistant,
+                    content:      vec![ContentPart::ToolCall(tool_call)],
+                    name:         None,
+                    tool_call_id: None,
+                },
+                finish_reason: FinishReason::ToolCalls,
+                usage:         TokenCounts::default(),
+                raw:           None,
+                warnings:      vec![],
+                rate_limit:    None,
+            },
             text_response("Done! Updated greet and farewell functions."),
         ];
 
@@ -1477,5 +1719,82 @@ def farewell(name):
         assert!(content.contains("Goodbye, {name}!"));
         assert!(!content.contains("Hi, {name}"));
         assert!(!content.contains("Bye, {name}"));
+
+        let created = env.read_file("src/created.py", None, None).await.unwrap();
+        assert!(created.contains("def created():"));
+        assert!(env.read_file("src/obsolete.py", None, None).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn failed_custom_tool_call_returns_codex_style_error_to_session_history() {
+        use crate::config::SessionOptions;
+        use crate::session::Session;
+        use crate::test_support::{MockLlmProvider, TestProfile, make_client, text_response};
+        use crate::tool_registry::ToolRegistry;
+        use crate::types::Message as AgentMessage;
+
+        let mut files = HashMap::new();
+        files.insert(
+            "src/app.py".to_string(),
+            "def present():\n    return 1\n".to_string(),
+        );
+        let env = Arc::new(MutableMockSandbox::new(files));
+
+        let mut registry = ToolRegistry::new();
+        registry.register(make_apply_patch_tool());
+
+        let patch_text = "\
+*** Begin Patch
+*** Update File: src/app.py
+@@ def missing():
+-    return 1
++    return 2
+*** End Patch";
+        let mut tool_call = ToolCall::new("call_1", "apply_patch", serde_json::json!(patch_text));
+        tool_call.tool_type = "custom".to_string();
+        tool_call.raw_arguments = Some(patch_text.to_string());
+
+        let responses = vec![
+            Response {
+                id:            "resp_call_1".to_string(),
+                model:         "mock-model".to_string(),
+                provider:      "mock".to_string(),
+                message:       LlmMessage {
+                    role:         Role::Assistant,
+                    content:      vec![ContentPart::ToolCall(tool_call)],
+                    name:         None,
+                    tool_call_id: None,
+                },
+                finish_reason: FinishReason::ToolCalls,
+                usage:         TokenCounts::default(),
+                raw:           None,
+                warnings:      vec![],
+                rate_limit:    None,
+            },
+            text_response("I will correct the patch."),
+        ];
+
+        let provider = Arc::new(MockLlmProvider::new(responses));
+        let client = make_client(provider).await;
+        let profile = Arc::new(TestProfile::with_tools(registry));
+        let mut session = Session::new(client, profile, env, SessionOptions::default(), None);
+        session.initialize().await.unwrap();
+        session
+            .process_input("Patch a missing function")
+            .await
+            .unwrap();
+
+        let turns = session.history().turns();
+        match &turns[2] {
+            AgentMessage::ToolResults { results, .. } => {
+                assert_eq!(results.len(), 1);
+                assert!(results[0].is_error);
+                assert_eq!(
+                    results[0].content.as_str(),
+                    Some("Failed to find context 'def missing():' in src/app.py")
+                );
+            }
+            other => panic!("expected tool result turn, got {other:?}"),
+        }
     }
 }

--- a/lib/crates/fabro-llm/src/providers/openai.rs
+++ b/lib/crates/fabro-llm/src/providers/openai.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use base64::Engine;
@@ -306,6 +307,7 @@ fn provider_error_from_openai_error_json(error: &serde_json::Value) -> Error {
 async fn translate_input(messages: &[Message]) -> (Option<String>, Vec<serde_json::Value>) {
     let mut instructions_parts: Vec<String> = Vec::new();
     let mut input: Vec<serde_json::Value> = Vec::new();
+    let mut tool_call_types: HashMap<String, (String, String)> = HashMap::new();
 
     for msg in messages {
         match msg.role {
@@ -386,10 +388,6 @@ async fn translate_input(messages: &[Message]) -> (Option<String>, Vec<serde_jso
                             }));
                         }
                         ContentPart::ToolCall(tc) if !tc.name.is_empty() => {
-                            let args = tc
-                                .raw_arguments
-                                .as_ref()
-                                .map_or_else(|| tc.arguments.to_string(), Clone::clone);
                             // Use the item-level ID (fc_xxx) for the `id` field;
                             // fall back to tc.id if no provider_metadata was stored.
                             let item_id = tc
@@ -398,13 +396,38 @@ async fn translate_input(messages: &[Message]) -> (Option<String>, Vec<serde_jso
                                 .and_then(|m| m.get("id"))
                                 .and_then(serde_json::Value::as_str)
                                 .unwrap_or(&tc.id);
-                            input.push(serde_json::json!({
-                                "type": "function_call",
-                                "id": item_id,
-                                "call_id": tc.id,
-                                "name": tc.name,
-                                "arguments": args,
-                            }));
+                            tool_call_types
+                                .insert(tc.id.clone(), (tc.tool_type.clone(), tc.name.clone()));
+                            if tc.tool_type == "custom" {
+                                let raw_input = tc.raw_arguments.as_ref().map_or_else(
+                                    || {
+                                        tc.arguments.as_str().map_or_else(
+                                            || tc.arguments.to_string(),
+                                            str::to_string,
+                                        )
+                                    },
+                                    Clone::clone,
+                                );
+                                input.push(serde_json::json!({
+                                    "type": "custom_tool_call",
+                                    "id": item_id,
+                                    "call_id": tc.id,
+                                    "name": tc.name,
+                                    "input": raw_input,
+                                }));
+                            } else {
+                                let args = tc
+                                    .raw_arguments
+                                    .as_ref()
+                                    .map_or_else(|| tc.arguments.to_string(), Clone::clone);
+                                input.push(serde_json::json!({
+                                    "type": "function_call",
+                                    "id": item_id,
+                                    "call_id": tc.id,
+                                    "name": tc.name,
+                                    "arguments": args,
+                                }));
+                            }
                         }
                         ContentPart::Other { data, .. } if part.is_opaque_openai() => {
                             input.push(data.clone());
@@ -420,12 +443,24 @@ async fn translate_input(messages: &[Message]) -> (Option<String>, Vec<serde_jso
                             .content
                             .as_str()
                             .map_or_else(|| tr.content.to_string(), str::to_string);
-                        let mut item = serde_json::json!({
-                            "type": "function_call_output",
-                            "call_id": tr.tool_call_id,
-                            "output": output,
-                        });
-                        if tr.is_error {
+                        let is_custom = tool_call_types
+                            .get(&tr.tool_call_id)
+                            .is_some_and(|(tool_type, _)| tool_type == "custom")
+                            || msg.name.as_deref() == Some("apply_patch");
+                        let mut item = if is_custom {
+                            serde_json::json!({
+                                "type": "custom_tool_call_output",
+                                "call_id": tr.tool_call_id,
+                                "output": output,
+                            })
+                        } else {
+                            serde_json::json!({
+                                "type": "function_call_output",
+                                "call_id": tr.tool_call_id,
+                                "output": output,
+                            })
+                        };
+                        if tr.is_error && !is_custom {
                             item["status"] = serde_json::json!("incomplete");
                         }
                         input.push(item);
@@ -449,12 +484,21 @@ fn translate_tools(tools: &[ToolDefinition]) -> Vec<serde_json::Value> {
     tools
         .iter()
         .map(|t| {
-            serde_json::json!({
-                "type": "function",
-                "name": t.name,
-                "description": t.description,
-                "parameters": t.parameters,
-            })
+            if t.is_custom() {
+                serde_json::json!({
+                    "type": "custom",
+                    "name": t.name,
+                    "description": t.description,
+                    "format": t.custom_format().cloned().unwrap_or_else(|| serde_json::json!({})),
+                })
+            } else {
+                serde_json::json!({
+                    "type": "function",
+                    "name": t.name,
+                    "description": t.description,
+                    "parameters": t.parameters,
+                })
+            }
         })
         .collect()
 }
@@ -656,6 +700,37 @@ fn parse_output(output: &[serde_json::Value]) -> (Vec<ContentPart>, bool) {
                 }
                 parts.push(ContentPart::ToolCall(tc));
             }
+            Some("custom_tool_call") => {
+                let item_id = item
+                    .get("id")
+                    .and_then(serde_json::Value::as_str)
+                    .unwrap_or("");
+                let call_id = item
+                    .get("call_id")
+                    .and_then(serde_json::Value::as_str)
+                    .unwrap_or(item_id)
+                    .to_string();
+                let name = item
+                    .get("name")
+                    .and_then(serde_json::Value::as_str)
+                    .unwrap_or("")
+                    .to_string();
+                if name.is_empty() {
+                    continue;
+                }
+                has_tool_calls = true;
+                let raw_input = item
+                    .get("input")
+                    .and_then(serde_json::Value::as_str)
+                    .unwrap_or("");
+                let mut tc = ToolCall::new(call_id, name, serde_json::json!(raw_input));
+                tc.tool_type = "custom".to_string();
+                tc.raw_arguments = Some(raw_input.to_string());
+                if !item_id.is_empty() {
+                    tc.provider_metadata = Some(serde_json::json!({"id": item_id}));
+                }
+                parts.push(ContentPart::ToolCall(tc));
+            }
             _ => {}
         }
     }
@@ -773,7 +848,10 @@ fn process_sse_event(
         "response.created" => handle_response_created(state, &json),
         "response.output_text.delta" => handle_text_delta(state, &json, &mut events),
         "response.function_call_arguments.delta" => {
-            handle_tool_call_delta(state, &json, &mut events);
+            handle_tool_call_delta(state, &json, &mut events, "function");
+        }
+        "response.custom_tool_call_input.delta" => {
+            handle_tool_call_delta(state, &json, &mut events, "custom");
         }
         "response.output_item.done" => handle_output_item_done(state, &json, &mut events),
         "response.completed" | "response.incomplete" => {
@@ -845,6 +923,7 @@ fn handle_tool_call_delta(
     state: &mut SseStreamState,
     json: &serde_json::Value,
     events: &mut Vec<StreamEvent>,
+    tool_type: &str,
 ) {
     let Some(delta) = json.get("delta").and_then(serde_json::Value::as_str) else {
         return;
@@ -871,6 +950,9 @@ fn handle_tool_call_delta(
     if let Some(idx) = tc_index {
         if let Some(ref mut raw) = state.tool_calls[idx].raw_arguments {
             raw.push_str(delta);
+            if tool_type == "custom" {
+                state.tool_calls[idx].arguments = serde_json::json!(raw.clone());
+            }
         }
     } else {
         let name = json
@@ -878,7 +960,16 @@ fn handle_tool_call_delta(
             .and_then(serde_json::Value::as_str)
             .unwrap_or("")
             .to_string();
-        let mut tc = ToolCall::new(lookup_id, name, serde_json::json!({}));
+        let mut tc = ToolCall::new(
+            lookup_id,
+            name,
+            if tool_type == "custom" {
+                serde_json::json!(delta)
+            } else {
+                serde_json::json!({})
+            },
+        );
+        tc.tool_type = tool_type.to_string();
         tc.raw_arguments = Some(delta.to_string());
         // Preserve item-level ID (fc_xxx) for Responses API round-trip
         if !item_id.is_empty() && item_id != *lookup_id {
@@ -897,6 +988,7 @@ fn handle_tool_call_delta(
 
     events.push(StreamEvent::ToolCallDelta {
         tool_call: ToolCall {
+            tool_type: tool_type.to_string(),
             raw_arguments: Some(delta.to_string()),
             ..current_tc
         },
@@ -963,6 +1055,46 @@ fn handle_output_item_done(
 
             if let Some(existing) = state.tool_calls.iter_mut().find(|t| t.id == call_id) {
                 existing.name.clone_from(&name);
+                existing.arguments = tc.arguments.clone();
+                existing.raw_arguments.clone_from(&tc.raw_arguments);
+                existing.provider_metadata.clone_from(&tc.provider_metadata);
+            } else {
+                state.tool_calls.push(tc.clone());
+            }
+
+            events.push(StreamEvent::ToolCallEnd { tool_call: tc });
+        }
+        Some("custom_tool_call") => {
+            let item = json.get("item").unwrap_or(json);
+            let item_id = item
+                .get("id")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or("");
+            let call_id = item
+                .get("call_id")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or(item_id)
+                .to_string();
+            let name = item
+                .get("name")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or("")
+                .to_string();
+            let raw_input = item
+                .get("input")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or("");
+
+            let mut tc = ToolCall::new(&call_id, &name, serde_json::json!(raw_input));
+            tc.tool_type = "custom".to_string();
+            tc.raw_arguments = Some(raw_input.to_string());
+            if !item_id.is_empty() {
+                tc.provider_metadata = Some(serde_json::json!({"id": item_id}));
+            }
+
+            if let Some(existing) = state.tool_calls.iter_mut().find(|t| t.id == call_id) {
+                existing.name.clone_from(&name);
+                existing.tool_type = "custom".to_string();
                 existing.arguments = tc.arguments.clone();
                 existing.raw_arguments.clone_from(&tc.raw_arguments);
                 existing.provider_metadata.clone_from(&tc.provider_metadata);
@@ -1205,7 +1337,7 @@ mod tests {
     use super::*;
     use crate::error::ProviderErrorKind;
     use crate::providers::common::LineReader;
-    use crate::types::{AudioData, DocumentData};
+    use crate::types::{AudioData, DocumentData, ToolResult};
 
     fn minimal_request() -> Request {
         Request {
@@ -1311,6 +1443,49 @@ mod tests {
             body["include"],
             serde_json::json!(["reasoning.encrypted_content"])
         );
+    }
+
+    #[tokio::test]
+    async fn build_request_body_emits_custom_apply_patch_tool() {
+        let mut request = minimal_request();
+        request.tools = Some(vec![
+            ToolDefinition::custom(
+                "apply_patch",
+                "Use the `apply_patch` tool to edit files. This is a FREEFORM tool, so do not wrap the patch in JSON.",
+                serde_json::json!({
+                    "type": "grammar",
+                    "syntax": "lark",
+                    "definition": "start: begin_patch hunk+ end_patch",
+                }),
+            ),
+            ToolDefinition::function(
+                "read_file",
+                "Read file",
+                serde_json::json!({
+                    "type": "object",
+                    "properties": {"file_path": {"type": "string"}},
+                    "required": ["file_path"],
+                }),
+            ),
+        ]);
+
+        let body = build_request_body(&request, false, false).await;
+        let tools = body["tools"].as_array().expect("tools should be present");
+        let apply_patch = tools
+            .iter()
+            .find(|tool| tool["name"] == "apply_patch")
+            .expect("apply_patch tool should be present");
+        let read_file = tools
+            .iter()
+            .find(|tool| tool["name"] == "read_file")
+            .expect("read_file tool should be present");
+
+        assert_eq!(apply_patch["type"], "custom");
+        assert_eq!(apply_patch["format"]["type"], "grammar");
+        assert_eq!(apply_patch["format"]["syntax"], "lark");
+        assert!(apply_patch.get("parameters").is_none());
+        assert_eq!(read_file["type"], "function");
+        assert_eq!(read_file["parameters"]["type"], "object");
     }
 
     #[tokio::test]
@@ -1465,6 +1640,38 @@ mod tests {
                     .as_ref()
                     .expect("provider_metadata should be set");
                 assert_eq!(meta["id"], "fc_abc123");
+            }
+            other => panic!("expected ToolCall, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_output_preserves_custom_tool_call_raw_input() {
+        let patch = "*** Begin Patch\n*** Add File: hello.txt\n+hello\n*** End Patch\n";
+        let output = vec![serde_json::json!({
+            "type": "custom_tool_call",
+            "id": "ctc_abc123",
+            "call_id": "call_xyz789",
+            "name": "apply_patch",
+            "input": patch,
+        })];
+
+        let (parts, has_tool_calls) = parse_output(&output);
+
+        assert!(has_tool_calls);
+        assert_eq!(parts.len(), 1);
+        match &parts[0] {
+            ContentPart::ToolCall(tc) => {
+                assert_eq!(tc.id, "call_xyz789");
+                assert_eq!(tc.name, "apply_patch");
+                assert_eq!(tc.tool_type, "custom");
+                assert_eq!(tc.arguments, serde_json::json!(patch));
+                assert_eq!(tc.raw_arguments.as_deref(), Some(patch));
+                let meta = tc
+                    .provider_metadata
+                    .as_ref()
+                    .expect("provider metadata should preserve item id");
+                assert_eq!(meta["id"], "ctc_abc123");
             }
             other => panic!("expected ToolCall, got {other:?}"),
         }
@@ -1711,6 +1918,85 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn custom_tool_call_history_round_trips_through_translate_input() {
+        let patch = "*** Begin Patch\n*** Delete File: stale.txt\n*** End Patch\n";
+        let mut tc = ToolCall::new("call_001", "apply_patch", serde_json::json!(patch));
+        tc.tool_type = "custom".to_string();
+        tc.raw_arguments = Some(patch.to_string());
+        tc.provider_metadata = Some(serde_json::json!({"id": "ctc_def456"}));
+
+        let msg = Message {
+            role:         Role::Assistant,
+            content:      vec![ContentPart::ToolCall(tc)],
+            name:         None,
+            tool_call_id: None,
+        };
+
+        let (_, input) = translate_input(&[msg]).await;
+
+        assert_eq!(input.len(), 1);
+        assert_eq!(input[0]["type"], "custom_tool_call");
+        assert_eq!(input[0]["id"], "ctc_def456");
+        assert_eq!(input[0]["call_id"], "call_001");
+        assert_eq!(input[0]["name"], "apply_patch");
+        assert_eq!(input[0]["input"], patch);
+    }
+
+    #[tokio::test]
+    async fn custom_tool_result_history_round_trips_through_translate_input() {
+        let msg = Message {
+            role:         Role::Tool,
+            content:      vec![ContentPart::ToolResult(ToolResult::success(
+                "call_001",
+                serde_json::json!("Success. Updated the following files:\nA hello.txt\n"),
+            ))],
+            name:         Some("apply_patch".to_string()),
+            tool_call_id: Some("call_001".to_string()),
+        };
+
+        let (_, input) = translate_input(&[msg]).await;
+
+        assert_eq!(input.len(), 1);
+        assert_eq!(input[0]["type"], "custom_tool_call_output");
+        assert_eq!(input[0]["call_id"], "call_001");
+        assert_eq!(
+            input[0]["output"],
+            "Success. Updated the following files:\nA hello.txt\n"
+        );
+    }
+
+    #[tokio::test]
+    async fn custom_tool_result_history_uses_prior_custom_call_without_tool_message_name() {
+        let patch = "*** Begin Patch\n*** Add File: hello.txt\n+hello\n*** End Patch\n";
+        let mut tc = ToolCall::new("call_001", "apply_patch", serde_json::json!(patch));
+        tc.tool_type = "custom".to_string();
+        tc.raw_arguments = Some(patch.to_string());
+        tc.provider_metadata = Some(serde_json::json!({"id": "ctc_def456"}));
+
+        let assistant_msg = Message {
+            role:         Role::Assistant,
+            content:      vec![ContentPart::ToolCall(tc)],
+            name:         None,
+            tool_call_id: None,
+        };
+        let tool_msg = Message::tool_result(
+            "call_001",
+            serde_json::json!("Success. Updated the following files:\nA hello.txt\n"),
+            false,
+        );
+
+        let (_, input) = translate_input(&[assistant_msg, tool_msg]).await;
+
+        assert_eq!(input.len(), 2);
+        assert_eq!(input[1]["type"], "custom_tool_call_output");
+        assert_eq!(input[1]["call_id"], "call_001");
+        assert_eq!(
+            input[1]["output"],
+            "Success. Updated the following files:\nA hello.txt\n"
+        );
+    }
+
+    #[tokio::test]
     async fn build_request_body_includes_stop_sequences() {
         let mut request = minimal_request();
         request.stop_sequences = Some(vec!["END".to_string(), "STOP".to_string()]);
@@ -1780,6 +2066,84 @@ mod tests {
         assert_eq!(state.usage.reasoning_tokens, 300);
         assert_eq!(state.usage.cache_write_tokens, 0);
         assert_eq!(state.usage.total_tokens(), 700);
+    }
+
+    #[test]
+    fn custom_tool_call_streaming_delta_accumulates_raw_input() {
+        let mut state = empty_sse_state();
+        let first = r#"{
+            "type": "response.custom_tool_call_input.delta",
+            "item_id": "ctc_abc",
+            "call_id": "call_001",
+            "delta": "*** Begin"
+        }"#;
+        let second = r#"{
+            "type": "response.custom_tool_call_input.delta",
+            "item_id": "ctc_abc",
+            "call_id": "call_001",
+            "delta": " Patch\n"
+        }"#;
+
+        let first_events = process_sse_event(
+            &mut state,
+            Some("response.custom_tool_call_input.delta"),
+            first,
+        )
+        .expect("first custom delta should parse");
+        let second_events = process_sse_event(
+            &mut state,
+            Some("response.custom_tool_call_input.delta"),
+            second,
+        )
+        .expect("second custom delta should parse");
+
+        assert!(matches!(
+            first_events.iter().find(|event| matches!(event, StreamEvent::ToolCallStart { .. })),
+            Some(StreamEvent::ToolCallStart { tool_call })
+                if tool_call.id == "call_001" && tool_call.tool_type == "custom"
+        ));
+        assert!(matches!(
+            second_events.last(),
+            Some(StreamEvent::ToolCallDelta { tool_call })
+                if tool_call.raw_arguments.as_deref() == Some(" Patch\n")
+                    && tool_call.tool_type == "custom"
+        ));
+        assert_eq!(
+            state.tool_calls[0].raw_arguments.as_deref(),
+            Some("*** Begin Patch\n")
+        );
+    }
+
+    #[test]
+    fn custom_tool_call_output_item_done_emits_tool_call_end() {
+        let mut state = empty_sse_state();
+        let patch = "*** Begin Patch\n*** Add File: hello.txt\n+hello\n*** End Patch\n";
+        let data = serde_json::json!({
+            "type": "response.output_item.done",
+            "item": {
+                "type": "custom_tool_call",
+                "id": "ctc_abc",
+                "call_id": "call_001",
+                "name": "apply_patch",
+                "input": patch,
+            }
+        });
+
+        let events = process_sse_event(
+            &mut state,
+            Some("response.output_item.done"),
+            &data.to_string(),
+        )
+        .expect("custom output item should parse");
+
+        assert!(matches!(
+            events.last(),
+            Some(StreamEvent::ToolCallEnd { tool_call })
+                if tool_call.id == "call_001"
+                    && tool_call.name == "apply_patch"
+                    && tool_call.tool_type == "custom"
+                    && tool_call.raw_arguments.as_deref() == Some(patch)
+        ));
     }
 
     #[test]

--- a/lib/crates/fabro-llm/src/tools.rs
+++ b/lib/crates/fabro-llm/src/tools.rs
@@ -211,26 +211,30 @@ pub async fn execute_all_tools_with_repair(
                     return ToolResult::error(call_id, format!("Unknown tool: {call_name}"));
                 };
 
-                let validated_args = match validate_tool_args(&args, &t.definition.parameters) {
-                    Ok(()) => args,
-                    Err(validation_error) => {
-                        debug!(tool = %call_name, "Tool call validation failed");
-                        if let Some(repair_fn) = repair {
-                            match repair_fn(call_clone, validation_error).await {
-                                Ok(repaired) => repaired,
-                                Err(repair_error) => {
-                                    warn!(tool = %call_name, "Tool call repair failed");
-                                    return ToolResult::error(
-                                        call_id,
-                                        format!("Tool call validation failed and repair failed: {repair_error}"),
-                                    );
+                let validated_args = if call_clone.tool_type == "custom" {
+                    args
+                } else {
+                    match validate_tool_args(&args, &t.definition.parameters) {
+                        Ok(()) => args,
+                        Err(validation_error) => {
+                            debug!(tool = %call_name, "Tool call validation failed");
+                            if let Some(repair_fn) = repair {
+                                match repair_fn(call_clone, validation_error).await {
+                                    Ok(repaired) => repaired,
+                                    Err(repair_error) => {
+                                        warn!(tool = %call_name, "Tool call repair failed");
+                                        return ToolResult::error(
+                                            call_id,
+                                            format!("Tool call validation failed and repair failed: {repair_error}"),
+                                        );
+                                    }
                                 }
+                            } else {
+                                return ToolResult::error(
+                                    call_id,
+                                    format!("Tool call validation failed: {validation_error}"),
+                                );
                             }
-                        } else {
-                            return ToolResult::error(
-                                call_id,
-                                format!("Tool call validation failed: {validation_error}"),
-                            );
                         }
                     }
                 };

--- a/lib/crates/fabro-llm/src/types.rs
+++ b/lib/crates/fabro-llm/src/types.rs
@@ -444,6 +444,53 @@ pub struct ToolDefinition {
     pub parameters:  serde_json::Value,
 }
 
+const CUSTOM_TOOL_TYPE_KEY: &str = "x-fabro-tool-type";
+const CUSTOM_TOOL_FORMAT_KEY: &str = "x-fabro-custom-tool-format";
+
+impl ToolDefinition {
+    #[must_use]
+    pub fn function(
+        name: impl Into<String>,
+        description: impl Into<String>,
+        parameters: serde_json::Value,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            description: description.into(),
+            parameters,
+        }
+    }
+
+    #[must_use]
+    pub fn custom(
+        name: impl Into<String>,
+        description: impl Into<String>,
+        format: impl Into<serde_json::Value>,
+    ) -> Self {
+        Self {
+            name:        name.into(),
+            description: description.into(),
+            parameters:  serde_json::json!({
+                CUSTOM_TOOL_TYPE_KEY: "custom",
+                CUSTOM_TOOL_FORMAT_KEY: format.into(),
+            }),
+        }
+    }
+
+    #[must_use]
+    pub fn is_custom(&self) -> bool {
+        self.parameters
+            .get(CUSTOM_TOOL_TYPE_KEY)
+            .and_then(serde_json::Value::as_str)
+            == Some("custom")
+    }
+
+    #[must_use]
+    pub fn custom_format(&self) -> Option<&serde_json::Value> {
+        self.parameters.get(CUSTOM_TOOL_FORMAT_KEY)
+    }
+}
+
 // --- 5.3 ToolChoice ---
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]


### PR DESCRIPTION
## Summary

OpenAI-profile agents now receive `apply_patch` as a Codex-compatible freeform custom tool instead of a JSON function with a `patch` field. The model sends raw patch text validated by the vendored Lark grammar, and Fabro round-trips OpenAI custom tool calls/results through the Responses API.

## What Changed

- Added `fabro-llm` support for function and custom tool definitions while preserving existing JSON function behavior for normal tools.
- Translated OpenAI custom tool calls, custom tool outputs, and streaming `response.custom_tool_call_input.delta` events into Fabro tool calls with raw arguments.
- Ported the Codex apply-patch grammar and adapted Codex-style patch parsing/application semantics to Fabro's `Sandbox` trait, including strict envelopes, fuzzy context matching, move/delete/add/update behavior, trailing-newline normalization, and Codex-style summaries/errors.
- Updated OpenAI agent prompt/tool registration so `apply_patch` is freeform, and skipped JSON-schema validation/repair for custom tool calls only.
- Updated file tracking to read Codex-style `A`/`M` result lines from successful patch output.

## Verification

- `cargo nextest run -p fabro-llm -p fabro-agent`
- `cargo +nightly-2026-04-14 fmt --check --all`
- `cargo +nightly-2026-04-14 clippy --no-deps -p fabro-llm -p fabro-agent --all-targets -- -D warnings`
- `git diff --check`

Note: the full non-`--no-deps` clippy command still surfaces an unrelated existing `fabro-sandbox` `large_enum_variant` warning in `lib/crates/fabro-sandbox/src/sandbox_spec.rs`.

---

[![Compound Engineering](https://img.shields.io/badge/Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with GPT-5 via [Codex](https://openai.com/codex)