### PR TITLE
fix(llm): stamp configured provider name into responses and error details

### DIFF
--- a/lib/crates/fabro-llm/src/providers/anthropic.rs
+++ b/lib/crates/fabro-llm/src/providers/anthropic.rs
@@ -734,6 +734,8 @@ enum ContentBlockKind {
 struct StreamAccumulator {
     id:                String,
     model:             String,
+    /// Configured provider name stamped into the final `Response.provider`.
+    provider:          String,
     content_parts:     Vec<ContentPart>,
     usage:             TokenCounts,
     finish_reason:     FinishReason,
@@ -750,10 +752,11 @@ struct StreamAccumulator {
 }
 
 impl StreamAccumulator {
-    fn new(rate_limit: Option<RateLimitInfo>) -> Self {
+    fn new(rate_limit: Option<RateLimitInfo>, provider: String) -> Self {
         Self {
             id: String::new(),
             model: String::new(),
+            provider,
             content_parts: Vec::new(),
             usage: TokenCounts::default(),
             finish_reason: FinishReason::Stop,
@@ -772,7 +775,7 @@ impl StreamAccumulator {
         Response {
             id:            self.id.clone(),
             model:         self.model.clone(),
-            provider:      "anthropic".to_string(),
+            provider:      self.provider.clone(),
             message:       Message {
                 role:         Role::Assistant,
                 content:      content_parts,
@@ -1114,7 +1117,7 @@ impl SseReaderState {
     ) -> Self {
         Self {
             line_reader: super::common::LineReader::new(http_resp, stream_read_timeout),
-            accumulator: StreamAccumulator::new(rate_limit),
+            accumulator: StreamAccumulator::new(rate_limit, provider_name.clone()),
             pending_events: std::collections::VecDeque::new(),
             json_schema_mode,
             provider_name,
@@ -1713,7 +1716,7 @@ mod tests {
 
     #[test]
     fn stream_token_counts_leaves_reasoning_zero_and_output_full() {
-        let mut acc = StreamAccumulator::new(None);
+        let mut acc = StreamAccumulator::new(None, "anthropic".to_string());
         acc.content_parts.push(ContentPart::Thinking(ThinkingData {
             text:      "summary text".to_string(),
             signature: Some(String::new()),
@@ -1747,7 +1750,7 @@ mod tests {
 
     #[test]
     fn stream_error_event_overloaded_becomes_retryable_server_error() {
-        let mut acc = StreamAccumulator::new(None);
+        let mut acc = StreamAccumulator::new(None, "anthropic".to_string());
         let data = serde_json::json!({
             "type": "error",
             "error": {
@@ -1774,7 +1777,7 @@ mod tests {
 
     #[test]
     fn stream_error_event_invalid_request_remains_non_retryable() {
-        let mut acc = StreamAccumulator::new(None);
+        let mut acc = StreamAccumulator::new(None, "anthropic".to_string());
         let data = serde_json::json!({
             "type": "error",
             "error": {
@@ -1798,7 +1801,7 @@ mod tests {
 
     #[test]
     fn unknown_sse_events_remain_ignored() {
-        let mut acc = StreamAccumulator::new(None);
+        let mut acc = StreamAccumulator::new(None, "anthropic".to_string());
         let data = serde_json::json!({
             "type": "content_block_delta",
             "delta": { "type": "text_delta", "text": "ignored" }

--- a/lib/crates/fabro-llm/src/providers/gemini.rs
+++ b/lib/crates/fabro-llm/src/providers/gemini.rs
@@ -555,6 +555,7 @@ fn parse_usage(metadata: Option<&UsageMetadata>) -> TokenCounts {
 /// available.
 async fn send_gemini_response(
     request: fabro_http::RequestBuilder,
+    provider: &str,
 ) -> Result<(String, HeaderMap), Error> {
     let http_resp = request.send().await.map_err(|e| {
         if e.is_timeout() {
@@ -574,7 +575,14 @@ async fn send_gemini_response(
 
     if !status.is_success() {
         let (msg, code, raw) = parse_error_body(&body, "status");
-        return Err(gemini_error(status.as_u16(), msg, code, raw, retry_after));
+        return Err(gemini_error(
+            status.as_u16(),
+            msg,
+            provider,
+            code,
+            raw,
+            retry_after,
+        ));
     }
 
     Ok((body, headers))
@@ -585,6 +593,7 @@ async fn send_gemini_response(
 fn gemini_error(
     status_code: u16,
     msg: String,
+    provider: &str,
     grpc_status: Option<String>,
     raw: Option<serde_json::Value>,
     retry_after: Option<f64>,
@@ -593,7 +602,7 @@ fn gemini_error(
         Some(grpc_code) => error_from_grpc_status(
             &grpc_code,
             msg,
-            "gemini".to_string(),
+            provider.to_string(),
             Some(grpc_code.clone()),
             raw,
             retry_after,
@@ -601,7 +610,7 @@ fn gemini_error(
         None => error_from_status_code(
             status_code,
             msg,
-            "gemini".to_string(),
+            provider.to_string(),
             None,
             raw,
             retry_after,
@@ -615,6 +624,7 @@ fn gemini_error(
 /// maps it to `Error` using gRPC status code mapping when available.
 async fn send_streaming_request(
     request: fabro_http::RequestBuilder,
+    provider: &str,
 ) -> Result<fabro_http::Response, Error> {
     let http_resp = request
         .send()
@@ -629,7 +639,14 @@ async fn send_streaming_request(
             .await
             .map_err(|e| Error::network(e.to_string(), e))?;
         let (msg, code, raw) = parse_error_body(&body, "status");
-        return Err(gemini_error(status.as_u16(), msg, code, raw, retry_after));
+        return Err(gemini_error(
+            status.as_u16(),
+            msg,
+            provider,
+            code,
+            raw,
+            retry_after,
+        ));
     }
 
     Ok(http_resp)
@@ -640,11 +657,12 @@ async fn send_streaming_request(
 fn process_sse_stream(
     http_resp: fabro_http::Response,
     model: String,
+    provider: String,
     rate_limit: Option<RateLimitInfo>,
     stream_read_timeout: Option<std::time::Duration>,
 ) -> StreamEventStream {
     Box::pin(stream::unfold(
-        SseStreamState::new(http_resp, model, rate_limit, stream_read_timeout),
+        SseStreamState::new(http_resp, model, provider, rate_limit, stream_read_timeout),
         |mut state| async move {
             // If we have buffered events, yield them first.
             if let Some(event) = state.pending_events.pop_front() {
@@ -726,6 +744,8 @@ fn process_sse_stream(
 struct SseStreamState {
     line_reader:            super::common::LineReader,
     model:                  String,
+    /// Configured provider name stamped into the final `Response.provider`.
+    provider:               String,
     /// Events extracted from a chunk but not yet yielded.
     pending_events:         std::collections::VecDeque<StreamEvent>,
     /// Whether we have emitted a `StreamStart` event.
@@ -756,12 +776,14 @@ impl SseStreamState {
     fn new(
         http_resp: fabro_http::Response,
         model: String,
+        provider: String,
         rate_limit: Option<RateLimitInfo>,
         stream_read_timeout: Option<std::time::Duration>,
     ) -> Self {
         Self {
             line_reader: super::common::LineReader::new(http_resp, stream_read_timeout),
             model,
+            provider,
             pending_events: std::collections::VecDeque::new(),
             stream_started: false,
             text_started: false,
@@ -909,7 +931,7 @@ impl SseStreamState {
         let response = Response {
             id:            uuid::Uuid::new_v4().to_string(),
             model:         self.model.clone(),
-            provider:      "gemini".to_string(),
+            provider:      self.provider.clone(),
             message:       Message {
                 role:         Role::Assistant,
                 content:      content_parts,
@@ -961,7 +983,7 @@ impl ProviderAdapter for Adapter {
         if let Some(t) = self.http.request_timeout {
             req = req.timeout(t);
         }
-        let (body, _headers) = send_gemini_response(req).await?;
+        let (body, _headers) = send_gemini_response(req, &self.provider_name).await?;
         let response: CountTokensResponse =
             serde_json::from_str(&body).map_err(|e| Error::Configuration {
                 message: format!("failed to parse Gemini token count: {e}"),
@@ -998,7 +1020,7 @@ impl ProviderAdapter for Adapter {
         if let Some(t) = self.http.request_timeout {
             gemini_req = gemini_req.timeout(t);
         }
-        let (body, headers) = send_gemini_response(gemini_req).await?;
+        let (body, headers) = send_gemini_response(gemini_req, &self.provider_name).await?;
 
         let api_resp: ApiResponse = serde_json::from_str(&body)
             .map_err(|e| Error::network(format!("failed to parse Gemini response: {e}"), e))?;
@@ -1011,7 +1033,7 @@ impl ProviderAdapter for Adapter {
                 kind:   ProviderErrorKind::Server,
                 detail: Box::new(ProviderErrorDetail::new(
                     "no candidates in Gemini response",
-                    "gemini",
+                    self.provider_name.as_str(),
                 )),
             })?;
 
@@ -1062,12 +1084,13 @@ impl ProviderAdapter for Adapter {
         for (key, value) in &self.http.default_headers {
             req = req.header(key, value);
         }
-        let http_resp = send_streaming_request(req.json(&api_body)).await?;
+        let http_resp = send_streaming_request(req.json(&api_body), &self.provider_name).await?;
 
         let rate_limit = parse_rate_limit_headers(http_resp.headers());
         Ok(process_sse_stream(
             http_resp,
             request.model.clone(),
+            self.provider_name.clone(),
             rate_limit,
             self.http.stream_read_timeout,
         ))
@@ -1372,6 +1395,7 @@ mod tests {
         let err = gemini_error(
             400,
             "model not found".into(),
+            "gemini",
             Some("NOT_FOUND".into()),
             None,
             None,
@@ -1384,6 +1408,7 @@ mod tests {
         let err = gemini_error(
             400,
             "bad args".into(),
+            "gemini",
             Some("INVALID_ARGUMENT".into()),
             None,
             None,
@@ -1396,6 +1421,7 @@ mod tests {
         let err = gemini_error(
             429,
             "rate limited".into(),
+            "gemini",
             Some("RESOURCE_EXHAUSTED".into()),
             None,
             None,
@@ -1408,6 +1434,7 @@ mod tests {
         let err = gemini_error(
             401,
             "bad key".into(),
+            "gemini",
             Some("UNAUTHENTICATED".into()),
             None,
             None,
@@ -1420,6 +1447,7 @@ mod tests {
         let err = gemini_error(
             403,
             "denied".into(),
+            "gemini",
             Some("PERMISSION_DENIED".into()),
             None,
             None,
@@ -1432,6 +1460,7 @@ mod tests {
         let err = gemini_error(
             504,
             "timeout".into(),
+            "gemini",
             Some("DEADLINE_EXCEEDED".into()),
             None,
             None,
@@ -1443,13 +1472,13 @@ mod tests {
     fn gemini_error_falls_back_to_http_status_without_grpc() {
         use crate::error::ProviderErrorKind;
 
-        let err = gemini_error(429, "rate limited".into(), None, None, None);
+        let err = gemini_error(429, "rate limited".into(), "gemini", None, None, None);
         assert!(matches!(err, Error::Provider {
             kind: ProviderErrorKind::RateLimit,
             ..
         }));
 
-        let err = gemini_error(500, "internal".into(), None, None, None);
+        let err = gemini_error(500, "internal".into(), "gemini", None, None, None);
         assert!(matches!(err, Error::Provider {
             kind: ProviderErrorKind::Server,
             ..

--- a/lib/crates/fabro-llm/src/providers/openai.rs
+++ b/lib/crates/fabro-llm/src/providers/openai.rs
@@ -250,7 +250,7 @@ fn map_finish_reason(status: Option<&str>, has_tool_calls: bool) -> FinishReason
     }
 }
 
-fn provider_error_from_openai_error_json(error: &serde_json::Value) -> Error {
+fn provider_error_from_openai_error_json(error: &serde_json::Value, provider: &str) -> Error {
     let classifier = error
         .get("code")
         .and_then(serde_json::Value::as_str)
@@ -301,7 +301,7 @@ fn provider_error_from_openai_error_json(error: &serde_json::Value) -> Error {
         kind,
         detail: Box::new(ProviderErrorDetail {
             message,
-            provider: "openai".to_string(),
+            provider: provider.to_string(),
             status_code: None,
             error_code: classifier.map(str::to_string),
             retry_after: None,
@@ -779,6 +779,8 @@ fn parse_output(output: &[serde_json::Value]) -> (Vec<ContentPart>, bool) {
 struct SseStreamState {
     line_reader:             super::common::LineReader,
     model:                   String,
+    /// Configured provider name stamped into responses and error details.
+    provider:                String,
     response_id:             String,
     response_model:          String,
     accumulated_text:        String,
@@ -878,7 +880,10 @@ fn process_sse_event(
     match resolved_type.as_str() {
         "error" => {
             let error = json.get("error").unwrap_or(&json);
-            return Err(provider_error_from_openai_error_json(error));
+            return Err(provider_error_from_openai_error_json(
+                error,
+                &state.provider,
+            ));
         }
         "response.created" => handle_response_created(state, &json),
         "response.output_text.delta" => handle_text_delta(state, &json, &mut events),
@@ -897,7 +902,10 @@ fn process_sse_event(
                 .get("response")
                 .and_then(|response| response.get("error"))
                 .unwrap_or(&json);
-            return Err(provider_error_from_openai_error_json(error));
+            return Err(provider_error_from_openai_error_json(
+                error,
+                &state.provider,
+            ));
         }
         "response.reasoning_summary_text.delta" | "response.reasoning_text.delta" => {
             if let Some(delta) = json.get("delta").and_then(serde_json::Value::as_str) {
@@ -1211,7 +1219,7 @@ fn handle_response_completed(
     let response = Response {
         id: state.response_id.clone(),
         model,
-        provider: "openai".to_string(),
+        provider: state.provider.clone(),
         message: Message {
             role:         Role::Assistant,
             content:      content_parts,
@@ -1313,7 +1321,7 @@ impl ProviderAdapter for Adapter {
         if let Some(t) = self.http.request_timeout {
             req = req.timeout(t);
         }
-        let (body, headers) = send_and_read_response(req, "openai", "type").await?;
+        let (body, headers) = send_and_read_response(req, &self.provider_name, "type").await?;
 
         let api_resp: ApiResponse = serde_json::from_str(&body)
             .map_err(|e| Error::network(format!("failed to parse OpenAI response: {e}"), e))?;
@@ -1326,7 +1334,7 @@ impl ProviderAdapter for Adapter {
         Ok(Response {
             id: api_resp.id,
             model: api_resp.model.unwrap_or_else(|| request.model.clone()),
-            provider: "openai".to_string(),
+            provider: self.provider_name.clone(),
             message: Message {
                 role:         Role::Assistant,
                 content:      content_parts,
@@ -1370,7 +1378,7 @@ impl ProviderAdapter for Adapter {
             return Err(error_from_status_code(
                 status.as_u16(),
                 msg,
-                "openai".to_string(),
+                self.provider_name.clone(),
                 code,
                 raw,
                 retry_after,
@@ -1384,6 +1392,7 @@ impl ProviderAdapter for Adapter {
         let state = SseStreamState {
             line_reader: super::common::LineReader::new(http_resp, stream_read_timeout),
             model,
+            provider: self.provider_name.clone(),
             response_id: String::new(),
             response_model: String::new(),
             accumulated_text: String::new(),
@@ -2329,6 +2338,7 @@ mod tests {
         SseStreamState {
             line_reader:             LineReader::new(response, None),
             model:                   String::new(),
+            provider:                "openai".to_string(),
             response_id:             String::new(),
             response_model:          String::new(),
             accumulated_text:        String::new(),

--- a/lib/crates/fabro-llm/tests/it/wire/anthropic.rs
+++ b/lib/crates/fabro-llm/tests/it/wire/anthropic.rs
@@ -591,3 +591,80 @@ async fn stream_without_message_stop_emits_no_finish() {
     let (_capture, events) = stream_capture(adapter(), &base_request(MODEL), &sse).await;
     fabro_test::fabro_json_snapshot!(events);
 }
+
+// ---------------------------------------------------------------------------
+// Custom-named route (the Kimi-over-anthropic shape)
+// ---------------------------------------------------------------------------
+
+/// Shared setup for a custom-named anthropic-dialect (Kimi) stream route; the
+/// request and event halves are pinned by separate tests.
+async fn custom_named_stream_capture() -> (WireCapture, Vec<serde_json::Value>) {
+    let sse = support::sse_transcript(&[
+        (
+            "message_start",
+            r#"{"type":"message_start","message":{"id":"msg_kimi","type":"message","role":"assistant","model":"kimi-test","content":[],"usage":{"input_tokens":5,"output_tokens":0}}}"#,
+        ),
+        (
+            "content_block_start",
+            r#"{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}"#,
+        ),
+        (
+            "content_block_delta",
+            r#"{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hi"}}"#,
+        ),
+        (
+            "content_block_stop",
+            r#"{"type":"content_block_stop","index":0}"#,
+        ),
+        (
+            "message_delta",
+            r#"{"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":2}}"#,
+        ),
+        ("message_stop", r#"{"type":"message_stop"}"#),
+    ]);
+    stream_capture(
+        adapter().with_name("kimi"),
+        &base_request("kimi-test"),
+        &sse,
+    )
+    .await
+}
+
+/// A custom-named (Kimi) route authenticates with a bearer token and sends no
+/// `anthropic-version` header. This pins that route shape on the wire.
+#[tokio::test]
+async fn custom_named_stream_route() {
+    let (capture, _) = custom_named_stream_capture().await;
+    fabro_test::fabro_json_snapshot!(capture);
+}
+
+/// Since provider-identity normalization, the streamed `Response.provider`
+/// carries the configured name.
+#[tokio::test]
+async fn custom_named_stream_identity() {
+    let (_, events) = custom_named_stream_capture().await;
+    fabro_test::fabro_json_snapshot!(events);
+}
+
+/// Error events on a custom-named route carry the configured name in the
+/// error detail (normalize-both decision).
+#[tokio::test]
+async fn custom_named_stream_error_identity() {
+    let sse = support::sse_transcript(&[
+        (
+            "message_start",
+            r#"{"type":"message_start","message":{"id":"msg_kimi_err","type":"message","role":"assistant","model":"kimi-test","content":[],"usage":{"input_tokens":5,"output_tokens":0}}}"#,
+        ),
+        (
+            "error",
+            r#"{"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}"#,
+        ),
+    ]);
+    let (_capture, events) = stream_capture(
+        adapter().with_name("kimi"),
+        &base_request("kimi-test"),
+        &sse,
+    )
+    .await;
+    fabro_test::fabro_json_snapshot!(events);
+}

--- a/lib/crates/fabro-llm/tests/it/wire/gemini.rs
+++ b/lib/crates/fabro-llm/tests/it/wire/gemini.rs
@@ -485,3 +485,51 @@ async fn stream_end_synthesizes_finish_without_finish_reason() {
     let (_capture, events) = stream_capture(adapter(), &base_request(MODEL), &sse).await;
     fabro_test::fabro_json_snapshot!(events);
 }
+
+// ---------------------------------------------------------------------------
+// Custom-named route identity
+// ---------------------------------------------------------------------------
+
+/// Streamed responses stamp the configured provider name (previously
+/// hardcoded "gemini").
+#[tokio::test]
+async fn custom_named_stream_identity() {
+    let sse = support::sse_data_transcript(&[
+        r#"{"candidates":[{"content":{"role":"model","parts":[{"text":"Hi"}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":5,"candidatesTokenCount":2}}"#,
+    ]);
+    let (_capture, events) = stream_capture(
+        adapter().with_name("gemini-proxy"),
+        &base_request(MODEL),
+        &sse,
+    )
+    .await;
+    fabro_test::fabro_json_snapshot!(events);
+}
+
+/// HTTP-level errors carry the configured name in the error detail
+/// (normalize-both decision).
+#[tokio::test]
+async fn custom_named_http_error_identity() {
+    let server = MockServer::start();
+    let mock = server.mock(|when, then| {
+        when.method(POST).path(COMPLETE_PATH);
+        then.status(500)
+            .header("content-type", "application/json")
+            .json_body(serde_json::json!({
+                "error": {"message": "backend exploded", "status": "INTERNAL", "code": 500}
+            }));
+    });
+    let adapter = adapter()
+        .with_name("gemini-proxy")
+        .with_base_url(server.base_url());
+    let error = adapter
+        .complete(&base_request(MODEL))
+        .await
+        .expect_err("complete should fail");
+    mock.assert();
+    fabro_test::fabro_json_snapshot!(serde_json::json!({
+        "error": error.to_string(),
+        "retryable": error.retryable(),
+        "failover_eligible": error.failover_eligible(),
+    }));
+}

--- a/lib/crates/fabro-llm/tests/it/wire/openai_compatible.rs
+++ b/lib/crates/fabro-llm/tests/it/wire/openai_compatible.rs
@@ -437,3 +437,22 @@ async fn stream_without_done_or_content_synthesizes_nothing() {
     let (_capture, events) = stream_capture(&base_request(MODEL), &sse).await;
     fabro_test::fabro_json_snapshot!(events);
 }
+
+// ---------------------------------------------------------------------------
+// Custom-named route identity
+// ---------------------------------------------------------------------------
+
+/// The compat adapter already stamped the configured name; pinned here to
+/// complete the per-dialect identity matrix.
+#[tokio::test]
+async fn custom_named_complete_identity() {
+    let server = MockServer::start();
+    let (mock, _slot) = mount_capture(&server, "/chat/completions", minimal_body());
+    let adapter = adapter(&server).with_name("kimi");
+    let response = adapter
+        .complete(&base_request(MODEL))
+        .await
+        .expect("complete should succeed");
+    mock.assert();
+    assert_eq!(response.provider, "kimi");
+}

--- a/lib/crates/fabro-llm/tests/it/wire/openai_responses.rs
+++ b/lib/crates/fabro-llm/tests/it/wire/openai_responses.rs
@@ -561,3 +561,41 @@ async fn stream_incomplete_maps_to_length() {
     let (_capture, events) = stream_capture(adapter(), &base_request(MODEL), &sse).await;
     fabro_test::fabro_json_snapshot!(events);
 }
+
+// ---------------------------------------------------------------------------
+// Custom-named route identity
+// ---------------------------------------------------------------------------
+
+/// Non-stream responses stamp the configured provider name (previously
+/// hardcoded "openai").
+#[tokio::test]
+async fn custom_named_complete_identity() {
+    let server = MockServer::start();
+    let (mock, _slot) = mount_capture(&server, "/responses", minimal_body());
+    let adapter = OpenAiAdapter::new("test-key")
+        .with_name("openai-proxy")
+        .with_base_url(server.base_url());
+    let response = adapter
+        .complete(&base_request(MODEL))
+        .await
+        .expect("complete should succeed");
+    mock.assert();
+    assert_eq!(response.provider, "openai-proxy");
+}
+
+/// Stream failure events carry the configured name in the error detail
+/// (normalize-both decision).
+#[tokio::test]
+async fn custom_named_stream_failed_event_identity() {
+    let sse = support::sse_data_transcript(&[
+        r#"{"type":"response.created","response":{"id":"resp_stream","model":"gpt-test"}}"#,
+        r#"{"type":"response.failed","response":{"id":"resp_stream","error":{"code":"server_error","message":"boom"}}}"#,
+    ]);
+    let (_capture, events) = stream_capture(
+        adapter().with_name("openai-proxy"),
+        &base_request(MODEL),
+        &sse,
+    )
+    .await;
+    fabro_test::fabro_json_snapshot!(events);
+}

--- a/lib/crates/fabro-llm/tests/it/wire/snapshots/it__wire__anthropic__custom_named_stream_error_identity.snap
+++ b/lib/crates/fabro-llm/tests/it/wire/snapshots/it__wire__anthropic__custom_named_stream_error_identity.snap
@@ -1,0 +1,14 @@
+---
+source: lib/crates/fabro-llm/tests/it/wire/anthropic.rs
+expression: rendered
+---
+[
+  {
+    "type": "stream_start"
+  },
+  {
+    "stream_item_error": "Server error from kimi: Overloaded",
+    "retryable": true,
+    "failover_eligible": true
+  }
+]

--- a/lib/crates/fabro-llm/tests/it/wire/snapshots/it__wire__anthropic__custom_named_stream_identity.snap
+++ b/lib/crates/fabro-llm/tests/it/wire/snapshots/it__wire__anthropic__custom_named_stream_identity.snap
@@ -1,0 +1,60 @@
+---
+source: lib/crates/fabro-llm/tests/it/wire/anthropic.rs
+expression: rendered
+---
+[
+  {
+    "type": "stream_start"
+  },
+  {
+    "type": "text_start",
+    "text_id": "block_0"
+  },
+  {
+    "type": "text_delta",
+    "delta": "Hi",
+    "text_id": "block_0"
+  },
+  {
+    "type": "text_end",
+    "text_id": "block_0"
+  },
+  {
+    "type": "finish",
+    "finish_reason": "stop",
+    "usage": {
+      "input_tokens": 5,
+      "output_tokens": 2,
+      "reasoning_tokens": 0,
+      "cache_read_tokens": 0,
+      "cache_write_tokens": 0
+    },
+    "response": {
+      "id": "msg_kimi",
+      "model": "kimi-test",
+      "provider": "kimi",
+      "message": {
+        "role": "assistant",
+        "content": [
+          {
+            "kind": "text",
+            "data": "Hi"
+          }
+        ],
+        "name": null,
+        "tool_call_id": null
+      },
+      "finish_reason": "stop",
+      "usage": {
+        "input_tokens": 5,
+        "output_tokens": 2,
+        "reasoning_tokens": 0,
+        "cache_read_tokens": 0,
+        "cache_write_tokens": 0
+      },
+      "raw": null,
+      "warnings": [],
+      "rate_limit": null
+    }
+  }
+]

--- a/lib/crates/fabro-llm/tests/it/wire/snapshots/it__wire__anthropic__custom_named_stream_route.snap
+++ b/lib/crates/fabro-llm/tests/it/wire/snapshots/it__wire__anthropic__custom_named_stream_route.snap
@@ -1,0 +1,47 @@
+---
+source: lib/crates/fabro-llm/tests/it/wire/anthropic.rs
+expression: rendered
+---
+{
+  "method": "POST",
+  "path": "/messages",
+  "headers": [
+    [
+      "accept",
+      "*/*"
+    ],
+    [
+      "authorization",
+      "Bearer test-key"
+    ],
+    [
+      "content-length",
+      "144"
+    ],
+    [
+      "content-type",
+      "application/json"
+    ],
+    [
+      "host",
+      "[host]"
+    ]
+  ],
+  "body": {
+    "model": "kimi-test",
+    "messages": [
+      {
+        "role": "user",
+        "content": [
+          {
+            "type": "text",
+            "text": "Hello"
+          }
+        ]
+      }
+    ],
+    "max_tokens": 128,
+    "stop_sequences": [],
+    "stream": true
+  }
+}

--- a/lib/crates/fabro-llm/tests/it/wire/snapshots/it__wire__gemini__custom_named_http_error_identity.snap
+++ b/lib/crates/fabro-llm/tests/it/wire/snapshots/it__wire__gemini__custom_named_http_error_identity.snap
@@ -1,0 +1,9 @@
+---
+source: lib/crates/fabro-llm/tests/it/wire/gemini.rs
+expression: rendered
+---
+{
+  "error": "Server error from gemini-proxy: backend exploded",
+  "retryable": true,
+  "failover_eligible": true
+}

--- a/lib/crates/fabro-llm/tests/it/wire/snapshots/it__wire__gemini__custom_named_stream_identity.snap
+++ b/lib/crates/fabro-llm/tests/it/wire/snapshots/it__wire__gemini__custom_named_stream_identity.snap
@@ -1,0 +1,60 @@
+---
+source: lib/crates/fabro-llm/tests/it/wire/gemini.rs
+expression: rendered
+---
+[
+  {
+    "type": "stream_start"
+  },
+  {
+    "type": "text_start",
+    "text_id": "[UUID]"
+  },
+  {
+    "type": "text_delta",
+    "delta": "Hi",
+    "text_id": "[UUID]"
+  },
+  {
+    "type": "text_end",
+    "text_id": "[UUID]"
+  },
+  {
+    "type": "finish",
+    "finish_reason": "stop",
+    "usage": {
+      "input_tokens": 5,
+      "output_tokens": 2,
+      "reasoning_tokens": 0,
+      "cache_read_tokens": 0,
+      "cache_write_tokens": 0
+    },
+    "response": {
+      "id": "[UUID]",
+      "model": "gemini-test",
+      "provider": "gemini-proxy",
+      "message": {
+        "role": "assistant",
+        "content": [
+          {
+            "kind": "text",
+            "data": "Hi"
+          }
+        ],
+        "name": null,
+        "tool_call_id": null
+      },
+      "finish_reason": "stop",
+      "usage": {
+        "input_tokens": 5,
+        "output_tokens": 2,
+        "reasoning_tokens": 0,
+        "cache_read_tokens": 0,
+        "cache_write_tokens": 0
+      },
+      "raw": null,
+      "warnings": [],
+      "rate_limit": null
+    }
+  }
+]

--- a/lib/crates/fabro-llm/tests/it/wire/snapshots/it__wire__openai_responses__custom_named_stream_failed_event_identity.snap
+++ b/lib/crates/fabro-llm/tests/it/wire/snapshots/it__wire__openai_responses__custom_named_stream_failed_event_identity.snap
@@ -1,0 +1,14 @@
+---
+source: lib/crates/fabro-llm/tests/it/wire/openai_responses.rs
+expression: rendered
+---
+[
+  {
+    "type": "stream_start"
+  },
+  {
+    "stream_item_error": "Server error from openai-proxy: boom",
+    "retryable": true,
+    "failover_eligible": true
+  }
+]


### PR DESCRIPTION
## What

Threads the configured provider name through the response and error paths so custom-named providers report their real identity. Previously several sites used hardcoded literals:

- streamed `Response.provider` always said `"anthropic"` / `"openai"` / `"gemini"` regardless of the configured name;
- OpenAI's **non-stream** `Response.provider` ignored `with_name` entirely;
- `ProviderErrorDetail.provider` in error paths (stream error events, HTTP/gRPC status mapping, request error contexts) carried the same literals.

Now the name flows through anthropic's `StreamAccumulator`, openai's `SseStreamState` / error-json mapper / complete + error paths, and gemini's stream state and error helpers.

## Why

One adapter code path already serves multiple providers — e.g. Kimi runs through the anthropic adapter via `with_name`, and the seven compat providers share one adapter. The "this file == this provider" assumption baked into the literals is wrong for those routes: a Kimi request that 429s reported `"Server error from anthropic"`, and its usage/error records were misattributed. The fix was also inconsistent before this change — some paths already used `provider_name` while the stream paths didn't, so the same request could be attributed differently depending on whether it streamed.

This is foundational for an upcoming gateway refactor that makes codec/transport/provider orthogonal, where identity must travel with the route as data rather than being hardcoded per adapter.

## Behavior change

The one intentional, behavior-visible delta: **custom-named providers** now report their configured name in `Response.provider` and `ProviderErrorDetail.provider`. Built-in default-named providers are byte-identical — the wire snapshot suite from #471 passes unmodified. Failover/retry policy keys on `ProviderErrorKind` and the `retryable()` / `failover_eligible()` flags, never on the provider string, so the error-detail change is display/log/signature-only (confirmed by a consumer sweep).

## Tests

New per-dialect `custom_named_*` wire tests pin the intentional deltas, including a capture of the Kimi-over-anthropic route shape (bearer auth, no `anthropic-version` header) — useful as a pin for the route-config work later in the refactor.

- `cargo nextest run -p fabro-llm` — 515 passed
- `cargo +nightly fmt --check` / `clippy --all-targets -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)