### PR TITLE
MCP subprocesses do not receive interpolated env from `project.toml` or sandbox env

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2098,10 +2098,12 @@ dependencies = [
  "fabro-config",
  "fabro-http",
  "fabro-types",
+ "fabro-vault",
  "futures",
  "rmcp",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
  "tracing",
 ]

--- a/lib/crates/fabro-config/src/resolve/run.rs
+++ b/lib/crates/fabro-config/src/resolve/run.rs
@@ -370,14 +370,14 @@ pub(crate) fn resolve_mcp_entry(name: &str, entry: &McpEntryLayer) -> McpServerS
             command: resolve_mcp_command(script.as_ref(), command.as_ref()),
             env:     env
                 .iter()
-                .map(|(key, value)| (key.clone(), value.as_source()))
+                .map(|(key, value)| (key.clone(), resolve_or_source(value)))
                 .collect(),
         },
         McpEntryLayer::Http { url, headers, .. } => McpTransport::Http {
-            url:     url.as_source(),
+            url:     resolve_or_source(url),
             headers: headers
                 .iter()
-                .map(|(key, value)| (key.clone(), value.as_source()))
+                .map(|(key, value)| (key.clone(), resolve_or_source(value)))
                 .collect(),
         },
         McpEntryLayer::Sandbox {
@@ -391,7 +391,7 @@ pub(crate) fn resolve_mcp_entry(name: &str, entry: &McpEntryLayer) -> McpServerS
             port:    *port,
             env:     env
                 .iter()
-                .map(|(key, value)| (key.clone(), value.as_source()))
+                .map(|(key, value)| (key.clone(), resolve_or_source(value)))
                 .collect(),
         },
     };
