### PR TITLE
test(llm): refresh wire snapshots for omitted null Message fields

### DIFF
--- a/lib/crates/fabro-llm/tests/it/wire/snapshots/it__wire__anthropic__custom_named_stream_identity.snap
+++ b/lib/crates/fabro-llm/tests/it/wire/snapshots/it__wire__anthropic__custom_named_stream_identity.snap
@@ -40,9 +40,7 @@ expression: rendered
             "kind": "text",
             "data": "Hi"
           }
-        ],
-        "name": null,
-        "tool_call_id": null
+        ]
       },
       "finish_reason": "stop",
       "usage": {

--- a/lib/crates/fabro-llm/tests/it/wire/snapshots/it__wire__anthropic__decode_max_tokens_stop_reason.snap
+++ b/lib/crates/fabro-llm/tests/it/wire/snapshots/it__wire__anthropic__decode_max_tokens_stop_reason.snap
@@ -13,9 +13,7 @@ expression: rendered
         "kind": "text",
         "data": "Truncated answe"
       }
-    ],
-    "name": null,
-    "tool_call_id": null
+    ]
   },
   "finish_reason": "length",
   "usage": {

--- a/lib/crates/fabro-llm/tests/it/wire/snapshots/it__wire__anthropic__decode_thinking_and_redacted_thinking.snap
+++ b/lib/crates/fabro-llm/tests/it/wire/snapshots/it__wire__anthropic__decode_thinking_and_redacted_thinking.snap
@@ -29,9 +29,7 @@ expression: rendered
         "kind": "text",
         "data": "Done."
       }
-    ],
-    "name": null,
-    "tool_call_id": null
+    ]
   },
   "finish_reason": "stop",
   "usage": {

--- a/lib/crates/fabro-llm/tests/it/wire/snapshots/it__wire__anthropic__decode_tool_use_stop_reason.snap
+++ b/lib/crates/fabro-llm/tests/it/wire/snapshots/it__wire__anthropic__decode_tool_use_stop_reason.snap
@@ -25,9 +25,7 @@ expression: rendered
           "raw_arguments": null
         }
       }
-    ],
-    "name": null,
-    "tool_call_id": null
+    ]
   },
   "finish_reason": "tool_calls",
   "usage": {

--- a/lib/crates/fabro-llm/tests/it/wire/snapshots/it__wire__anthropic__stream_text_happy_path_events.snap
+++ b/lib/crates/fabro-llm/tests/it/wire/snapshots/it__wire__anthropic__stream_text_happy_path_events.snap
@@ -45,9 +45,7 @@ expression: rendered
             "kind": "text",
             "data": "Hello"
           }
-        ],
-        "name": null,
-        "tool_call_id": null
+        ]
       },
       "finish_reason": "stop",
       "usage": {

--- a/lib/crates/fabro-llm/tests/it/wire/snapshots/it__wire__anthropic__stream_thinking_with_signature_delta.snap
+++ b/lib/crates/fabro-llm/tests/it/wire/snapshots/it__wire__anthropic__stream_thinking_with_signature_delta.snap
@@ -58,9 +58,7 @@ expression: rendered
             "kind": "text",
             "data": "4."
           }
-        ],
-        "name": null,
-        "tool_call_id": null
+        ]
       },
       "finish_reason": "stop",
       "usage": {

--- a/lib/crates/fabro-llm/tests/it/wire/snapshots/it__wire__anthropic__stream_tool_call_deltas.snap
+++ b/lib/crates/fabro-llm/tests/it/wire/snapshots/it__wire__anthropic__stream_tool_call_deltas.snap
@@ -77,9 +77,7 @@ expression: rendered
               "raw_arguments": "{\"query\":\"foo\"}"
             }
           }
-        ],
-        "name": null,
-        "tool_call_id": null
+        ]
       },
       "finish_reason": "tool_calls",
       "usage": {

--- a/lib/crates/fabro-llm/tests/it/wire/snapshots/it__wire__anthropic__system_and_tools_decode.snap
+++ b/lib/crates/fabro-llm/tests/it/wire/snapshots/it__wire__anthropic__system_and_tools_decode.snap
@@ -13,9 +13,7 @@ expression: rendered
         "kind": "text",
         "data": "Hello back"
       }
-    ],
-    "name": null,
-    "tool_call_id": null
+    ]
   },
   "finish_reason": "stop",
   "usage": {

--- a/lib/crates/fabro-llm/tests/it/wire/snapshots/it__wire__gemini__custom_named_stream_identity.snap
+++ b/lib/crates/fabro-llm/tests/it/wire/snapshots/it__wire__gemini__custom_named_stream_identity.snap
@@ -40,9 +40,7 @@ expression: rendered
             "kind": "text",
             "data": "Hi"
           }
