### PR TITLE
fix(server): enforce content security policy

### DIFF
--- a/docs/public/administration/security.mdx
+++ b/docs/public/administration/security.mdx
@@ -16,7 +16,7 @@ Fabro is single-tenant software designed for small, trusted teams. The following
 | **Multi-tenancy** | Not supported. Fabro is single-tenant only — there is no organization or tenant isolation. |
 | **Roles or ACLs** | Not supported. All authenticated users have identical, full access to every run, workflow, and API endpoint. |
 | **Rate limiting** | Not implemented. The API server does not throttle requests. |
-| **Security headers** | Not configured. The API does not set `Strict-Transport-Security`, `Content-Security-Policy`, `X-Frame-Options`, or similar headers. |
+| **Custom security header policy** | Not configurable. Fabro emits default security headers, including enforced `Content-Security-Policy`, `X-Frame-Options`, `X-Content-Type-Options`, `Referrer-Policy`, `Permissions-Policy`, and `Strict-Transport-Security` when HTTPS is detected. |
 
 ## Security recommendations
 

--- a/lib/crates/fabro-server/src/csp.rs
+++ b/lib/crates/fabro-server/src/csp.rs
@@ -13,12 +13,15 @@ use sha2::{Digest, Sha256};
 
 static POLICY: OnceLock<String> = OnceLock::new();
 
+pub(crate) const INSTALL_MODE_SCRIPT_BODY: &str = "window.__FABRO_MODE__ = \"install\";";
+
 pub fn policy() -> &'static str {
     POLICY.get_or_init(build_policy)
 }
 
 fn build_policy() -> String {
-    let script_hashes = inline_script_hashes_from_embedded_index();
+    let mut script_hashes = inline_script_hashes_from_embedded_index();
+    script_hashes.push(script_hash(INSTALL_MODE_SCRIPT_BODY));
     build_policy_with_hashes(&script_hashes)
 }
 
@@ -57,11 +60,15 @@ pub(crate) fn inline_script_hashes(html: &str) -> Vec<String> {
         };
         let content_end = content_start + close_rel;
         let body = &html[content_start..content_end];
-        let hash = Sha256::digest(body.as_bytes());
-        hashes.push(format!("sha256-{}", STANDARD.encode(hash)));
+        hashes.push(script_hash(body));
         cursor = content_end;
     }
     hashes