@@ -432,11 +432,26 @@ fn resolve_mcp_command(
     command: Option<&Vec<InterpString>>,
 ) -> Vec<String> {
     if let Some(script) = script {
-        return vec!["sh".to_string(), "-c".to_string(), script.as_source()];
+        return vec![
+            "sh".to_string(),
+            "-c".to_string(),
+            resolve_or_source(script),
+        ];
     }
     command
-        .map(|command| command.iter().map(InterpString::as_source).collect())
+        .map(|command| command.iter().map(resolve_or_source).collect())
         .unwrap_or_default()
+}
+
+#[expect(
+    clippy::disallowed_methods,
+    reason = "MCP config interpolation uses process env for `{{ env.* }}` values, mirroring \
+              `fabro_workflow::operations::start::resolve_interp` for [run.sandbox.env]."
+)]
+fn resolve_or_source(value: &InterpString) -> String {
+    value
+        .resolve(|name| std::env::var(name).ok())
+        .map_or_else(|_| value.as_source(), |resolved| resolved.value)
 }
 
 fn resolve_hook(hook: &HookEntry, index: usize, errors: &mut Vec<ResolveError>) -> HookDefinition {

--- a/lib/crates/fabro-mcp/Cargo.toml
+++ b/lib/crates/fabro-mcp/Cargo.toml
@@ -33,3 +33,5 @@ rmcp = { workspace = true, features = [
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util", "macros"] }
+fabro-vault = { path = "../fabro-vault" }
+tempfile = "3"

--- a/lib/crates/fabro-mcp/tests/env_propagation.rs
+++ b/lib/crates/fabro-mcp/tests/env_propagation.rs
@@ -1,0 +1,301 @@
+//! Black-box tests that demonstrate the env-propagation gaps in
+//! `scotts_docs/issues/fabro-mcp-env-propagation.md`.
+//!
+//! Each test takes a TOML snippet that exercises one documented way of getting
+//! an env var to an MCP, resolves it through the same public API the CLI uses
+//! (`WorkflowSettingsBuilder::from_toml`), spawns the existing Python test MCP
+//! at `tests/test_mcp_server.py`, and asks the subprocess (via the
+//! `__env:KEY__` echo sentinel) what it actually sees in `os.environ`. The
+//! assertions encode the *user-facing expectation*, so each test fails today
+//! and will pass once the underlying bug is fixed.
+//!
+//! The MCP key name (`TARGET`) is intentionally distinct from any
+//! `{{ env.SOURCE_VAR }}` source key — `McpClient` runs with `clear_env=false`
+//! so the child inherits the parent's env, and a same-named source key would
+//! make the test pass by accident via inheritance instead of through the code
+//! path under test.
+
+use std::time::Duration;
+
+use fabro_config::WorkflowSettingsBuilder;
+use fabro_mcp::client::McpClient;
+use fabro_mcp::connection_manager::call_result_to_string;
+use fabro_types::settings::run::McpTransport;
+use fabro_vault::{SecretType, Vault};
+
+fn test_server_path() -> String {
+    format!("{}/tests/test_mcp_server.py", env!("CARGO_MANIFEST_DIR"))
+}
+
+fn settings_toml(server_path: &str, extra: &str) -> String {
+    format!(
+        r#"
+_version = 1
+
+[server.auth]
+methods = ["dev-token"]
+
+[run.agent.mcps.envcheck]
+type = "stdio"
+command = ["python3", "{server_path}"]
+
+{extra}
+"#
+    )
+}
+
+async fn mcp_observed_env(toml: &str, env_key: &str) -> String {
+    let settings =
+        WorkflowSettingsBuilder::from_toml(toml).expect("workflow settings should resolve");
+    let mcp = settings
+        .run
+        .agent
+        .mcps
+        .get("envcheck")
+        .expect("envcheck mcp should be present in resolved settings")
+        .clone();
+    let client = McpClient::new(&mcp).expect("McpClient::new should succeed");
+    client
+        .initialize(mcp.startup_timeout())
+        .await
+        .expect("MCP initialize");
+    let result = client
+        .call_tool(
+            "echo",
+            serde_json::json!({ "message": format!("__env:{env_key}__") }),
+            Duration::from_secs(5),
+        )
+        .await
+        .expect("echo tool call");
+    let observed = call_result_to_string(&result).expect("echo result string");
+    client.shutdown().await.expect("MCP shutdown");
+    observed
+}
+
+/// Baseline / working path: `[run.agent.mcps.*.env]` with a *literal* value
+/// (no template) reaches the MCP subprocess today. This test should PASS — it
+/// documents the only currently-working way to pass an env var to an MCP from
+/// `project.toml`. Note that the value is in plaintext in the TOML, which
+/// makes this unsuitable for secrets.
+#[tokio::test]
+async fn mcp_env_table_with_literal_value_propagates_to_subprocess() {
+    let expected = "baseline-literal-value";
+
+    let toml = settings_toml(
+        &test_server_path(),
+        &format!(
+            r#"[run.agent.mcps.envcheck.env]
+TARGET = "{expected}"
+"#
+        ),
+    );
+
+    let observed = mcp_observed_env(&toml, "TARGET").await;
+
+    assert_eq!(
+        observed, expected,
+        "literal values in [run.agent.mcps.envcheck.env] should reach the MCP \
+         subprocess via `cmd.envs(env)` in fabro_mcp::client. If this test \
+         fails, the baseline working path is broken.",
+    );
+}
+
+/// Finding 1: `[run.agent.mcps.*.env]` with `{{ env.X }}` should resolve to
+/// the parent process's value of `X` before the MCP child is spawned. Today
+/// `fabro_config::resolve::run::resolve_mcp_entry` collapses the value via
+/// `InterpString::as_source()`, so the literal template string is what reaches
+/// the subprocess.
+#[tokio::test]
+#[expect(
+    clippy::disallowed_methods,
+    reason = "this test verifies env-variable interpolation end-to-end; the source var must \
+              live in the parent process env. The name is unique to this test to avoid \
+              clashing with parallel tests in the same binary."
+)]
+async fn mcp_env_table_with_env_template_resolves_in_subprocess() {
+    let source_var = "FABRO_MCP_ENV_PROP_F1_SOURCE";
+    let expected = "finding-1-secret";
+    std::env::set_var(source_var, expected);
+
+    let toml = settings_toml(
+        &test_server_path(),
+        &format!(
+            r#"[run.agent.mcps.envcheck.env]
+TARGET = "{{{{ env.{source_var} }}}}"
+"#
+        ),
+    );
+
+    let observed = mcp_observed_env(&toml, "TARGET").await;
+    std::env::remove_var(source_var);
+
+    assert_eq!(
+        observed, expected,
+        "MCP subprocess saw TARGET={observed:?} but should see {expected:?}; \
+         [run.agent.mcps.envcheck.env] `{{{{ env.X }}}}` is not being resolved \
+         (Finding 1 in scotts_docs/issues/fabro-mcp-env-propagation.md)",
+    );
+}
+
+/// Finding 2 (literal value): `[run.sandbox.env]` is documented in
+/// `docs/public/execution/run-configuration.mdx` as the canonical way to set
+/// run-wide env. With no MCP-local `env` table at all, the MCP subprocess
+/// should still see the sandbox env. Today it sees nothing because
+/// `lib/crates/fabro-workflow/src/operations/start.rs:runtime_mcp_server`
+/// never merges `SandboxEnvSpec.toml_env` into the MCP transport.
+#[tokio::test]
+async fn sandbox_env_with_literal_value_propagates_to_mcp_subprocess() {
+    let expected = "finding-2-literal";
+
+    let toml = settings_toml(
+        &test_server_path(),
+        &format!(
+            r#"[run.sandbox.env]
+TARGET = "{expected}"
+"#
+        ),
+    );
+
+    let observed = mcp_observed_env(&toml, "TARGET").await;
+
+    assert_eq!(
+        observed, expected,
+        "MCP subprocess saw TARGET={observed:?} but should see {expected:?}; \
+         [run.sandbox.env] does not propagate to MCP children \
+         (Finding 2 in scotts_docs/issues/fabro-mcp-env-propagation.md)",
+    );
+}
+
+/// Finding 2 (interpolated): same as the previous test but the sandbox env
+/// value is itself a `{{ env.X }}` template. `[run.sandbox.env]` keeps
+/// `InterpString` to runtime, so the template is preserved through resolve;
+/// the gap is purely that the resolved value never reaches the MCP child.
+#[tokio::test]
+#[expect(
+    clippy::disallowed_methods,
+    reason = "test sets a unique parent env var to drive {{ env.X }} interpolation; see \
+              the rationale on mcp_env_table_with_env_template_resolves_in_subprocess."
+)]
+async fn sandbox_env_with_env_template_propagates_to_mcp_subprocess() {
+    let source_var = "FABRO_MCP_ENV_PROP_F2_SOURCE";
+    let expected = "finding-2-interpolated";
+    std::env::set_var(source_var, expected);
+
+    let toml = settings_toml(
+        &test_server_path(),
+        &format!(
+            r#"[run.sandbox.env]
+TARGET = "{{{{ env.{source_var} }}}}"
+"#
+        ),
+    );
+
+    let observed = mcp_observed_env(&toml, "TARGET").await;
+    std::env::remove_var(source_var);
+
+    assert_eq!(
+        observed, expected,
+        "MCP subprocess saw TARGET={observed:?} but should see {expected:?}; \
+         [run.sandbox.env] `{{{{ env.X }}}}` is not being resolved into MCP children \
+         (Finding 2 in scotts_docs/issues/fabro-mcp-env-propagation.md)",
+    );
+}
+
+/// Finding 1 — sandbox transport variant. `type = "sandbox"` MCPs run inside
+/// the workflow's Docker/Daytona container; their `env` is passed via
+/// `sandbox.exec_command(..., env_ref, ...)` and ultimately `docker exec -e`.
+/// The same `as_source()` bug in
+/// `fabro_config::resolve::run::resolve_mcp_entry` (the `Sandbox` arm at
+/// `lib/crates/fabro-config/src/resolve/run.rs:392-395`) means templates are
+/// not resolved for sandbox MCPs either.
+///
+/// This test stops at the config layer rather than spawning a real container
+/// — it asserts the resolved `McpTransport::Sandbox.env` contains the
+/// resolved value, which is what `sandbox.exec_command` would forward.
+#[tokio::test]
+#[expect(
+    clippy::disallowed_methods,
+    reason = "same rationale as the stdio template tests above"
+)]
+async fn sandbox_mcp_env_table_with_env_template_resolves_at_config_layer() {
+    let source_var = "FABRO_MCP_ENV_PROP_SANDBOX_F1_SOURCE";
+    let expected = "sandbox-finding-1-secret";
+    std::env::set_var(source_var, expected);
+
+    let toml = format!(
+        r#"
+_version = 1
+
+[server.auth]
+methods = ["dev-token"]
+
+[run.agent.mcps.envcheck]
+type    = "sandbox"
+command = ["python3", "/unused/in/this/test.py"]
+port    = 3100
+
+[run.agent.mcps.envcheck.env]
+TARGET = "{{{{ env.{source_var} }}}}"
+"#
+    );
+
+    let settings =
+        WorkflowSettingsBuilder::from_toml(&toml).expect("workflow settings should resolve");
+    let mcp = settings
+        .run
+        .agent
+        .mcps
+        .get("envcheck")
+        .expect("envcheck mcp should be present");
+    let resolved = match &mcp.transport {
+        McpTransport::Sandbox { env, .. } => env.get("TARGET").cloned().unwrap_or_default(),
+        other => panic!("expected Sandbox transport, got {other:?}"),
+    };
+    std::env::remove_var(source_var);
+
+    assert_eq!(
+        resolved, expected,
+        "Sandbox McpTransport.env contained TARGET={resolved:?} but should hold {expected:?}; \
+         [run.agent.mcps.X.env] `{{{{ env.X }}}}` is not being resolved for sandbox transport \
+         either (Finding 1 variant in scotts_docs/issues/fabro-mcp-env-propagation.md)",
+    );
+}
+
+/// Finding 3: `fabro secret set --type environment TARGET hunter2` puts the
+/// secret in the vault (the only persistent place it lives), but no code path
+/// reads the vault when launching an MCP child. The user-facing expectation
+/// — secrets of type=environment are available to MCPs without further
+/// configuration — is encoded as this assertion. Today: fails with TARGET="".
+#[tokio::test]
+async fn fabro_secret_environment_type_propagates_to_mcp_subprocess() {
+    let expected = "finding-3-secret";
+
+    // Mirror what `fabro secret set TARGET <value> --type environment` does
+    // internally: load the vault and call `Vault::set`. This is the same
+    // SecretType::Environment storage path the CLI uses.
+    let vault_dir = tempfile::tempdir().expect("vault tempdir");
+    let mut vault = Vault::load(vault_dir.path().join("secrets.json")).expect("vault should load");
+    vault
+        .set("TARGET", expected, SecretType::Environment, None)
+        .expect("vault set should succeed");
+    assert_eq!(
+        vault.get("TARGET"),
+        Some(expected),
+        "vault should hold the secret we just stored",
+    );
+
+    // Plain MCP config with NO `env` table and NO `[run.sandbox.env]` — the
+    // user relies entirely on `fabro secret set` to get the value to the MCP.
+    let toml = settings_toml(&test_server_path(), "");
+    let observed = mcp_observed_env(&toml, "TARGET").await;
+
+    assert_eq!(
+        observed,
+        expected,
+        "MCP subprocess saw TARGET={observed:?} but should see {expected:?}; \
+         secrets of SecretType::Environment do not auto-inject into MCP child env \
+         (Finding 3 in scotts_docs/issues/fabro-mcp-env-propagation.md). \
+         The vault contains TARGET={:?}, but nothing in the MCP launch path consults it.",
+        vault.get("TARGET"),
+    );
+}