-        ],
-        "name": null,
-        "tool_call_id": null
+        ]
       },
       "finish_reason": "stop",
       "usage": {

--- a/lib/crates/fabro-llm/tests/it/wire/snapshots/it__wire__gemini__decode_function_call_with_thought_signature.snap
+++ b/lib/crates/fabro-llm/tests/it/wire/snapshots/it__wire__gemini__decode_function_call_with_thought_signature.snap
@@ -28,9 +28,7 @@ expression: rendered
           }
         }
       }
-    ],
-    "name": null,
-    "tool_call_id": null
+    ]
   },
   "finish_reason": "tool_calls",
   "usage": {

--- a/lib/crates/fabro-llm/tests/it/wire/snapshots/it__wire__gemini__decode_thought_parts.snap
+++ b/lib/crates/fabro-llm/tests/it/wire/snapshots/it__wire__gemini__decode_thought_parts.snap
@@ -21,9 +21,7 @@ expression: rendered
         "kind": "text",
         "data": "4."
       }
-    ],
-    "name": null,
-    "tool_call_id": null
+    ]
   },
   "finish_reason": "stop",
   "usage": {

--- a/lib/crates/fabro-llm/tests/it/wire/snapshots/it__wire__gemini__decode_usage_arithmetic.snap
+++ b/lib/crates/fabro-llm/tests/it/wire/snapshots/it__wire__gemini__decode_usage_arithmetic.snap
@@ -13,9 +13,7 @@ expression: rendered
         "kind": "text",
         "data": "ok"
       }
-    ],
-    "name": null,
-    "tool_call_id": null
+    ]
   },
   "finish_reason": "stop",
   "usage": {

--- a/lib/crates/fabro-llm/tests/it/wire/snapshots/it__wire__gemini__stream_end_synthesizes_finish_without_finish_reason.snap
+++ b/lib/crates/fabro-llm/tests/it/wire/snapshots/it__wire__gemini__stream_end_synthesizes_finish_without_finish_reason.snap
@@ -36,9 +36,7 @@ expression: rendered
             "kind": "text",
             "data": "Hello"
           }
-        ],
-        "name": null,
-        "tool_call_id": null
+        ]
       },
       "finish_reason": "stop",
       "usage": {

--- a/lib/crates/fabro-llm/tests/it/wire/snapshots/it__wire__gemini__stream_function_call.snap
+++ b/lib/crates/fabro-llm/tests/it/wire/snapshots/it__wire__gemini__stream_function_call.snap
@@ -68,9 +68,7 @@ expression: rendered
               }
             }
           }
-        ],
-        "name": null,
-        "tool_call_id": null
+        ]
       },
       "finish_reason": "tool_calls",
       "usage": {

--- a/lib/crates/fabro-llm/tests/it/wire/snapshots/it__wire__gemini__stream_text_happy_path_events.snap
+++ b/lib/crates/fabro-llm/tests/it/wire/snapshots/it__wire__gemini__stream_text_happy_path_events.snap
@@ -45,9 +45,7 @@ expression: rendered
             "kind": "text",
             "data": "Hello"
           }
-        ],
-        "name": null,
-        "tool_call_id": null
+        ]
       },
       "finish_reason": "stop",
       "usage": {

--- a/lib/crates/fabro-llm/tests/it/wire/snapshots/it__wire__gemini__stream_thought_parts.snap
+++ b/lib/crates/fabro-llm/tests/it/wire/snapshots/it__wire__gemini__stream_thought_parts.snap
@@ -58,9 +58,7 @@ expression: rendered
             "kind": "text",
             "data": "4."
           }
-        ],
-        "name": null,
-        "tool_call_id": null
+        ]
       },
       "finish_reason": "stop",
       "usage": {

--- a/lib/crates/fabro-llm/tests/it/wire/snapshots/it__wire__gemini__system_and_tools_decode.snap
+++ b/lib/crates/fabro-llm/tests/it/wire/snapshots/it__wire__gemini__system_and_tools_decode.snap
@@ -13,9 +13,7 @@ expression: rendered
         "kind": "text",
         "data": "Hello back"
       }
-    ],
-    "name": null,
-    "tool_call_id": null
+    ]
   },
   "finish_reason": "stop",
   "usage": {

--- a/lib/crates/fabro-llm/tests/it/wire/snapshots/it__wire__openai_compatible__decode_reasoning_content_as_thinking.snap
+++ b/lib/crates/fabro-llm/tests/it/wire/snapshots/it__wire__openai_compatible__decode_reasoning_content_as_thinking.snap
@@ -21,9 +21,7 @@ expression: rendered
         "kind": "text",
         "data": "4."
       }
