### PR TITLE
fix(web): generalize GitHub App post-install copy

### DIFF
--- a/apps/fabro-web/app/routes/setup.test.ts
+++ b/apps/fabro-web/app/routes/setup.test.ts
@@ -14,7 +14,7 @@ describe("setupContentForSearch", () => {
     );
     expect(content.steps.map((step) => step.title)).toEqual([
       "Return to Fabro",
-      "Retry the run",
+      "Use the new installation",
     ]);
   });
 });

--- a/apps/fabro-web/app/routes/setup.tsx
+++ b/apps/fabro-web/app/routes/setup.tsx
@@ -44,11 +44,11 @@ const githubInstallReturnSteps = [
     ),
   },
   {
-    title: "Retry the run",
+    title: "Use the new installation",
     body: (
       <p className="text-sm/6 text-fg-3">
-        Start the run or preflight again so Fabro can clone the repository and
-        push checkpoint branches with the new installation.
+        Sign in and start a run or preflight. Fabro can now clone repositories
+        and push checkpoint branches using the new installation.
       </p>
     ),
   },


### PR DESCRIPTION
## Summary

The `/setup` screen rendered after GitHub redirects post-install (params `installation_id` + `setup_action=install`) showed copy that assumed the user was retrying a failed run:

> **Retry the run** — Start the run or preflight again so Fabro can clone the repository and push checkpoint branches with the new installation.

But this screen is also where **first-time installers** land during onboarding, when there is no prior run to retry. The "retry" framing is confusing in that path.

## Fix

Rewrite step 2 to be neutral between onboarding and retry-after-failure:

> **Use the new installation** — Sign in and start a run or preflight. Fabro can now clone repositories and push checkpoint branches using the new installation.

The CTA below the steps ("Continue to sign in") and step 1 ("Return to Fabro / The GitHub App is installed for the selected account or repositories") already work for both paths — only step 2 was over-fit. No structural changes; the route still keys off the same query params.

Update `setup.test.ts` to assert the new title.

## Test plan
- [x] `bun test app/routes/setup.test.ts` — 1 pass
- [x] `bun run typecheck` — clean
- [x] Manual: behavior unchanged for first-time-setup path (no install params); only the post-install variant text changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)