### PR DESCRIPTION
## Summary

While trying to give a custom Gemini MCP a real `GEMINI_API_KEY`, I ran into
the same wall on every documented `project.toml` path — templates leaked
through as literal strings, `[run.sandbox.env]` never reached the MCP, and
`fabro secret set --type environment` populated the vault but nothing read it
on MCP launch. Wrapper-script-with-sibling-`.env` is the only thing that
I could get working today.

This PR is partly a fix and partly a discussion-starter: it adds a single failing test
per entry point (so we can talk about each one concretely), and folds in the
one cheap fix that doesn't require any product decisions. The remaining red
tests are placeholders for that discussion — see **Conversation** below.

## Changes

- New: `lib/crates/fabro-mcp/tests/env_propagation.rs` — 6 black-box tests that
  exercise different ways to feed an env var to an MCP. Each test parses
  a project.toml snippet through the public `WorkflowSettingsBuilder::from_toml`
  API, spawns the existing `test_mcp_server.py` via `McpClient`, and asks the
  subprocess via the `__env:KEY__` echo sentinel what env it actually saw.
- Fix: `lib/crates/fabro-config/src/resolve/run.rs` — `resolve_mcp_entry` was
  collapsing every interpolated MCP field via `InterpString::as_source()`, so
  `{{ env.X }}` templates leaked through as literal strings. New
  `resolve_or_source` helper mirrors `fabro_workflow::operations::start::resolve_interp`:
  try `InterpString::resolve(process_env_var)`, fall back to `as_source()` when
  the env var is unset (so existing tests that don't seed the env still pass).
  Applies to `Stdio.env`, `Sandbox.env`, `Http.url`, `Http.headers`, and the
  script/command args of both stdio and sandbox transports.
- Dev-deps: `fabro-vault` and `tempfile` added to `fabro-mcp/Cargo.toml` for
  the Finding 3 test.

## Verification

```
$ cargo test -p fabro-mcp --test env_propagation

mcp_env_table_with_literal_value_propagates_to_subprocess              PASS  baseline
mcp_env_table_with_env_template_resolves_in_subprocess                 PASS  F1 stdio (fixed)
sandbox_mcp_env_table_with_env_template_resolves_at_config_layer       PASS  F1 sandbox (fixed)
sandbox_env_with_literal_value_propagates_to_mcp_subprocess            FAIL  see Conversation
sandbox_env_with_env_template_propagates_to_mcp_subprocess             FAIL  see Conversation
fabro_secret_environment_type_propagates_to_mcp_subprocess             FAIL  see Conversation
```

Also confirmed `cargo test -p fabro-config resolve_preserves_source_templates_for_mcp_and_hook_strings`
still passes — the fallback semantics preserve the existing behavior whenever
the referenced env var isn't set.

## Conversation

The three failing tests below are deliberate placeholders. I'd love feedback on
whether each is a bug we should fix here, or whether it warrants a product
decision first.

### `sandbox_env_with_literal_value_propagates_to_mcp_subprocess` (Finding 2, literal)

```
left:  ""
right: "finding-2-literal"
```

`docs/public/execution/run-configuration.mdx` documents `[run.sandbox.env]`
as the canonical run-wide env knob, with no caveat about MCPs. Today the
resolved sandbox env is fed into `WorkflowToolEnvProvider` for agent tools
and never threaded into `runtime_mcp_server` at
`lib/crates/fabro-workflow/src/operations/start.rs:650-673`. Is this intentional? Solution would be to merge `SandboxEnvSpec.toml_env` into the MCP transport's
env before handing to `McpClient`, with the MCP-local table winning on
conflict. **Fix here, or split into a follow-up?**

### `sandbox_env_with_env_template_propagates_to_mcp_subprocess` (Finding 2, interpolated)

Same gap, with the additional layer that the user wrote `{{ env.X }}`. Fixed
by the same wiring change as above — the template resolution already happens
upstream in `build_sandbox_env`.

### `fabro_secret_environment_type_propagates_to_mcp_subprocess` (Finding 3)

```
left:  ""
right: "finding-3-secret"
note:  vault contains TARGET=Some("finding-3-secret"), but nothing in the
       MCP launch path consults it.
```

This is the one that probably wants a product decision. Today `Vault::snapshot()`
(the function that filters `SecretType::Environment`) has zero production
callers — secrets are read by name via `Vault::get(name)` for LLM provider
auth only (`fabro-auth/src/resolve.rs:299`), so is `--type environment`
really intended as a storage-shape tag rather than a behavioral switch?

Reasonable options:
1. Auto-inject all environment-type secrets into MCP env. Easy, but every MCP would see every secret.
2. Opt-in scoping, e.g. `[run.agent.mcps.X.secrets] = ["GEMINI_API_KEY"]`.
3. A new interpolation token, e.g. `{{ secret.X }}`, that resolves from the vault — keeps explicit naming, parallels `{{ env.X }}`.

I'm partial to (2) or (3) but happy to defer to whatever you think fits
Fabro's secrets model.

---

Happy to iterate, split into smaller PRs, or rebase any of this. Mostly
hoping the failing tests give us a concrete shared artifact to talk against.