-    ],
-    "name": null,
-    "tool_call_id": null
+    ]
   },
   "finish_reason": "stop",
   "usage": {

--- a/lib/crates/fabro-llm/tests/it/wire/snapshots/it__wire__openai_compatible__decode_tool_calls_with_string_arguments.snap
+++ b/lib/crates/fabro-llm/tests/it/wire/snapshots/it__wire__openai_compatible__decode_tool_calls_with_string_arguments.snap
@@ -21,9 +21,7 @@ expression: rendered
           "raw_arguments": "{\"query\":\"foo\"}"
         }
       }
-    ],
-    "name": null,
-    "tool_call_id": null
+    ]
   },
   "finish_reason": "tool_calls",
   "usage": {

--- a/lib/crates/fabro-llm/tests/it/wire/snapshots/it__wire__openai_compatible__decode_usage_ignores_token_details.snap
+++ b/lib/crates/fabro-llm/tests/it/wire/snapshots/it__wire__openai_compatible__decode_usage_ignores_token_details.snap
@@ -13,9 +13,7 @@ expression: rendered
         "kind": "text",
         "data": "ok"
       }
-    ],
-    "name": null,
-    "tool_call_id": null
+    ]
   },
   "finish_reason": "length",
   "usage": {

--- a/lib/crates/fabro-llm/tests/it/wire/snapshots/it__wire__openai_compatible__stream_reasoning_content_deltas.snap
+++ b/lib/crates/fabro-llm/tests/it/wire/snapshots/it__wire__openai_compatible__stream_reasoning_content_deltas.snap
@@ -45,9 +45,7 @@ expression: rendered
             "kind": "text",
             "data": "4."
           }
-        ],
-        "name": null,
-        "tool_call_id": null
+        ]
       },
       "finish_reason": "stop",
       "usage": {

--- a/lib/crates/fabro-llm/tests/it/wire/snapshots/it__wire__openai_compatible__stream_text_happy_path_events.snap
+++ b/lib/crates/fabro-llm/tests/it/wire/snapshots/it__wire__openai_compatible__stream_text_happy_path_events.snap
@@ -42,9 +42,7 @@ expression: rendered
             "kind": "text",
             "data": "Hello"
           }
-        ],
-        "name": null,
-        "tool_call_id": null
+        ]
       },
       "finish_reason": "stop",
       "usage": {

--- a/lib/crates/fabro-llm/tests/it/wire/snapshots/it__wire__openai_compatible__stream_tool_call_deltas.snap
+++ b/lib/crates/fabro-llm/tests/it/wire/snapshots/it__wire__openai_compatible__stream_tool_call_deltas.snap
@@ -74,9 +74,7 @@ expression: rendered
               "raw_arguments": "{\"query\":\"foo\"}"
             }
           }
-        ],
-        "name": null,
-        "tool_call_id": null
+        ]
       },
       "finish_reason": "tool_calls",
       "usage": {

--- a/lib/crates/fabro-llm/tests/it/wire/snapshots/it__wire__openai_compatible__stream_without_done_synthesizes_finish_when_content_started.snap
+++ b/lib/crates/fabro-llm/tests/it/wire/snapshots/it__wire__openai_compatible__stream_without_done_synthesizes_finish_when_content_started.snap
@@ -37,9 +37,7 @@ expression: rendered
             "kind": "text",
             "data": "Hello"
           }
-        ],
-        "name": null,
-        "tool_call_id": null
+        ]
       },
       "finish_reason": "stop",
       "usage": {

--- a/lib/crates/fabro-llm/tests/it/wire/snapshots/it__wire__openai_compatible__system_and_tools_decode.snap
+++ b/lib/crates/fabro-llm/tests/it/wire/snapshots/it__wire__openai_compatible__system_and_tools_decode.snap
@@ -13,9 +13,7 @@ expression: rendered
         "kind": "text",
         "data": "Hello back"
       }
-    ],
-    "name": null,
-    "tool_call_id": null
+    ]
   },
   "finish_reason": "stop",
   "usage": {

--- a/lib/crates/fabro-llm/tests/it/wire/snapshots/it__wire__openai_responses__decode_incomplete_status_maps_to_length.snap
+++ b/lib/crates/fabro-llm/tests/it/wire/snapshots/it__wire__openai_responses__decode_incomplete_status_maps_to_length.snap
@@ -27,9 +27,7 @@ expression: rendered
         "kind": "text",
         "data": "Truncated"
       }
-    ],
-    "name": null,
-    "tool_call_id": null
+    ]
   },
   "finish_reason": "length",
   "usage": {

--- a/lib/crates/fabro-llm/tests/it/wire/snapshots/it__wire__openai_responses__decode_reasoning_and_function_call_items.snap
+++ b/lib/crates/fabro-llm/tests/it/wire/snapshots/it__wire__openai_responses__decode_reasoning_and_function_call_items.snap
@@ -37,9 +37,7 @@ expression: rendered
           }
         }
       }