+}
+
+fn script_hash(script: &str) -> String {
+    let hash = Sha256::digest(script.as_bytes());
+    format!("sha256-{}", STANDARD.encode(hash))
 }
 
 fn build_policy_with_hashes(script_hashes: &[String]) -> String {
@@ -79,18 +86,19 @@ fn build_policy_with_hashes(script_hashes: &[String]) -> String {
     };
     // `'wasm-unsafe-eval'` lets `@viz-js/viz` instantiate the Graphviz
     // WASM module for graph rendering. `'unsafe-inline'` on style-src is
-    // accepted as a pragmatic concession — React and Tailwind's runtime
-    // utilities regularly set inline `style=` attributes, and a CSP
-    // violation on every mouse-hover would make the report-only output
-    // useless. The meaningful XSS protection still comes from the
-    // script-src restrictions above.
+    // accepted as a pragmatic concession — React and UI utilities regularly
+    // set inline `style=` attributes, and blocking those would break normal
+    // interactions. The meaningful XSS protection still comes from the
+    // script-src restrictions above. `ws:`/`wss:` keep the same-origin
+    // terminal WebSocket working across browsers that do not treat `'self'`
+    // as matching WebSocket schemes for connect-src.
     format!(
         "default-src 'self'; \
          script-src 'self'{inline_script_sources} 'wasm-unsafe-eval'; \
          style-src 'self' https://fonts.googleapis.com 'unsafe-inline'; \
          font-src 'self' https://fonts.gstatic.com; \
          img-src 'self' data: blob:; \
-         connect-src 'self'; \
+         connect-src 'self' ws: wss:; \
          worker-src 'self' blob:; \
          manifest-src 'self'; \
          frame-ancestors 'none'; \
@@ -137,6 +145,16 @@ mod tests {
     }
 
     #[test]
+    fn policy_allows_install_mode_inline_bootstrap() {
+        let policy = build_policy();
+        let expected_hash = script_hash(INSTALL_MODE_SCRIPT_BODY);
+        assert!(
+            policy.contains(&format!("'{expected_hash}'")),
+            "install-mode inline script hash should be present in CSP: {policy}"
+        );
+    }
+
+    #[test]
     fn policy_is_constructed_with_expected_directives() {
         let policy = build_policy_with_hashes(&["sha256-abc".to_string()]);
         assert!(policy.contains("default-src 'self'"));
@@ -146,6 +164,7 @@ mod tests {
         );
         assert!(policy.contains("font-src 'self' https://fonts.gstatic.com"));
         assert!(policy.contains("style-src 'self' https://fonts.googleapis.com 'unsafe-inline'"));
+        assert!(policy.contains("connect-src 'self' ws: wss:"));
         assert!(policy.contains("frame-ancestors 'none'"));
         assert!(policy.contains("object-src 'none'"));
     }

--- a/lib/crates/fabro-server/src/security_headers.rs
+++ b/lib/crates/fabro-server/src/security_headers.rs
@@ -20,16 +20,9 @@ pub async fn layer(req: Request, next: Next) -> Response {
 }
 
 fn apply_csp(headers: &mut HeaderMap) {
-    // Ship in Report-Only mode while the policy settles — browsers emit
-    // violations to DevTools and any configured report endpoint without
-    // actually blocking the offending resource. Flip to
-    // `Content-Security-Policy` once real-world use confirms no false
-    // positives.
     if let Ok(value) = HeaderValue::from_str(csp::policy()) {
         headers
-            .entry(HeaderName::from_static(
-                "content-security-policy-report-only",
-            ))
+            .entry(HeaderName::from_static("content-security-policy"))
             .or_insert(value);
     }
 }
@@ -191,6 +184,14 @@ mod tests {
         assert_eq!(headers.get("cache-control").unwrap(), "no-store");
         assert_eq!(headers.get("pragma").unwrap(), "no-cache");
         assert_eq!(headers.get("vary").unwrap(), "Accept-Encoding");
+    }
+
+    #[test]
+    fn csp_is_enforced_not_report_only() {
+        let mut headers = HeaderMap::new();
+        apply_csp(&mut headers);
+        assert!(headers.contains_key("content-security-policy"));
+        assert!(!headers.contains_key("content-security-policy-report-only"));
     }
 
     #[test]

--- a/lib/crates/fabro-server/src/static_files.rs
+++ b/lib/crates/fabro-server/src/static_files.rs
@@ -7,6 +7,8 @@ use axum::response::{IntoResponse, Response};
 use fabro_static::EnvVars;
 use tokio::fs;
 
+use crate::csp;
+
 const INSTALL_MODE_MARKER: &str = "__FABRO_MODE__ = \"install\"";
 
 // Tiny shell shown in `--watch-web` mode when the requested asset isn't on disk
@@ -245,7 +247,10 @@ fn inject_install_mode(bytes: Vec<u8>) -> Vec<u8> {
 
     let injected = html.replace(
         "</head>",
-        "    <script>window.__FABRO_MODE__ = \"install\";</script>\n  </head>",
+        &format!(
+            "    <script>{}</script>\n  </head>",
+            csp::INSTALL_MODE_SCRIPT_BODY
+        ),
     );
     assert!(
         injected.contains(INSTALL_MODE_MARKER),

--- a/lib/crates/fabro-server/tests/it/api/routing.rs
+++ b/lib/crates/fabro-server/tests/it/api/routing.rs
@@ -350,17 +350,23 @@ async fn security_headers_are_applied_to_all_responses() {
         "no-cache"
     );
 
-    // CSP is shipped in Report-Only mode and must cover the sources the
-    // embedded SPA actually loads: same-origin scripts, Google Fonts,
-    // WASM instantiation (viz-js), data: and blob: images, blob: workers.
+    // CSP must cover the sources the embedded SPA actually loads: same-origin
+    // scripts, Google Fonts, WASM instantiation (viz-js), data: and blob:
+    // images, blob: workers, and terminal WebSockets.
     // Inline hashes are optional because the current SPA ships only
     // external module scripts.
     let csp = spa_response
         .headers()
-        .get("content-security-policy-report-only")
-        .expect("CSP Report-Only header should be emitted")
+        .get("content-security-policy")
+        .expect("CSP header should be emitted")
         .to_str()
         .expect("CSP should be ASCII");
+    assert!(
+        !spa_response
+            .headers()
+            .contains_key("content-security-policy-report-only"),
+        "CSP should be enforced, not report-only"
+    );
     assert!(csp.contains("default-src 'self'"), "got: {csp}");
     assert!(csp.contains("script-src 'self'"), "got: {csp}");
     assert!(csp.contains("'wasm-unsafe-eval'"), "got: {csp}");
@@ -373,6 +379,7 @@ async fn security_headers_are_applied_to_all_responses() {
         "got: {csp}"
     );
     assert!(csp.contains("img-src 'self' data: blob:"), "got: {csp}");
+    assert!(csp.contains("connect-src 'self' ws: wss:"), "got: {csp}");
     assert!(csp.contains("worker-src 'self' blob:"), "got: {csp}");
     assert!(csp.contains("frame-ancestors 'none'"), "got: {csp}");
     assert!(csp.contains("object-src 'none'"), "got: {csp}");


### PR DESCRIPTION
## Summary

Enforces Fabro's CSP by switching from `Content-Security-Policy-Report-Only` to `Content-Security-Policy` while preserving the SPA sources we know are required. The policy now hashes the install-mode inline bootstrap and allows `ws:`/`wss:` connections so terminal WebSockets do not regress under enforcement.

The security headers integration test now asserts enforced CSP behavior, and the public security docs now describe the default headers Fabro emits.

## Verification

- `cargo +nightly-2026-04-14 fmt --check --all`
- `cargo test -p fabro-server csp::tests --lib`
- `cargo test -p fabro-server security_headers::tests --lib`
- `cargo test -p fabro-server --features test-support --test it security_headers_are_applied_to_all_responses`
- Browser QA against an enforced local server: login, runs list, settings, and automation diagram rendered with no CSP console violations or page errors.
- Live listener on `127.0.0.1:32276` restarted and verified to emit `content-security-policy` with no report-only header.

---

[![Compound Engineering](https://img.shields.io/badge/Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with GPT-5 via [Codex](https://openai.com/codex)