### PR TITLE
chore(model): update provider default models

### DIFF
--- a/docs/public/core-concepts/models.mdx
+++ b/docs/public/core-concepts/models.mdx
@@ -146,8 +146,8 @@ When no model or provider is specified, Fabro checks configured provider credent
 | Provider | Default model |
 |---|---|
 | `anthropic` | `claude-sonnet-4-6` |
-| `openai` | `gpt-5.4` |
-| `gemini` | `gemini-3.1-pro-preview` |
+| `openai` | `gpt-5.5` |
+| `gemini` | `gemini-3.5-flash` |
 | `kimi` | `kimi-k2.5` |
 | `zai` | `glm-4.7` |
 | `minimax` | `minimax-m2.5` |

--- a/lib/crates/fabro-cli/tests/it/cmd/attach.rs
+++ b/lib/crates/fabro-cli/tests/it/cmd/attach.rs
@@ -991,7 +991,7 @@ fn attach_json_errors_without_prompting_for_human_input() {
                   "speed": null
                 },
                 "fallbacks": [],
-                "name": "gpt-5.4",
+                "name": "gpt-5.5",
                 "provider": "openai"
               },
               "notifications": {},

--- a/lib/crates/fabro-model/src/catalog.rs
+++ b/lib/crates/fabro-model/src/catalog.rs
@@ -1874,12 +1874,12 @@ enabled = true
         let m = Catalog::builtin()
             .default_for_provider(&ProviderId::openai())
             .unwrap();
-        assert_eq!(m.id, "gpt-5.4");
+        assert_eq!(m.id, "gpt-5.5");
 
         let m = Catalog::builtin()
             .default_for_provider(&ProviderId::gemini())
             .unwrap();
-        assert_eq!(m.id, "gemini-3.1-pro-preview");
+        assert_eq!(m.id, "gemini-3.5-flash");
     }
 
     #[test]
@@ -1903,7 +1903,7 @@ enabled = true
         let m = Catalog::builtin()
             .probe_for_provider(&ProviderId::gemini())
             .unwrap();
-        assert_eq!(m.id, "gemini-3.1-pro-preview");
+        assert_eq!(m.id, "gemini-3.5-flash");
     }
 
     #[test]
@@ -2496,7 +2496,7 @@ probe = false
                 .probe_for_provider(&ProviderId::openai())
                 .unwrap()
                 .id,
-            "gpt-5.4"
+            "gpt-5.5"
         );
     }
 
@@ -2905,7 +2905,7 @@ small_default = false
                 .small_default_for_provider(&ProviderId::openai())
                 .unwrap()
                 .id,
-            "gpt-5.4"
+            "gpt-5.5"
         );
     }
 

--- a/lib/crates/fabro-model/src/catalog/providers/gemini.toml
+++ b/lib/crates/fabro-model/src/catalog/providers/gemini.toml
@@ -16,7 +16,6 @@ display_name = "Gemini 3.1 Pro (Preview)"
 family = "gemini-3"
 training = "2025-01-01"
 knowledge_cutoff = "January 2025"
-default = true
 estimated_output_tps = 85
 aliases = ["gemini-pro"]
 
@@ -67,6 +66,7 @@ display_name = "Gemini 3.5 Flash"
 family = "gemini-3"
 training = "2025-01-01"
 knowledge_cutoff = "January 2025"
+default = true
 estimated_output_tps = 150
 aliases = ["gemini-35-flash"]
 

--- a/lib/crates/fabro-model/src/catalog/providers/openai.toml
+++ b/lib/crates/fabro-model/src/catalog/providers/openai.toml
@@ -15,7 +15,6 @@ display_name = "GPT-5.4"
 family = "gpt-5"
 training = "2025-08-31"
 knowledge_cutoff = "April 2025"
-default = true
 estimated_output_tps = 70
 aliases = ["gpt54", "gpt-54", "gpt-5.2", "gpt5", "gpt-5.3-codex", "codex"]
 
@@ -41,6 +40,7 @@ display_name = "GPT-5.5"
 family = "gpt-5"
 training = "2025-12-01"
 knowledge_cutoff = "December 2025"
+default = true
 estimated_output_tps = 70
 aliases = ["gpt55", "gpt-55"]
 

--- a/lib/crates/fabro-server/tests/it/api/runs.rs
+++ b/lib/crates/fabro-server/tests/it/api/runs.rs
@@ -150,7 +150,7 @@ _version = 1
         created["ask_fabro"]["unavailable_reason"],
         "sandbox_not_ready"
     );
-    assert_eq!(created["ask_fabro"]["default_model"], "gpt-5.4");
+    assert_eq!(created["ask_fabro"]["default_model"], "gpt-5.5");
 
     let get_request = Request::builder()
         .method("GET")


### PR DESCRIPTION
Updates the built-in catalog so OpenAI default selection now resolves to `gpt-5.5` and Gemini default selection resolves to `gemini-3.5-flash`. The public model defaults table and catalog assertions were updated to pin the new behavior.

Verified with `cargo nextest run -p fabro-model`.

---

[![Compound Engineering](https://img.shields.io/badge/Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with GPT-5 (Codex) via [Codex](https://openai.com/codex)