-    ],
-    "name": null,
-    "tool_call_id": null
+    ]
   },
   "finish_reason": "tool_calls",
   "usage": {

--- a/lib/crates/fabro-llm/tests/it/wire/snapshots/it__wire__openai_responses__decode_usage_subtracts_cached_and_reasoning.snap
+++ b/lib/crates/fabro-llm/tests/it/wire/snapshots/it__wire__openai_responses__decode_usage_subtracts_cached_and_reasoning.snap
@@ -27,9 +27,7 @@ expression: rendered
         "kind": "text",
         "data": "ok"
       }
-    ],
-    "name": null,
-    "tool_call_id": null
+    ]
   },
   "finish_reason": "stop",
   "usage": {

--- a/lib/crates/fabro-llm/tests/it/wire/snapshots/it__wire__openai_responses__stream_incomplete_maps_to_length.snap
+++ b/lib/crates/fabro-llm/tests/it/wire/snapshots/it__wire__openai_responses__stream_incomplete_maps_to_length.snap
@@ -36,9 +36,7 @@ expression: rendered
             "kind": "text",
             "data": "Trunc"
           }
-        ],
-        "name": null,
-        "tool_call_id": null
+        ]
       },
       "finish_reason": "length",
       "usage": {

--- a/lib/crates/fabro-llm/tests/it/wire/snapshots/it__wire__openai_responses__stream_reasoning_summary_deltas.snap
+++ b/lib/crates/fabro-llm/tests/it/wire/snapshots/it__wire__openai_responses__stream_reasoning_summary_deltas.snap
@@ -47,9 +47,7 @@ expression: rendered
             "kind": "text",
             "data": "4."
           }
-        ],
-        "name": null,
-        "tool_call_id": null
+        ]
       },
       "finish_reason": "stop",
       "usage": {

--- a/lib/crates/fabro-llm/tests/it/wire/snapshots/it__wire__openai_responses__stream_text_happy_path_events.snap
+++ b/lib/crates/fabro-llm/tests/it/wire/snapshots/it__wire__openai_responses__stream_text_happy_path_events.snap
@@ -41,9 +41,7 @@ expression: rendered
             "kind": "text",
             "data": "Hello"
           }
-        ],
-        "name": null,
-        "tool_call_id": null
+        ]
       },
       "finish_reason": "stop",
       "usage": {

--- a/lib/crates/fabro-llm/tests/it/wire/snapshots/it__wire__openai_responses__stream_tool_call_deltas.snap
+++ b/lib/crates/fabro-llm/tests/it/wire/snapshots/it__wire__openai_responses__stream_tool_call_deltas.snap
@@ -92,9 +92,7 @@ expression: rendered
               }
             }
           }
-        ],
-        "name": null,
-        "tool_call_id": null
+        ]
       },
       "finish_reason": "tool_calls",
       "usage": {

--- a/lib/crates/fabro-llm/tests/it/wire/snapshots/it__wire__openai_responses__system_and_tools_decode.snap
+++ b/lib/crates/fabro-llm/tests/it/wire/snapshots/it__wire__openai_responses__system_and_tools_decode.snap
@@ -27,9 +27,7 @@ expression: rendered
         "kind": "text",
         "data": "Hello back"
       }
-    ],
-    "name": null,
-    "tool_call_id": null
+    ]
   },
   "finish_reason": "stop",
   "usage": {


### PR DESCRIPTION
## Summary

Fixes the 33 `fabro-llm::it wire::*` snapshot failures currently red on `main`.

These are a **semantic merge conflict** between two PRs that landed in
parallel, not a behavior regression:

- **#450** made the canonical `fabro_types::Message` omit absent optional
  fields (`name`, `tool_call_id`) via `#[serde(skip_serializing_if = "Option::is_none")]`,
  to match the OpenAPI completions wire contract.
- **#471** added the per-dialect wire snapshots in parallel, authored
  against the older shape that emitted explicit `"name": null` /
  `"tool_call_id": null`.

Each PR was green on its own branch (#450 never contained #471's
snapshots; #471 predated #450's serde change). They only collided once
both sat on `main` together — and because the serde attribute and the
snapshots live in different files, there was no textual git conflict to
flag it at merge time.

## What changed

Regenerated the 33 affected snapshots (anthropic / gemini /
openai_compatible / openai_responses) via `cargo insta accept`. The
**only** change in every snapshot is the removal of the two trailing
null fields:

```diff
-    ],
-    "name": null,
-    "tool_call_id": null
+    ]
```

No decode/stream behavior changed; the new shape is the intended
canonical serialization.

## Test plan

- [x] `cargo nextest run -p fabro-llm` — 515 passed, 0 failed
- [x] Verified the diff across all 33 snapshots is uniformly the
      null-field omission (plus the `],`→`]` reflow), nothing else

🤖 Generated with [Claude Code](https://claude.com/claude-code)