### PR TITLE
Add legacy SSE MCP transport support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2099,6 +2099,7 @@ name = "fabro-mcp"
 version = "0.243.0-nightly.1"
 dependencies = [
  "anyhow",
+ "axum",
  "fabro-config",
  "fabro-http",
  "fabro-types",
@@ -2107,6 +2108,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tokio-stream",
  "tracing",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2107,6 +2107,8 @@ dependencies = [
  "rmcp",
  "serde",
  "serde_json",
+ "sse-stream",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
 tokio = { version = "1", features = ["full"] }
 reqwest = { version = "0.13", default-features = false, features = ["json", "stream", "rustls", "query", "form", "multipart"] }
+sse-stream = "0.2"
 ulid = "1"
 uuid = { version = "1", features = ["v4", "v7", "v8"] }
 rand = "0.9"

--- a/docs/public/agents/mcp.mdx
+++ b/docs/public/agents/mcp.mdx
@@ -145,6 +145,7 @@ Authorization = "Bearer sk-xxx"
 | Field | Description | Default |
 |---|---|---|
 | `type` | Must be `"http"`. | — |
+| `protocol` | HTTP MCP protocol: `"streamable_http"` or legacy `"sse"`. | `"streamable_http"` |
 | `url` | The MCP server endpoint URL. | — |
 | `headers` | Optional HTTP headers (e.g., for authentication). | `{}` |
 | `startup_timeout` | Max duration to wait for the MCP handshake. | `"10s"` |
@@ -157,6 +158,7 @@ Runs the MCP server inside the workflow's sandbox (e.g., a [Daytona](/integratio
 ```toml
 [run.agent.mcps.playwright]
 type = "sandbox"
+protocol = "sse"
 command = ["npx", "@playwright/mcp@latest", "--port", "3100", "--headless", "--browser", "chromium"]
 port = 3100
 startup_timeout = "60s"
@@ -166,6 +168,7 @@ tool_timeout = "2m"
 | Field | Description | Default |
 |---|---|---|
 | `type` | Must be `"sandbox"`. | — |
+| `protocol` | HTTP MCP protocol exposed by the sandbox server: `"streamable_http"` or legacy `"sse"`. | `"streamable_http"` |
 | `command` | Array: the command to run inside the sandbox. Must include a flag that makes the server listen on `port`. | — |
 | `script` | Shell script alternative to `command`. | — |
 | `port` | The port the MCP server listens on inside the sandbox. | — |
@@ -244,6 +247,7 @@ include = ["screenshots/**"]
 
 [run.agent.mcps.playwright]
 type = "sandbox"
+protocol = "sse"
 command = ["npx", "@playwright/mcp@latest", "--port", "3100", "--headless", "--browser", "chromium"]
 port = 3100
 startup_timeout = "60s"

--- a/lib/crates/fabro-agent/src/session.rs
+++ b/lib/crates/fabro-agent/src/session.rs
@@ -733,10 +733,17 @@ impl Session {
     fn sandbox_mcp_http_url(protocol: McpHttpProtocol, preview_url: &str) -> String {
         match protocol {
             McpHttpProtocol::StreamableHttp => preview_url.to_string(),
-            McpHttpProtocol::Sse => fabro_http::Url::parse(preview_url)
-                .ok()
-                .and_then(|url| url.join("sse").ok())
-                .map_or_else(|| preview_url.to_string(), |url| url.to_string()),
+            McpHttpProtocol::Sse => {
+                #[expect(
+                    clippy::disallowed_types,
+                    reason = "internal preview URL path joining; no raw URL is logged or included in errors"
+                )]
+                let url = fabro_http::Url::parse(preview_url)
+                    .ok()
+                    .and_then(|url| url.join("sse").ok());
+
+                url.map_or_else(|| preview_url.to_string(), |url| url.to_string())
+            }
         }
     }
 

--- a/lib/crates/fabro-agent/src/session.rs
+++ b/lib/crates/fabro-agent/src/session.rs
@@ -14,8 +14,9 @@ use fabro_llm::types::{
     TokenCounts, ToolChoice,
 };
 use fabro_llm::{Error as LlmError, retry};
-use fabro_mcp::config::{McpHttpProtocol, McpServerSettings, McpTransport};
+use fabro_mcp::config::{McpServerSettings, McpTransport};
 use fabro_mcp::connection_manager::McpConnectionManager;
+use fabro_mcp::http_transport;
 use fabro_model::{AgentProfileKind, Catalog, ModelRef, Speed};
 use fabro_types::{
     PermissionLevel, Principal, SessionMessage, SessionRecord, StageContextWindowProjection,
@@ -690,7 +691,8 @@ impl Session {
                         .await?
                     {
                         Ok((url, headers)) => {
-                            let url = Self::sandbox_mcp_http_url(*protocol, &url);
+                            let url = http_transport::sandbox_mcp_http_url(*protocol, &url)
+                                .map_err(|err| Error::InvalidState(err.to_string()))?;
                             info!(
                                 server = %config.name,
                                 url = %url,
@@ -728,23 +730,6 @@ impl Session {
         }
 
         Ok(resolved)
-    }
-
-    fn sandbox_mcp_http_url(protocol: McpHttpProtocol, preview_url: &str) -> String {
-        match protocol {
-            McpHttpProtocol::StreamableHttp => preview_url.to_string(),
-            McpHttpProtocol::Sse => {
-                #[expect(
-                    clippy::disallowed_types,
-                    reason = "internal preview URL path joining; no raw URL is logged or included in errors"
-                )]
-                let url = fabro_http::Url::parse(preview_url)
-                    .ok()
-                    .and_then(|url| url.join("sse").ok());
-
-                url.map_or_else(|| preview_url.to_string(), |url| url.to_string())
-            }
-        }
     }
 
     /// Start an MCP server inside the sandbox and return (url, headers) for

--- a/lib/crates/fabro-agent/src/session.rs
+++ b/lib/crates/fabro-agent/src/session.rs
@@ -14,7 +14,7 @@ use fabro_llm::types::{
     TokenCounts, ToolChoice,
 };
 use fabro_llm::{Error as LlmError, retry};
-use fabro_mcp::config::{McpServerSettings, McpTransport};
+use fabro_mcp::config::{McpHttpProtocol, McpServerSettings, McpTransport};
 use fabro_mcp::connection_manager::McpConnectionManager;
 use fabro_model::{AgentProfileKind, Catalog, ModelRef, Speed};
 use fabro_types::{
@@ -678,13 +678,19 @@ impl Session {
                 return Err(Error::Interrupted(InterruptReason::Cancelled));
             }
             match &config.transport {
-                McpTransport::Sandbox { command, port, env } => {
+                McpTransport::Sandbox {
+                    protocol,
+                    command,
+                    port,
+                    env,
+                } => {
                     let port = *port;
                     match self
                         .start_sandbox_mcp_server(command, port, env, cancel_token)
                         .await?
                     {
                         Ok((url, headers)) => {
+                            let url = Self::sandbox_mcp_http_url(*protocol, &url);
                             info!(
                                 server = %config.name,
                                 url = %url,
@@ -692,7 +698,11 @@ impl Session {
                             );
                             resolved.push(McpServerSettings {
                                 name:                 config.name.clone(),
-                                transport:            McpTransport::Http { url, headers },
+                                transport:            McpTransport::Http {
+                                    protocol: *protocol,
+                                    url,
+                                    headers,
+                                },
                                 current_dir:          config.current_dir.clone(),
                                 clear_env:            config.clear_env,
                                 startup_timeout_secs: config.startup_timeout_secs,
@@ -718,6 +728,16 @@ impl Session {
         }
 
         Ok(resolved)
+    }
+
+    fn sandbox_mcp_http_url(protocol: McpHttpProtocol, preview_url: &str) -> String {
+        match protocol {
+            McpHttpProtocol::StreamableHttp => preview_url.to_string(),
+            McpHttpProtocol::Sse => fabro_http::Url::parse(preview_url)
+                .ok()
+                .and_then(|url| url.join("sse").ok())
+                .map_or_else(|| preview_url.to_string(), |url| url.to_string()),
+        }
     }
 
     /// Start an MCP server inside the sandbox and return (url, headers) for

--- a/lib/crates/fabro-config/src/layers/run.rs
+++ b/lib/crates/fabro-config/src/layers/run.rs
@@ -3,7 +3,7 @@
 use std::collections::HashMap;
 
 use fabro_types::settings::run::{
-    AgentPermissions, ApprovalMode, HookEvent, MergeStrategy, RunMode,
+    AgentPermissions, ApprovalMode, HookEvent, McpHttpProtocol, MergeStrategy, RunMode,
 };
 use fabro_types::settings::{Duration, InterpString, ModelRef};
 use serde::{Deserialize, Serialize};
@@ -424,6 +424,8 @@ pub enum McpEntryLayer {
     Http {
         #[serde(default)]
         enabled:         Option<bool>,
+        #[serde(default)]
+        protocol:        McpHttpProtocol,
         url:             InterpString,
         #[serde(default)]
         headers:         HashMap<String, InterpString>,
@@ -449,6 +451,8 @@ pub enum McpEntryLayer {
     Sandbox {
         #[serde(default)]
         enabled:         Option<bool>,
+        #[serde(default)]
+        protocol:        McpHttpProtocol,
         #[serde(default)]
         script:          Option<InterpString>,
         #[serde(default)]

--- a/lib/crates/fabro-config/src/resolve/mod.rs
+++ b/lib/crates/fabro-config/src/resolve/mod.rs
@@ -54,7 +54,7 @@ pub(crate) fn default_interp(path: impl AsRef<std::path::Path>) -> InterpString 
 mod tests {
     use std::collections::HashMap;
 
-    use fabro_types::settings::run::{HookType, McpTransport, TlsMode};
+    use fabro_types::settings::run::{HookType, McpHttpProtocol, McpTransport, TlsMode};
 
     use crate::{SettingsLayer, WorkflowSettingsBuilder};
 
@@ -117,7 +117,7 @@ Authorization = "Bearer {{ env.HOOK_TOKEN }}"
         assert_eq!(
             mcps.get("http").map(|mcp| &mcp.transport),
             Some(&McpTransport::Http {
-                protocol: Default::default(),
+                protocol: McpHttpProtocol::default(),
                 url:      "https://mcp.example.com".to_string(),
                 headers:  HashMap::from([(
                     "Authorization".to_string(),
@@ -128,7 +128,7 @@ Authorization = "Bearer {{ env.HOOK_TOKEN }}"
         assert_eq!(
             mcps.get("sandbox").map(|mcp| &mcp.transport),
             Some(&McpTransport::Sandbox {
-                protocol: Default::default(),
+                protocol: McpHttpProtocol::default(),
                 command:  vec!["fabro-mcp".to_string(), "--sandbox".to_string()],
                 port:     3333,
                 env:      HashMap::from([(

--- a/lib/crates/fabro-config/src/resolve/mod.rs
+++ b/lib/crates/fabro-config/src/resolve/mod.rs
@@ -117,8 +117,9 @@ Authorization = "Bearer {{ env.HOOK_TOKEN }}"
         assert_eq!(
             mcps.get("http").map(|mcp| &mcp.transport),
             Some(&McpTransport::Http {
-                url:     "https://mcp.example.com".to_string(),
-                headers: HashMap::from([(
+                protocol: Default::default(),
+                url:      "https://mcp.example.com".to_string(),
+                headers:  HashMap::from([(
                     "Authorization".to_string(),
                     "Bearer {{ env.MCP_HTTP_TOKEN }}".to_string(),
                 )]),
@@ -127,9 +128,10 @@ Authorization = "Bearer {{ env.HOOK_TOKEN }}"
         assert_eq!(
             mcps.get("sandbox").map(|mcp| &mcp.transport),
             Some(&McpTransport::Sandbox {
-                command: vec!["fabro-mcp".to_string(), "--sandbox".to_string()],
-                port:    3333,
-                env:     HashMap::from([(
+                protocol: Default::default(),
+                command:  vec!["fabro-mcp".to_string(), "--sandbox".to_string()],
+                port:     3333,
+                env:      HashMap::from([(
                     "TOKEN".to_string(),
                     "{{ env.MCP_SANDBOX_TOKEN }}".to_string(),
                 )]),

--- a/lib/crates/fabro-config/src/resolve/run.rs
+++ b/lib/crates/fabro-config/src/resolve/run.rs
@@ -295,23 +295,31 @@ pub(crate) fn resolve_mcp_entry(name: &str, entry: &McpEntryLayer) -> McpServerS
                 .map(|(key, value)| (key.clone(), value.as_source()))
                 .collect(),
         },
-        McpEntryLayer::Http { url, headers, .. } => McpTransport::Http {
-            url:     url.as_source(),
-            headers: headers
+        McpEntryLayer::Http {
+            protocol,
+            url,
+            headers,
+            ..
+        } => McpTransport::Http {
+            protocol: *protocol,
+            url:      url.as_source(),
+            headers:  headers
                 .iter()
                 .map(|(key, value)| (key.clone(), value.as_source()))
                 .collect(),
         },
         McpEntryLayer::Sandbox {
+            protocol,
             script,
             command,
             port,
             env,
             ..
         } => McpTransport::Sandbox {
-            command: resolve_mcp_command(script.as_ref(), command.as_ref()),
-            port:    *port,
-            env:     env
+            protocol: *protocol,
+            command:  resolve_mcp_command(script.as_ref(), command.as_ref()),
+            port:     *port,
+            env:      env
                 .iter()
                 .map(|(key, value)| (key.clone(), value.as_source()))
                 .collect(),

--- a/lib/crates/fabro-mcp/Cargo.toml
+++ b/lib/crates/fabro-mcp/Cargo.toml
@@ -32,4 +32,6 @@ rmcp = { workspace = true, features = [
 ] }
 
 [dev-dependencies]
+axum.workspace = true
 tokio = { workspace = true, features = ["test-util", "macros"] }
+tokio-stream.workspace = true

--- a/lib/crates/fabro-mcp/Cargo.toml
+++ b/lib/crates/fabro-mcp/Cargo.toml
@@ -22,6 +22,8 @@ serde_json.workspace = true
 tokio.workspace = true
 futures.workspace = true
 tracing.workspace = true
+thiserror.workspace = true
+sse-stream.workspace = true
 rmcp = { workspace = true, features = [
     "client",
     "macros",

--- a/lib/crates/fabro-mcp/src/client.rs
+++ b/lib/crates/fabro-mcp/src/client.rs
@@ -102,11 +102,7 @@ impl McpClient {
                     }
                     McpHttpProtocol::Sse => {
                         let headers = headers_from_pairs(headers)?;
-                        PendingTransport::Sse(SseClientTransport::new(
-                            url.clone(),
-                            headers,
-                            http_client,
-                        )?)
+                        PendingTransport::Sse(SseClientTransport::new(url, headers, http_client)?)
                     }
                 }
             }

--- a/lib/crates/fabro-mcp/src/client.rs
+++ b/lib/crates/fabro-mcp/src/client.rs
@@ -3,7 +3,6 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::{Context as _, Result, anyhow};
-use fabro_http::{HeaderMap, HeaderName, HeaderValue};
 use rmcp::model::{CallToolRequestParams, CallToolResult};
 use rmcp::service::{RoleClient, RunningService, serve_client};
 use rmcp::transport::StreamableHttpClientTransport;
@@ -16,7 +15,8 @@ use tracing::{debug, error, info, warn};
 
 use crate::client_handler::LoggingClientHandler;
 use crate::config::{McpHttpProtocol, McpServerSettings, McpTransport};
-use crate::sse_client::{SseClientTransport, headers_from_pairs};
+use crate::http_transport::headers_from_pairs;
+use crate::sse_client::SseClientTransport;
 
 enum ClientState {
     /// Transport created but handshake not yet performed.
@@ -78,17 +78,10 @@ impl McpClient {
                 url,
                 headers,
             } => {
+                let headers = headers_from_pairs(headers)?;
                 let mut builder = fabro_http::HttpClientBuilder::new();
                 if !headers.is_empty() {
-                    let mut header_map = HeaderMap::new();
-                    for (key, value) in headers {
-                        let name = HeaderName::from_bytes(key.as_bytes())
-                            .with_context(|| format!("invalid header name '{key}'"))?;
-                        let val = HeaderValue::from_str(value)
-                            .with_context(|| format!("invalid header value for '{key}'"))?;
-                        header_map.insert(name, val);
-                    }
-                    builder = builder.default_headers(header_map);
+                    builder = builder.default_headers(headers);
                 }
 
                 let http_client = builder.build()?;
@@ -101,8 +94,7 @@ impl McpClient {
                         PendingTransport::Http(transport)
                     }
                     McpHttpProtocol::Sse => {
-                        let headers = headers_from_pairs(headers)?;
-                        PendingTransport::Sse(SseClientTransport::new(url, headers, http_client)?)
+                        PendingTransport::Sse(SseClientTransport::new(url, http_client)?)
                     }
                 }
             }

--- a/lib/crates/fabro-mcp/src/client.rs
+++ b/lib/crates/fabro-mcp/src/client.rs
@@ -15,7 +15,8 @@ use tokio::time;
 use tracing::{debug, error, info, warn};
 
 use crate::client_handler::LoggingClientHandler;
-use crate::config::{McpServerSettings, McpTransport};
+use crate::config::{McpHttpProtocol, McpServerSettings, McpTransport};
+use crate::sse_client::{SseClientTransport, headers_from_pairs};
 
 enum ClientState {
     /// Transport created but handshake not yet performed.
@@ -29,6 +30,7 @@ enum ClientState {
 enum PendingTransport {
     Stdio(TokioChildProcess),
     Http(StreamableHttpClientTransport<fabro_http::HttpClient>),
+    Sse(SseClientTransport),
 }
 
 /// MCP client wrapping the rmcp SDK. Handles stdio and HTTP transports.
@@ -71,9 +73,11 @@ impl McpClient {
 
                 PendingTransport::Stdio(transport)
             }
-            McpTransport::Http { url, headers } => {
-                let http_config = StreamableHttpClientTransportConfig::with_uri(url.clone());
-
+            McpTransport::Http {
+                protocol,
+                url,
+                headers,
+            } => {
                 let mut builder = fabro_http::HttpClientBuilder::new();
                 if !headers.is_empty() {
                     let mut header_map = HeaderMap::new();
@@ -88,10 +92,23 @@ impl McpClient {
                 }
 
                 let http_client = builder.build()?;
-                let transport =
-                    StreamableHttpClientTransport::with_client(http_client, http_config);
-
-                PendingTransport::Http(transport)
+                match protocol {
+                    McpHttpProtocol::StreamableHttp => {
+                        let http_config =
+                            StreamableHttpClientTransportConfig::with_uri(url.clone());
+                        let transport =
+                            StreamableHttpClientTransport::with_client(http_client, http_config);
+                        PendingTransport::Http(transport)
+                    }
+                    McpHttpProtocol::Sse => {
+                        let headers = headers_from_pairs(headers)?;
+                        PendingTransport::Sse(SseClientTransport::new(
+                            url.clone(),
+                            headers,
+                            http_client,
+                        )?)
+                    }
+                }
             }
             McpTransport::Sandbox { .. } => {
                 return Err(anyhow!(
@@ -104,6 +121,7 @@ impl McpClient {
         let transport_type = match &transport {
             PendingTransport::Stdio(_) => "stdio",
             PendingTransport::Http(_) => "http",
+            PendingTransport::Sse(_) => "sse",
         };
         debug!(server = %config.name, transport = transport_type, "Creating MCP client");
 
@@ -136,6 +154,7 @@ impl McpClient {
                 match transport {
                     PendingTransport::Stdio(t) => serve_client(handler.clone(), t).await,
                     PendingTransport::Http(t) => serve_client(handler.clone(), t).await,
+                    PendingTransport::Sse(t) => serve_client(handler.clone(), t).await,
                 }
             };
 

--- a/lib/crates/fabro-mcp/src/config.rs
+++ b/lib/crates/fabro-mcp/src/config.rs
@@ -1,1 +1,1 @@
-pub use fabro_types::settings::run::{McpServerSettings, McpTransport};
+pub use fabro_types::settings::run::{McpHttpProtocol, McpServerSettings, McpTransport};

--- a/lib/crates/fabro-mcp/src/http_transport.rs
+++ b/lib/crates/fabro-mcp/src/http_transport.rs
@@ -1,0 +1,35 @@
+#![expect(
+    clippy::disallowed_types,
+    reason = "MCP HTTP helpers parse operator-provided endpoint URLs; callers control what is logged"
+)]
+
+use std::collections::HashMap;
+
+use anyhow::{Context as _, Result};
+use fabro_http::{HeaderMap, HeaderName, HeaderValue, Url};
+
+use crate::config::McpHttpProtocol;
+
+pub fn sandbox_mcp_http_url(protocol: McpHttpProtocol, preview_url: &str) -> Result<String> {
+    match protocol {
+        McpHttpProtocol::StreamableHttp => Ok(preview_url.to_string()),
+        McpHttpProtocol::Sse => {
+            let mut url = Url::parse(preview_url).context("invalid sandbox MCP preview URL")?;
+            let path = url.path().trim_end_matches('/');
+            url.set_path(&format!("{path}/sse"));
+            Ok(url.to_string())
+        }
+    }
+}
+
+pub(crate) fn headers_from_pairs(headers: &HashMap<String, String>) -> Result<HeaderMap> {
+    let mut header_map = HeaderMap::new();
+    for (key, value) in headers {
+        let name = HeaderName::from_bytes(key.as_bytes())
+            .with_context(|| format!("invalid header name '{key}'"))?;
+        let val = HeaderValue::from_str(value)
+            .with_context(|| format!("invalid header value for '{key}'"))?;
+        header_map.insert(name, val);
+    }
+    Ok(header_map)
+}

--- a/lib/crates/fabro-mcp/src/lib.rs
+++ b/lib/crates/fabro-mcp/src/lib.rs
@@ -2,4 +2,5 @@ pub mod client;
 mod client_handler;
 pub mod config;
 pub mod connection_manager;
+pub mod http_transport;
 mod sse_client;

--- a/lib/crates/fabro-mcp/src/lib.rs
+++ b/lib/crates/fabro-mcp/src/lib.rs
@@ -2,3 +2,4 @@ pub mod client;
 mod client_handler;
 pub mod config;
 pub mod connection_manager;
+mod sse_client;

--- a/lib/crates/fabro-mcp/src/sse_client.rs
+++ b/lib/crates/fabro-mcp/src/sse_client.rs
@@ -5,7 +5,7 @@
 
 use std::future::Future;
 
-use anyhow::{Context as _, Result};
+use anyhow::{Context as _, Result, anyhow};
 use fabro_http::{Url, header};
 use futures::{StreamExt as _, TryStreamExt as _};
 use rmcp::RoleClient;
@@ -171,7 +171,11 @@ async fn handle_sse_event(
 }
 
 fn resolve_endpoint_url(sse_url: &Url, endpoint: &str) -> Result<Url> {
-    if endpoint.starts_with('/') {
+    if endpoint.starts_with("//") {
+        return Err(anyhow!("SSE MCP endpoint must not be protocol-relative"));
+    }
+
+    let resolved = if endpoint.starts_with('/') {
         let (path, query) = endpoint
             .split_once('?')
             .map_or((endpoint, None), |(path, query)| (path, Some(query)));
@@ -180,10 +184,16 @@ fn resolve_endpoint_url(sse_url: &Url, endpoint: &str) -> Result<Url> {
         let mut url = sse_url.clone();
         url.set_path(&format!("{prefix}{path}"));
         url.set_query(query);
-        return Ok(url);
+        url
+    } else {
+        sse_url.join(endpoint)?
+    };
+
+    if resolved.origin() != sse_url.origin() {
+        return Err(anyhow!("SSE MCP endpoint origin must match SSE URL origin"));
     }
 
-    sse_url.join(endpoint).map_err(Into::into)
+    Ok(resolved)
 }
 
 #[derive(Default)]
@@ -236,5 +246,74 @@ pub(crate) enum SseClientError {
 impl SseClientError {
     fn from_error(error: impl std::error::Error + Send + Sync + 'static) -> Self {
         Self::Source(anyhow::Error::new(error))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sse_url() -> Url {
+        Url::parse("https://srv.example.com/sse").unwrap()
+    }
+
+    #[test]
+    fn accepts_relative_path_with_query() {
+        let resolved = resolve_endpoint_url(&sse_url(), "/messages?sessionId=abc").unwrap();
+        assert_eq!(
+            resolved.as_str(),
+            "https://srv.example.com/messages?sessionId=abc"
+        );
+    }
+
+    #[test]
+    fn accepts_same_origin_absolute_url() {
+        let resolved =
+            resolve_endpoint_url(&sse_url(), "https://srv.example.com/messages?s=1").unwrap();
+        assert_eq!(resolved.as_str(), "https://srv.example.com/messages?s=1");
+    }
+
+    #[test]
+    fn accepts_same_origin_default_port() {
+        let resolved =
+            resolve_endpoint_url(&sse_url(), "https://srv.example.com:443/messages").unwrap();
+        assert_eq!(resolved.origin(), sse_url().origin());
+    }
+
+    #[test]
+    fn rejects_cross_host_absolute_url() {
+        let err = resolve_endpoint_url(&sse_url(), "https://evil.example/steal").unwrap_err();
+        assert!(
+            err.to_string().contains("origin"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn rejects_scheme_downgrade() {
+        let err = resolve_endpoint_url(&sse_url(), "http://srv.example.com/messages").unwrap_err();
+        assert!(
+            err.to_string().contains("origin"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn rejects_port_mismatch() {
+        let err =
+            resolve_endpoint_url(&sse_url(), "https://srv.example.com:8443/messages").unwrap_err();
+        assert!(
+            err.to_string().contains("origin"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn rejects_protocol_relative_url() {
+        let err = resolve_endpoint_url(&sse_url(), "//evil.example/steal").unwrap_err();
+        assert!(
+            err.to_string().contains("protocol-relative"),
+            "unexpected error: {err}"
+        );
     }
 }

--- a/lib/crates/fabro-mcp/src/sse_client.rs
+++ b/lib/crates/fabro-mcp/src/sse_client.rs
@@ -3,39 +3,38 @@
     reason = "SSE transport needs URL parsing for internal request routing; error messages omit raw URLs"
 )]
 
-use std::fmt;
 use std::future::Future;
-use std::sync::Arc;
 
-use anyhow::{Context as _, Result, anyhow};
-use fabro_http::{HeaderMap, HeaderName, HeaderValue, Url, header};
-use futures::StreamExt as _;
+use anyhow::{Context as _, Result};
+use fabro_http::{Url, header};
+use futures::{StreamExt as _, TryStreamExt as _};
 use rmcp::RoleClient;
 use rmcp::model::ServerJsonRpcMessage;
 use rmcp::service::{RxJsonRpcMessage, TxJsonRpcMessage};
 use rmcp::transport::Transport;
-use tokio::sync::{Mutex, mpsc, watch};
+use sse_stream::{Sse, SseStream};
+use tokio::sync::{mpsc, watch};
+use tokio::task::JoinHandle;
+
+const MAX_SSE_MESSAGE_BYTES: usize = 1024 * 1024;
 
 pub(crate) struct SseClientTransport {
     client:      fabro_http::HttpClient,
     endpoint_rx: watch::Receiver<Option<String>>,
     messages_rx: mpsc::Receiver<ServerJsonRpcMessage>,
+    stream_task: Option<JoinHandle<()>>,
 }
 
 impl SseClientTransport {
-    pub(crate) fn new(
-        url: &str,
-        headers: HeaderMap,
-        client: fabro_http::HttpClient,
-    ) -> Result<Self> {
+    pub(crate) fn new(url: &str, client: fabro_http::HttpClient) -> Result<Self> {
         let (endpoint_tx, endpoint_rx) = watch::channel(None);
         let (messages_tx, messages_rx) = mpsc::channel(64);
         let sse_url = Url::parse(url).context("invalid SSE MCP URL")?;
         let stream_client = client.clone();
 
-        tokio::spawn(async move {
+        let stream_task = tokio::spawn(async move {
             if let Err(err) =
-                read_sse_stream(stream_client, sse_url, headers, endpoint_tx, messages_tx).await
+                read_sse_stream(stream_client, sse_url, endpoint_tx, messages_tx).await
             {
                 tracing::warn!(error = %err, "SSE MCP stream ended");
             }
@@ -45,7 +44,16 @@ impl SseClientTransport {
             client,
             endpoint_rx,
             messages_rx,
+            stream_task: Some(stream_task),
         })
+    }
+}
+
+impl Drop for SseClientTransport {
+    fn drop(&mut self) {
+        if let Some(stream_task) = &self.stream_task {
+            stream_task.abort();
+        }
     }
 }
 
@@ -78,6 +86,9 @@ impl Transport<RoleClient> for SseClientTransport {
     }
 
     async fn close(&mut self) -> std::result::Result<(), Self::Error> {
+        if let Some(stream_task) = self.stream_task.take() {
+            stream_task.abort();
+        }
         Ok(())
     }
 }
@@ -92,71 +103,67 @@ async fn wait_for_endpoint(
         endpoint_rx
             .changed()
             .await
-            .map_err(SseClientError::from_error)?;
+            .map_err(|_| SseClientError::EndpointUnavailable)?;
     }
 }
 
 async fn read_sse_stream(
     client: fabro_http::HttpClient,
     sse_url: Url,
-    headers: HeaderMap,
     endpoint_tx: watch::Sender<Option<String>>,
     messages_tx: mpsc::Sender<ServerJsonRpcMessage>,
-) -> Result<()> {
-    let mut request = client
+) -> std::result::Result<(), SseClientError> {
+    let request = client
         .get(sse_url.clone())
         .header(header::ACCEPT, "text/event-stream");
-    for (name, value) in &headers {
-        request = request.header(name, value);
-    }
-    let response = request.send().await?.error_for_status()?;
-    let mut stream = response.bytes_stream();
-    let mut buffer = String::new();
-    let state = Arc::new(Mutex::new(SseEvent::default()));
+    let response = request
+        .send()
+        .await
+        .map_err(SseClientError::from_error)?
+        .error_for_status()
+        .map_err(SseClientError::from_error)?;
+    let mut size_guard = SseSizeGuard::default();
+    let byte_stream = response.bytes_stream().map(move |chunk| {
+        let chunk = chunk.map_err(SseClientError::from_error)?;
+        size_guard.check_chunk(&chunk)?;
+        Ok::<_, SseClientError>(chunk)
+    });
+    let mut stream = SseStream::from_byte_stream(byte_stream);
 
-    while let Some(chunk) = stream.next().await {
-        let chunk = chunk?;
-        buffer.push_str(&String::from_utf8_lossy(&chunk));
-
-        while let Some(index) = buffer.find('\n') {
-            let mut line = buffer[..index].to_string();
-            buffer.drain(..=index);
-            if line.ends_with('\r') {
-                line.pop();
-            }
-            let mut event = state.lock().await;
-            if let Some(complete) = event.push_line(&line) {
-                drop(event);
-                handle_sse_event(complete, &sse_url, &endpoint_tx, &messages_tx).await?;
-            }
-        }
+    while let Some(event) = stream
+        .try_next()
+        .await
+        .map_err(SseClientError::from_error)?
+    {
+        handle_sse_event(event, &sse_url, &endpoint_tx, &messages_tx).await?;
     }
 
     Ok(())
 }
 
 async fn handle_sse_event(
-    event: SseEvent,
+    event: Sse,
     sse_url: &Url,
     endpoint_tx: &watch::Sender<Option<String>>,
     messages_tx: &mpsc::Sender<ServerJsonRpcMessage>,
-) -> Result<()> {
+) -> std::result::Result<(), SseClientError> {
+    let data = event.data.unwrap_or_default();
     match event.event.as_deref() {
         Some("endpoint") => {
-            let endpoint = resolve_endpoint_url(sse_url, event.data.trim())
-                .context("invalid SSE MCP endpoint")?;
+            let endpoint =
+                resolve_endpoint_url(sse_url, data.trim()).context("invalid SSE MCP endpoint")?;
             let _ = endpoint_tx.send(Some(endpoint.to_string()));
         }
         None | Some("" | "message") => {
-            if event.data.trim().is_empty() {
+            if data.trim().is_empty() {
                 return Ok(());
             }
-            let message: ServerJsonRpcMessage = serde_json::from_str(&event.data)
-                .with_context(|| format!("invalid SSE MCP JSON-RPC message '{}'", event.data))?;
+            let message: ServerJsonRpcMessage =
+                serde_json::from_str(&data).context("invalid SSE MCP JSON-RPC message")?;
             messages_tx
                 .send(message)
                 .await
-                .map_err(|_| anyhow!("SSE MCP receiver closed"))?;
+                .map_err(|_| SseClientError::ReceiverClosed)?;
         }
         _ => {}
     }
@@ -180,66 +187,54 @@ fn resolve_endpoint_url(sse_url: &Url, endpoint: &str) -> Result<Url> {
 }
 
 #[derive(Default)]
-struct SseEvent {
-    event: Option<String>,
-    data:  String,
+struct SseSizeGuard {
+    current_event_bytes: usize,
+    current_line_bytes:  usize,
 }
 
-impl SseEvent {
-    fn push_line(&mut self, line: &str) -> Option<Self> {
-        if line.is_empty() {
-            if self.event.is_none() && self.data.is_empty() {
-                return None;
-            }
-            return Some(std::mem::take(self));
-        }
-        if line.starts_with(':') {
-            return None;
-        }
-        let (field, value) = line.split_once(':').map_or((line, ""), |(field, value)| {
-            (field, value.strip_prefix(' ').unwrap_or(value))
-        });
-        match field {
-            "event" => self.event = Some(value.to_string()),
-            "data" => {
-                if !self.data.is_empty() {
-                    self.data.push('\n');
+impl SseSizeGuard {
+    fn check_chunk(&mut self, chunk: &[u8]) -> std::result::Result<(), SseClientError> {
+        for byte in chunk {
+            self.current_event_bytes = self
+                .current_event_bytes
+                .checked_add(1)
+                .filter(|bytes| *bytes <= MAX_SSE_MESSAGE_BYTES)
+                .ok_or(SseClientError::MessageTooLarge {
+                    max_bytes: MAX_SSE_MESSAGE_BYTES,
+                })?;
+
+            match *byte {
+                b'\n' => {
+                    if self.current_line_bytes == 0 {
+                        self.current_event_bytes = 0;
+                    }
+                    self.current_line_bytes = 0;
                 }
-                self.data.push_str(value);
+                b'\r' => {}
+                _ => {
+                    self.current_line_bytes += 1;
+                }
             }
-            _ => {}
         }
-        None
+
+        Ok(())
     }
 }
 
-pub(crate) fn headers_from_pairs(
-    headers: &std::collections::HashMap<String, String>,
-) -> Result<HeaderMap> {
-    let mut header_map = HeaderMap::new();
-    for (key, value) in headers {
-        let name = HeaderName::from_bytes(key.as_bytes())
-            .with_context(|| format!("invalid header name '{key}'"))?;
-        let val = HeaderValue::from_str(value)
-            .with_context(|| format!("invalid header value for '{key}'"))?;
-        header_map.insert(name, val);
-    }
-    Ok(header_map)
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum SseClientError {
+    #[error(transparent)]
+    Source(#[from] anyhow::Error),
+    #[error("SSE MCP endpoint was not received before the stream closed")]
+    EndpointUnavailable,
+    #[error("SSE MCP receiver closed")]
+    ReceiverClosed,
+    #[error("SSE MCP message exceeds maximum size of {max_bytes} bytes")]
+    MessageTooLarge { max_bytes: usize },
 }
-
-#[derive(Debug)]
-pub(crate) struct SseClientError(String);
 
 impl SseClientError {
-    fn from_error(error: impl std::error::Error) -> Self {
-        Self(error.to_string())
+    fn from_error(error: impl std::error::Error + Send + Sync + 'static) -> Self {
+        Self::Source(anyhow::Error::new(error))
     }
 }
-
-impl fmt::Display for SseClientError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(&self.0)
-    }
-}
-
-impl std::error::Error for SseClientError {}

--- a/lib/crates/fabro-mcp/src/sse_client.rs
+++ b/lib/crates/fabro-mcp/src/sse_client.rs
@@ -1,0 +1,240 @@
+use std::fmt;
+use std::future::Future;
+use std::sync::Arc;
+
+use anyhow::{Context as _, Result, anyhow};
+use fabro_http::{HeaderMap, HeaderName, HeaderValue, Url, header};
+use futures::StreamExt as _;
+use rmcp::RoleClient;
+use rmcp::model::ServerJsonRpcMessage;
+use rmcp::service::{RxJsonRpcMessage, TxJsonRpcMessage};
+use rmcp::transport::Transport;
+use tokio::sync::{Mutex, mpsc, watch};
+
+pub(crate) struct SseClientTransport {
+    client:      fabro_http::HttpClient,
+    endpoint_rx: watch::Receiver<Option<String>>,
+    messages_rx: mpsc::Receiver<ServerJsonRpcMessage>,
+}
+
+impl SseClientTransport {
+    pub(crate) fn new(
+        url: String,
+        headers: HeaderMap,
+        client: fabro_http::HttpClient,
+    ) -> Result<Self> {
+        let (endpoint_tx, endpoint_rx) = watch::channel(None);
+        let (messages_tx, messages_rx) = mpsc::channel(64);
+        let sse_url = Url::parse(&url).with_context(|| format!("invalid SSE MCP URL '{url}'"))?;
+        let stream_client = client.clone();
+
+        tokio::spawn(async move {
+            if let Err(err) =
+                read_sse_stream(stream_client, sse_url, headers, endpoint_tx, messages_tx).await
+            {
+                tracing::warn!(error = %err, "SSE MCP stream ended");
+            }
+        });
+
+        Ok(Self {
+            client,
+            endpoint_rx,
+            messages_rx,
+        })
+    }
+}
+
+impl Transport<RoleClient> for SseClientTransport {
+    type Error = SseClientError;
+
+    fn send(
+        &mut self,
+        item: TxJsonRpcMessage<RoleClient>,
+    ) -> impl Future<Output = Result<(), Self::Error>> + Send + 'static {
+        let client = self.client.clone();
+        let mut endpoint_rx = self.endpoint_rx.clone();
+        async move {
+            let endpoint = wait_for_endpoint(&mut endpoint_rx).await?;
+            client
+                .post(endpoint)
+                .header(header::CONTENT_TYPE, "application/json")
+                .json(&item)
+                .send()
+                .await
+                .map_err(SseClientError::from_error)?
+                .error_for_status()
+                .map_err(SseClientError::from_error)?;
+            Ok(())
+        }
+    }
+
+    fn receive(&mut self) -> impl Future<Output = Option<RxJsonRpcMessage<RoleClient>>> + Send {
+        self.messages_rx.recv()
+    }
+
+    async fn close(&mut self) -> std::result::Result<(), Self::Error> {
+        Ok(())
+    }
+}
+
+async fn wait_for_endpoint(
+    endpoint_rx: &mut watch::Receiver<Option<String>>,
+) -> std::result::Result<String, SseClientError> {
+    loop {
+        if let Some(endpoint) = endpoint_rx.borrow().clone() {
+            return Ok(endpoint);
+        }
+        endpoint_rx
+            .changed()
+            .await
+            .map_err(SseClientError::from_error)?;
+    }
+}
+
+async fn read_sse_stream(
+    client: fabro_http::HttpClient,
+    sse_url: Url,
+    headers: HeaderMap,
+    endpoint_tx: watch::Sender<Option<String>>,
+    messages_tx: mpsc::Sender<ServerJsonRpcMessage>,
+) -> Result<()> {
+    let mut request = client
+        .get(sse_url.clone())
+        .header(header::ACCEPT, "text/event-stream");
+    for (name, value) in &headers {
+        request = request.header(name, value);
+    }
+    let response = request.send().await?.error_for_status()?;
+    let mut stream = response.bytes_stream();
+    let mut buffer = String::new();
+    let state = Arc::new(Mutex::new(SseEvent::default()));
+
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk?;
+        buffer.push_str(&String::from_utf8_lossy(&chunk));
+
+        while let Some(index) = buffer.find('\n') {
+            let mut line = buffer[..index].to_string();
+            buffer.drain(..=index);
+            if line.ends_with('\r') {
+                line.pop();
+            }
+            let mut event = state.lock().await;
+            if let Some(complete) = event.push_line(&line) {
+                drop(event);
+                handle_sse_event(complete, &sse_url, &endpoint_tx, &messages_tx).await?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+async fn handle_sse_event(
+    event: SseEvent,
+    sse_url: &Url,
+    endpoint_tx: &watch::Sender<Option<String>>,
+    messages_tx: &mpsc::Sender<ServerJsonRpcMessage>,
+) -> Result<()> {
+    match event.event.as_deref() {
+        Some("endpoint") => {
+            let endpoint = resolve_endpoint_url(sse_url, event.data.trim())
+                .with_context(|| format!("invalid SSE MCP endpoint '{}'", event.data))?;
+            let _ = endpoint_tx.send(Some(endpoint.to_string()));
+        }
+        None | Some("") | Some("message") => {
+            if event.data.trim().is_empty() {
+                return Ok(());
+            }
+            let message: ServerJsonRpcMessage = serde_json::from_str(&event.data)
+                .with_context(|| format!("invalid SSE MCP JSON-RPC message '{}'", event.data))?;
+            messages_tx
+                .send(message)
+                .await
+                .map_err(|_| anyhow!("SSE MCP receiver closed"))?;
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+fn resolve_endpoint_url(sse_url: &Url, endpoint: &str) -> Result<Url> {
+    if endpoint.starts_with('/') {
+        let (path, query) = endpoint
+            .split_once('?')
+            .map_or((endpoint, None), |(path, query)| (path, Some(query)));
+        let base_path = sse_url.path().trim_end_matches('/');
+        let prefix = base_path.rsplit_once('/').map_or("", |(prefix, _)| prefix);
+        let mut url = sse_url.clone();
+        url.set_path(&format!("{prefix}{path}"));
+        url.set_query(query);
+        return Ok(url);
+    }
+
+    sse_url.join(endpoint).map_err(Into::into)
+}
+
+#[derive(Default)]
+struct SseEvent {
+    event: Option<String>,
+    data:  String,
+}
+
+impl SseEvent {
+    fn push_line(&mut self, line: &str) -> Option<Self> {
+        if line.is_empty() {
+            if self.event.is_none() && self.data.is_empty() {
+                return None;
+            }
+            return Some(std::mem::take(self));
+        }
+        if line.starts_with(':') {
+            return None;
+        }
+        let (field, value) = line.split_once(':').map_or((line, ""), |(field, value)| {
+            (field, value.strip_prefix(' ').unwrap_or(value))
+        });
+        match field {
+            "event" => self.event = Some(value.to_string()),
+            "data" => {
+                if !self.data.is_empty() {
+                    self.data.push('\n');
+                }
+                self.data.push_str(value);
+            }
+            _ => {}
+        }
+        None
+    }
+}
+
+pub(crate) fn headers_from_pairs(
+    headers: &std::collections::HashMap<String, String>,
+) -> Result<HeaderMap> {
+    let mut header_map = HeaderMap::new();
+    for (key, value) in headers {
+        let name = HeaderName::from_bytes(key.as_bytes())
+            .with_context(|| format!("invalid header name '{key}'"))?;
+        let val = HeaderValue::from_str(value)
+            .with_context(|| format!("invalid header value for '{key}'"))?;
+        header_map.insert(name, val);
+    }
+    Ok(header_map)
+}
+
+#[derive(Debug)]
+pub(crate) struct SseClientError(String);
+
+impl SseClientError {
+    fn from_error(error: impl std::error::Error) -> Self {
+        Self(error.to_string())
+    }
+}
+
+impl fmt::Display for SseClientError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl std::error::Error for SseClientError {}

--- a/lib/crates/fabro-mcp/src/sse_client.rs
+++ b/lib/crates/fabro-mcp/src/sse_client.rs
@@ -1,3 +1,8 @@
+#![expect(
+    clippy::disallowed_types,
+    reason = "SSE transport needs URL parsing for internal request routing; error messages omit raw URLs"
+)]
+
 use std::fmt;
 use std::future::Future;
 use std::sync::Arc;
@@ -19,13 +24,13 @@ pub(crate) struct SseClientTransport {
 
 impl SseClientTransport {
     pub(crate) fn new(
-        url: String,
+        url: &str,
         headers: HeaderMap,
         client: fabro_http::HttpClient,
     ) -> Result<Self> {
         let (endpoint_tx, endpoint_rx) = watch::channel(None);
         let (messages_tx, messages_rx) = mpsc::channel(64);
-        let sse_url = Url::parse(&url).with_context(|| format!("invalid SSE MCP URL '{url}'"))?;
+        let sse_url = Url::parse(url).context("invalid SSE MCP URL")?;
         let stream_client = client.clone();
 
         tokio::spawn(async move {
@@ -139,10 +144,10 @@ async fn handle_sse_event(
     match event.event.as_deref() {
         Some("endpoint") => {
             let endpoint = resolve_endpoint_url(sse_url, event.data.trim())
-                .with_context(|| format!("invalid SSE MCP endpoint '{}'", event.data))?;
+                .context("invalid SSE MCP endpoint")?;
             let _ = endpoint_tx.send(Some(endpoint.to_string()));
         }
-        None | Some("") | Some("message") => {
+        None | Some("" | "message") => {
             if event.data.trim().is_empty() {
                 return Ok(());
             }

--- a/lib/crates/fabro-mcp/tests/stdio_integration.rs
+++ b/lib/crates/fabro-mcp/tests/stdio_integration.rs
@@ -1,7 +1,9 @@
 use std::collections::HashMap;
+use std::convert::Infallible;
+use std::sync::Arc;
 use std::time::Duration;
 
-use axum::body::Body;
+use axum::body::{Body, Bytes};
 use axum::extract::{Query, State};
 use axum::http::{HeaderMap, StatusCode, header};
 use axum::response::Response;
@@ -12,7 +14,9 @@ use fabro_mcp::config::{McpHttpProtocol, McpServerSettings, McpTransport};
 use fabro_mcp::connection_manager::{McpConnectionManager, call_result_to_string};
 use futures::{StreamExt as _, stream};
 use serde_json::Value;
-use tokio::sync::mpsc;
+use tokio::net::TcpListener;
+use tokio::sync::{Mutex, mpsc};
+use tokio_stream::wrappers::ReceiverStream;
 
 fn test_server_config() -> McpServerSettings {
     let test_server = format!("{}/tests/test_mcp_server.py", env!("CARGO_MANIFEST_DIR"));
@@ -163,7 +167,7 @@ async fn connection_manager_stdio_roundtrip() {
 async fn sse_client_initialize_and_call_tool() {
     #[derive(Clone)]
     struct SseState {
-        messages: std::sync::Arc<tokio::sync::Mutex<HashMap<String, mpsc::Sender<String>>>>,
+        messages: Arc<Mutex<HashMap<String, mpsc::Sender<String>>>>,
     }
 
     async fn sse(State(state): State<SseState>) -> Response {
@@ -172,12 +176,8 @@ async fn sse_client_initialize_and_call_tool() {
         state.messages.lock().await.insert(session_id.clone(), tx);
         let endpoint = format!("event: endpoint\ndata: /sse?sessionId={session_id}\n\n");
         let body = Body::from_stream(
-            stream::once(async move {
-                Ok::<_, std::convert::Infallible>(axum::body::Bytes::from(endpoint))
-            })
-            .chain(
-                tokio_stream::wrappers::ReceiverStream::new(rx)
-                    .map(|event| Ok::<_, std::convert::Infallible>(axum::body::Bytes::from(event))),
+            stream::once(async move { Ok::<_, Infallible>(Bytes::from(endpoint)) }).chain(
+                ReceiverStream::new(rx).map(|event| Ok::<_, Infallible>(Bytes::from(event))),
             ),
         );
         Response::builder()
@@ -242,12 +242,12 @@ async fn sse_client_initialize_and_call_tool() {
     }
 
     let state = SseState {
-        messages: std::sync::Arc::new(tokio::sync::Mutex::new(HashMap::new())),
+        messages: Arc::new(Mutex::new(HashMap::new())),
     };
     let app = Router::new()
         .route("/sse", get(sse).post(post_sse))
         .with_state(state);
-    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
     tokio::spawn(async move {
         axum::serve(listener, app).await.unwrap();

--- a/lib/crates/fabro-mcp/tests/stdio_integration.rs
+++ b/lib/crates/fabro-mcp/tests/stdio_integration.rs
@@ -1,9 +1,18 @@
 use std::collections::HashMap;
 use std::time::Duration;
 
+use axum::body::Body;
+use axum::extract::{Query, State};
+use axum::http::{HeaderMap, StatusCode, header};
+use axum::response::Response;
+use axum::routing::get;
+use axum::{Json, Router};
 use fabro_mcp::client::McpClient;
-use fabro_mcp::config::{McpServerSettings, McpTransport};
+use fabro_mcp::config::{McpHttpProtocol, McpServerSettings, McpTransport};
 use fabro_mcp::connection_manager::{McpConnectionManager, call_result_to_string};
+use futures::{StreamExt as _, stream};
+use serde_json::Value;
+use tokio::sync::mpsc;
 
 fn test_server_config() -> McpServerSettings {
     let test_server = format!("{}/tests/test_mcp_server.py", env!("CARGO_MANIFEST_DIR"));
@@ -148,4 +157,127 @@ async fn connection_manager_stdio_roundtrip() {
 
     let text = call_result_to_string(&result).unwrap();
     assert_eq!(text, "roundtrip");
+}
+
+#[tokio::test]
+async fn sse_client_initialize_and_call_tool() {
+    #[derive(Clone)]
+    struct SseState {
+        messages: std::sync::Arc<tokio::sync::Mutex<HashMap<String, mpsc::Sender<String>>>>,
+    }
+
+    async fn sse(State(state): State<SseState>) -> Response {
+        let session_id = "session-1".to_string();
+        let (tx, rx) = mpsc::channel::<String>(16);
+        state.messages.lock().await.insert(session_id.clone(), tx);
+        let endpoint = format!("event: endpoint\ndata: /sse?sessionId={session_id}\n\n");
+        let body = Body::from_stream(
+            stream::once(async move {
+                Ok::<_, std::convert::Infallible>(axum::body::Bytes::from(endpoint))
+            })
+            .chain(
+                tokio_stream::wrappers::ReceiverStream::new(rx)
+                    .map(|event| Ok::<_, std::convert::Infallible>(axum::body::Bytes::from(event))),
+            ),
+        );
+        Response::builder()
+            .header(header::CONTENT_TYPE, "text/event-stream")
+            .body(body)
+            .unwrap()
+    }
+
+    async fn post_sse(
+        State(state): State<SseState>,
+        Query(query): Query<HashMap<String, String>>,
+        headers: HeaderMap,
+        Json(message): Json<Value>,
+    ) -> StatusCode {
+        assert_eq!(
+            headers
+                .get("x-test-token")
+                .and_then(|value| value.to_str().ok()),
+            Some("secret")
+        );
+        let session_id = query.get("sessionId").expect("sessionId query").clone();
+        let sender = state
+            .messages
+            .lock()
+            .await
+            .get(&session_id)
+            .cloned()
+            .expect("active SSE stream");
+        let Some(id) = message.get("id").cloned() else {
+            return StatusCode::ACCEPTED;
+        };
+        let method = message.get("method").and_then(Value::as_str).unwrap_or("");
+        let result = match method {
+            "initialize" => serde_json::json!({
+                "protocolVersion": "2024-11-05",
+                "capabilities": {"tools": {}},
+                "serverInfo": {"name": "legacy-sse-test", "version": "1.0.0"}
+            }),
+            "tools/list" => serde_json::json!({
+                "tools": [{
+                    "name": "echo",
+                    "description": "Echo back the message",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {"message": {"type": "string"}},
+                        "required": ["message"]
+                    }
+                }]
+            }),
+            "tools/call" => serde_json::json!({
+                "content": [{"type": "text", "text": "hello from sse"}],
+                "isError": false
+            }),
+            _ => serde_json::json!({}),
+        };
+        let response = serde_json::json!({"jsonrpc": "2.0", "id": id, "result": result});
+        sender
+            .send(format!("data: {response}\n\n"))
+            .await
+            .expect("SSE stream should be open");
+        StatusCode::ACCEPTED
+    }
+
+    let state = SseState {
+        messages: std::sync::Arc::new(tokio::sync::Mutex::new(HashMap::new())),
+    };
+    let app = Router::new()
+        .route("/sse", get(sse).post(post_sse))
+        .with_state(state);
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+
+    let config = McpServerSettings {
+        name:                 "test-sse".into(),
+        transport:            McpTransport::Http {
+            protocol: McpHttpProtocol::Sse,
+            url:      format!("http://{addr}/sse"),
+            headers:  HashMap::from([("x-test-token".to_string(), "secret".to_string())]),
+        },
+        current_dir:          None,
+        clear_env:            false,
+        startup_timeout_secs: 10,
+        tool_timeout_secs:    30,
+    };
+    let client = McpClient::new(&config).unwrap();
+    client.initialize(config.startup_timeout()).await.unwrap();
+
+    let tools = client.list_tools().await.unwrap();
+    assert_eq!(tools[0].0, "echo");
+
+    let result = client
+        .call_tool(
+            "echo",
+            serde_json::json!({"message": "hello"}),
+            Duration::from_secs(5),
+        )
+        .await
+        .unwrap();
+    assert_eq!(call_result_to_string(&result).unwrap(), "hello from sse");
 }

--- a/lib/crates/fabro-mcp/tests/stdio_integration.rs
+++ b/lib/crates/fabro-mcp/tests/stdio_integration.rs
@@ -380,6 +380,89 @@ async fn sse_client_rejects_oversized_messages() {
     );
 }
 
+#[tokio::test]
+async fn sse_client_rejects_cross_origin_endpoint() {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use axum::routing::post;
+
+    #[derive(Clone)]
+    struct EvilState {
+        hits: Arc<AtomicUsize>,
+    }
+
+    async fn evil_post(State(state): State<EvilState>) -> StatusCode {
+        state.hits.fetch_add(1, Ordering::SeqCst);
+        StatusCode::ACCEPTED
+    }
+
+    #[derive(Clone)]
+    struct VictimState {
+        endpoint: String,
+    }
+
+    async fn sse(State(state): State<VictimState>) -> Response {
+        let body = Body::from_stream(stream::once(async move {
+            Ok::<_, Infallible>(Bytes::from(format!(
+                "event: endpoint\ndata: {endpoint}\n\n",
+                endpoint = state.endpoint
+            )))
+        }));
+        Response::builder()
+            .header(header::CONTENT_TYPE, "text/event-stream")
+            .body(body)
+            .unwrap()
+    }
+
+    let evil_state = EvilState {
+        hits: Arc::new(AtomicUsize::new(0)),
+    };
+    let evil_app = Router::new()
+        .route("/steal", post(evil_post))
+        .with_state(evil_state.clone());
+    let evil_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let evil_addr = evil_listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(evil_listener, evil_app).await.unwrap();
+    });
+
+    let victim_state = VictimState {
+        endpoint: format!("http://127.0.0.1:{}/steal", evil_addr.port()),
+    };
+    let victim_app = Router::new()
+        .route("/sse", get(sse))
+        .with_state(victim_state);
+    let victim_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let victim_addr = victim_listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(victim_listener, victim_app).await.unwrap();
+    });
+
+    let config = McpServerSettings {
+        name:                 "test-sse".into(),
+        transport:            McpTransport::Http {
+            protocol: McpHttpProtocol::Sse,
+            url:      format!("http://{victim_addr}/sse"),
+            headers:  HashMap::from([("authorization".to_string(), "Bearer secret".to_string())]),
+        },
+        current_dir:          None,
+        clear_env:            false,
+        startup_timeout_secs: 2,
+        tool_timeout_secs:    30,
+    };
+    let client = McpClient::new(&config).unwrap();
+    client
+        .initialize(config.startup_timeout())
+        .await
+        .expect_err("cross-origin SSE endpoint should fail initialization");
+
+    assert_eq!(
+        evil_state.hits.load(Ordering::SeqCst),
+        0,
+        "client must not POST to a cross-origin endpoint advertised by the SSE server"
+    );
+}
+
 #[test]
 fn sandbox_mcp_http_url_builds_sse_endpoint_under_preview_path() {
     let url = sandbox_mcp_http_url(

--- a/lib/crates/fabro-mcp/tests/stdio_integration.rs
+++ b/lib/crates/fabro-mcp/tests/stdio_integration.rs
@@ -12,6 +12,7 @@ use axum::{Json, Router};
 use fabro_mcp::client::McpClient;
 use fabro_mcp::config::{McpHttpProtocol, McpServerSettings, McpTransport};
 use fabro_mcp::connection_manager::{McpConnectionManager, call_result_to_string};
+use fabro_mcp::http_transport::sandbox_mcp_http_url;
 use futures::{StreamExt as _, stream};
 use serde_json::Value;
 use tokio::net::TcpListener;
@@ -280,4 +281,134 @@ async fn sse_client_initialize_and_call_tool() {
         .await
         .unwrap();
     assert_eq!(call_result_to_string(&result).unwrap(), "hello from sse");
+}
+
+#[tokio::test]
+async fn sse_client_rejects_oversized_messages() {
+    #[derive(Clone)]
+    struct SseState {
+        messages: Arc<Mutex<HashMap<String, mpsc::Sender<String>>>>,
+    }
+
+    async fn sse(State(state): State<SseState>) -> Response {
+        let session_id = "oversized-session".to_string();
+        let (tx, rx) = mpsc::channel::<String>(16);
+        state.messages.lock().await.insert(session_id.clone(), tx);
+        let endpoint = format!("event: endpoint\ndata: /sse?sessionId={session_id}\n\n");
+        let body = Body::from_stream(
+            stream::once(async move { Ok::<_, Infallible>(Bytes::from(endpoint)) }).chain(
+                ReceiverStream::new(rx).map(|event| Ok::<_, Infallible>(Bytes::from(event))),
+            ),
+        );
+        Response::builder()
+            .header(header::CONTENT_TYPE, "text/event-stream")
+            .body(body)
+            .unwrap()
+    }
+
+    async fn post_sse(
+        State(state): State<SseState>,
+        Query(query): Query<HashMap<String, String>>,
+        Json(message): Json<Value>,
+    ) -> StatusCode {
+        let session_id = query.get("sessionId").expect("sessionId query").clone();
+        let sender = state
+            .messages
+            .lock()
+            .await
+            .get(&session_id)
+            .cloned()
+            .expect("active SSE stream");
+        let Some(id) = message.get("id").cloned() else {
+            return StatusCode::ACCEPTED;
+        };
+        let oversized_name = "x".repeat(1024 * 1024 + 1);
+        let response = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "result": {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {"tools": {}},
+                "serverInfo": {"name": oversized_name, "version": "1.0.0"}
+            }
+        });
+        sender
+            .send(format!("data: {response}\n\n"))
+            .await
+            .expect("SSE stream should be open");
+        StatusCode::ACCEPTED
+    }
+
+    let state = SseState {
+        messages: Arc::new(Mutex::new(HashMap::new())),
+    };
+    let app = Router::new()
+        .route("/sse", get(sse).post(post_sse))
+        .with_state(state);
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+
+    let config = McpServerSettings {
+        name:                 "test-sse".into(),
+        transport:            McpTransport::Http {
+            protocol: McpHttpProtocol::Sse,
+            url:      format!("http://{addr}/sse"),
+            headers:  HashMap::new(),
+        },
+        current_dir:          None,
+        clear_env:            false,
+        startup_timeout_secs: 2,
+        tool_timeout_secs:    30,
+    };
+    let client = McpClient::new(&config).unwrap();
+    let error = client
+        .initialize(config.startup_timeout())
+        .await
+        .expect_err("oversized SSE message should fail initialization");
+    let error = error.to_string();
+
+    assert!(
+        error.contains("connection closed"),
+        "unexpected error: {error}"
+    );
+    assert!(
+        !error.contains("xxxxxxxx"),
+        "oversized payload leaked: {error}"
+    );
+}
+
+#[test]
+fn sandbox_mcp_http_url_builds_sse_endpoint_under_preview_path() {
+    let url = sandbox_mcp_http_url(
+        McpHttpProtocol::Sse,
+        "https://preview.example.com/proxy/3100/",
+    )
+    .unwrap();
+
+    assert_eq!(url, "https://preview.example.com/proxy/3100/sse");
+}
+
+#[test]
+fn sandbox_mcp_http_url_leaves_streamable_http_preview_url_unchanged() {
+    let url = sandbox_mcp_http_url(
+        McpHttpProtocol::StreamableHttp,
+        "https://preview.example.com/proxy/3100/mcp",
+    )
+    .unwrap();
+
+    assert_eq!(url, "https://preview.example.com/proxy/3100/mcp");
+}
+
+#[test]
+fn sandbox_mcp_http_url_preserves_query_and_path_without_trailing_slash() {
+    let url = sandbox_mcp_http_url(
+        McpHttpProtocol::Sse,
+        "https://preview.example.com/proxy/3100?token=abc",
+    )
+    .unwrap();
+
+    assert_eq!(url, "https://preview.example.com/proxy/3100/sse?token=abc");
 }

--- a/lib/crates/fabro-types/src/settings/run.rs
+++ b/lib/crates/fabro-types/src/settings/run.rs
@@ -679,14 +679,26 @@ pub enum McpTransport {
         env:     HashMap<String, String>,
     },
     Http {
-        url:     String,
-        headers: HashMap<String, String>,
+        #[serde(default)]
+        protocol: McpHttpProtocol,
+        url:      String,
+        headers:  HashMap<String, String>,
     },
     Sandbox {
-        command: Vec<String>,
-        port:    u16,
-        env:     HashMap<String, String>,
+        #[serde(default)]
+        protocol: McpHttpProtocol,
+        command:  Vec<String>,
+        port:     u16,
+        env:      HashMap<String, String>,
     },
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum McpHttpProtocol {
+    #[default]
+    StreamableHttp,
+    Sse,
 }
 
 #[expect(

--- a/lib/crates/fabro-workflow/src/operations/start.rs
+++ b/lib/crates/fabro-workflow/src/operations/start.rs
@@ -646,14 +646,25 @@ fn runtime_mcp_server(settings: &ResolvedMcpServerSettings) -> McpServerSettings
                 command: command.clone(),
                 env:     env.clone(),
             },
-            ResolvedMcpTransport::Http { url, headers } => McpTransport::Http {
-                url:     url.clone(),
-                headers: headers.clone(),
+            ResolvedMcpTransport::Http {
+                protocol,
+                url,
+                headers,
+            } => McpTransport::Http {
+                protocol: *protocol,
+                url:      url.clone(),
+                headers:  headers.clone(),
             },
-            ResolvedMcpTransport::Sandbox { command, port, env } => McpTransport::Sandbox {
-                command: command.clone(),
-                port:    *port,
-                env:     env.clone(),
+            ResolvedMcpTransport::Sandbox {
+                protocol,
+                command,
+                port,
+                env,
+            } => McpTransport::Sandbox {
+                protocol: *protocol,
+                command:  command.clone(),
+                port:     *port,
+                env:      env.clone(),
             },
         },
         current_dir:          None,

--- a/lib/crates/fabro-workflow/tests/it/daytona_integration.rs
+++ b/lib/crates/fabro-workflow/tests/it/daytona_integration.rs
@@ -2081,11 +2081,14 @@ async fn daytona_playwright_mcp_sandbox_transport() {
 
             let url = match protocol {
                 fabro_mcp::config::McpHttpProtocol::StreamableHttp => url,
-                fabro_mcp::config::McpHttpProtocol::Sse => fabro_http::Url::parse(&url)
-                    .unwrap()
-                    .join("sse")
-                    .unwrap()
-                    .to_string(),
+                fabro_mcp::config::McpHttpProtocol::Sse => {
+                    #[expect(
+                        clippy::disallowed_types,
+                        reason = "test-only preview URL path joining; not a logging boundary"
+                    )]
+                    let url = fabro_http::Url::parse(&url).unwrap().join("sse").unwrap();
+                    url.to_string()
+                }
             };
 
             fabro_mcp::config::McpServerSettings {

--- a/lib/crates/fabro-workflow/tests/it/daytona_integration.rs
+++ b/lib/crates/fabro-workflow/tests/it/daytona_integration.rs
@@ -2079,17 +2079,7 @@ async fn daytona_playwright_mcp_sandbox_transport() {
             };
             eprintln!("Preview URL: {url}");
 
-            let url = match protocol {
-                fabro_mcp::config::McpHttpProtocol::StreamableHttp => url,
-                fabro_mcp::config::McpHttpProtocol::Sse => {
-                    #[expect(
-                        clippy::disallowed_types,
-                        reason = "test-only preview URL path joining; not a logging boundary"
-                    )]
-                    let url = fabro_http::Url::parse(&url).unwrap().join("sse").unwrap();
-                    url.to_string()
-                }
-            };
+            let url = fabro_mcp::http_transport::sandbox_mcp_http_url(*protocol, &url).unwrap();
 
             fabro_mcp::config::McpServerSettings {
                 name:                 mcp_config.name.clone(),

--- a/lib/crates/fabro-workflow/tests/it/daytona_integration.rs
+++ b/lib/crates/fabro-workflow/tests/it/daytona_integration.rs
@@ -2006,7 +2006,8 @@ async fn daytona_playwright_mcp_sandbox_transport() {
     let mcp_config = fabro_mcp::config::McpServerSettings {
         name:                 "playwright".into(),
         transport:            fabro_mcp::config::McpTransport::Sandbox {
-            command: vec![
+            protocol: fabro_mcp::config::McpHttpProtocol::Sse,
+            command:  vec![
                 "npx".into(),
                 "@playwright/mcp@latest".into(),
                 "--port".into(),
@@ -2015,8 +2016,8 @@ async fn daytona_playwright_mcp_sandbox_transport() {
                 "--browser".into(),
                 "chromium".into(),
             ],
-            port:    mcp_port,
-            env:     std::collections::HashMap::new(),
+            port:     mcp_port,
+            env:      std::collections::HashMap::new(),
         },
         current_dir:          None,
         clear_env:            false,
@@ -2027,7 +2028,12 @@ async fn daytona_playwright_mcp_sandbox_transport() {
     // Resolve the sandbox transport: start the server, get preview URL, rewrite to
     // HTTP
     let resolved = match &mcp_config.transport {
-        fabro_mcp::config::McpTransport::Sandbox { command, port, .. } => {
+        fabro_mcp::config::McpTransport::Sandbox {
+            protocol,
+            command,
+            port,
+            ..
+        } => {
             let (url, headers) = {
                 let cmd_str = command.join(" ");
                 let launch_script = format!(
@@ -2073,9 +2079,22 @@ async fn daytona_playwright_mcp_sandbox_transport() {
             };
             eprintln!("Preview URL: {url}");
 
+            let url = match protocol {
+                fabro_mcp::config::McpHttpProtocol::StreamableHttp => url,
+                fabro_mcp::config::McpHttpProtocol::Sse => fabro_http::Url::parse(&url)
+                    .unwrap()
+                    .join("sse")
+                    .unwrap()
+                    .to_string(),
+            };
+
             fabro_mcp::config::McpServerSettings {
                 name:                 mcp_config.name.clone(),
-                transport:            fabro_mcp::config::McpTransport::Http { url, headers },
+                transport:            fabro_mcp::config::McpTransport::Http {
+                    protocol: *protocol,
+                    url,
+                    headers,
+                },
                 current_dir:          mcp_config.current_dir.clone(),
                 clear_env:            mcp_config.clear_env,
                 startup_timeout_secs: mcp_config.startup_timeout_secs,


### PR DESCRIPTION
## Summary

Adds support for MCP servers that use the SSE-based HTTP transport, including Playwright MCP.

Fabro already supports stdio and Streamable HTTP MCP servers. Some MCP servers still expose the SSE transport shape where the client opens an SSE stream, receives an `endpoint` event, and sends JSON-RPC requests back to that endpoint. This PR adds an explicit `protocol = "sse"` option while keeping Streamable HTTP as the default.

## What Changed

- Added `McpHttpProtocol` with `streamable_http` as the default and `sse` as an opt-in protocol.
- Added an SSE MCP client transport implementation.
- Wired HTTP MCP setup to choose Streamable HTTP or SSE based on config.
- Added `protocol = "sse"` support for both `http` and `sandbox` MCP entries.
- Updated sandbox MCP resolution so SSE sandbox servers connect through the preview `/sse` path.
- Documented `protocol = "sse"` for Playwright MCP.
- Added an integration test covering SSE initialize, tool listing, and tool calls.

## Example

```toml
[run.agent.mcps.playwright]
type = "sandbox"
protocol = "sse"
command = ["npx", "@playwright/mcp@latest", "--port", "3100", "--headless", "--browser", "chromium"]
port = 3100
startup_timeout = "60s"
tool_timeout = "2m"
```

## Compatibility

Existing MCP configs are unchanged because `protocol` defaults to `streamable_http`.

## Validation

- `cargo +nightly-2026-04-14 fmt --check --all`
- `cargo nextest run -p fabro-mcp`
- `cargo check -p fabro-agent -p fabro-workflow -p fabro-config`
