### PR TITLE
refactor(llm): extract codec/gemini_generate behind the Codec trait

### DIFF
--- a/lib/crates/fabro-llm/src/codec/gemini_generate/decode.rs
+++ b/lib/crates/fabro-llm/src/codec/gemini_generate/decode.rs
@@ -169,3 +169,196 @@ pub(super) fn decode_count_tokens(body: &str) -> Result<i64, Error> {
         })?;
     Ok(response.total_tokens)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn token_counts_disjoint_with_cache_thoughts_and_tool_use() {
+        let body = serde_json::json!({
+            "promptTokenCount": 200,
+            "cachedContentTokenCount": 180,
+            "candidatesTokenCount": 200,
+            "thoughtsTokenCount": 300,
+            "toolUsePromptTokenCount": 400
+        });
+        let meta: UsageMetadata = serde_json::from_value(body).unwrap();
+        let usage = parse_usage(Some(&meta));
+
+        assert_eq!(usage.input_tokens, 420);
+        assert_eq!(usage.cache_read_tokens, 180);
+        assert_eq!(usage.output_tokens, 200);
+        assert_eq!(usage.reasoning_tokens, 300);
+        assert_eq!(usage.cache_write_tokens, 0);
+        assert_eq!(usage.total_tokens(), 1100);
+    }
+
+    #[test]
+    fn gemini_error_uses_grpc_status_when_available() {
+        let err = gemini_error(
+            400,
+            "model not found".into(),
+            "gemini",
+            Some("NOT_FOUND".into()),
+            None,
+            None,
+        );
+        assert!(matches!(err, Error::Provider {
+            kind: ProviderErrorKind::NotFound,
+            ..
+        }));
+
+        let err = gemini_error(
+            400,
+            "bad args".into(),
+            "gemini",
+            Some("INVALID_ARGUMENT".into()),
+            None,
+            None,
+        );
+        assert!(matches!(err, Error::Provider {
+            kind: ProviderErrorKind::InvalidRequest,
+            ..
+        }));
+
+        let err = gemini_error(
+            429,
+            "rate limited".into(),
+            "gemini",
+            Some("RESOURCE_EXHAUSTED".into()),
+            None,
+            None,
+        );
+        assert!(matches!(err, Error::Provider {
+            kind: ProviderErrorKind::RateLimit,
+            ..
+        }));
+
+        let err = gemini_error(
+            401,
+            "bad key".into(),
+            "gemini",
+            Some("UNAUTHENTICATED".into()),
+            None,
+            None,
+        );
+        assert!(matches!(err, Error::Provider {
+            kind: ProviderErrorKind::Authentication,
+            ..
+        }));
+
+        let err = gemini_error(
+            403,
+            "denied".into(),
+            "gemini",
+            Some("PERMISSION_DENIED".into()),
+            None,
+            None,
+        );
+        assert!(matches!(err, Error::Provider {
+            kind: ProviderErrorKind::AccessDenied,
+            ..
+        }));
+
+        let err = gemini_error(
+            504,
+            "timeout".into(),
+            "gemini",
+            Some("DEADLINE_EXCEEDED".into()),
+            None,
+            None,
+        );
+        assert!(matches!(err, Error::RequestTimeout { .. }));
+    }
+
+    #[test]
+    fn gemini_error_falls_back_to_http_status_without_grpc() {
+        let err = gemini_error(429, "rate limited".into(), "gemini", None, None, None);
+        assert!(matches!(err, Error::Provider {
+            kind: ProviderErrorKind::RateLimit,
+            ..
+        }));
+
+        let err = gemini_error(500, "internal".into(), "gemini", None, None, None);
+        assert!(matches!(err, Error::Provider {
+            kind: ProviderErrorKind::Server,
+            ..
+        }));
+    }
+
+    #[test]
+    fn parse_part_handles_thought_text() {
+        let part = serde_json::json!({"text": "Let me think about this...", "thought": true});
+        let result = parse_part(&part).expect("should parse thought part");
+        match result {
+            ContentPart::Thinking(td) => {
+                assert_eq!(td.text, "Let me think about this...");
+                assert!(td.signature.is_none());
+                assert!(!td.redacted);
+            }
+            other => panic!("expected Thinking, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_part_text_without_thought_flag() {
+        let part = serde_json::json!({"text": "Hello world"});
+        let result = parse_part(&part).expect("should parse text part");
+        match result {
+            ContentPart::Text(text) => assert_eq!(text, "Hello world"),
+            other => panic!("expected Text, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_part_function_call() {
+        let part = serde_json::json!({
+            "functionCall": {
+                "name": "get_weather",
+                "args": {"location": "NYC"}
+            }
+        });
+        let result = parse_part(&part).expect("should parse function call");
+        match result {
+            ContentPart::ToolCall(tc) => {
+                assert_eq!(tc.name, "get_weather");
+                assert_eq!(tc.arguments, serde_json::json!({"location": "NYC"}));
+                assert!(tc.provider_metadata.is_none());
+            }
+            other => panic!("expected ToolCall, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_part_function_call_with_thought_signature() {
+        let part = serde_json::json!({
+            "functionCall": {
+                "name": "get_weather",
+                "args": {"location": "NYC"}
+            },
+            "thoughtSignature": "abc123sig"
+        });
+        let result = parse_part(&part).expect("should parse function call with thought signature");
+        match result {
+            ContentPart::ToolCall(tc) => {
+                assert_eq!(tc.name, "get_weather");
+                let meta = tc
+                    .provider_metadata
+                    .expect("provider_metadata should be set");
+                assert_eq!(meta["thoughtSignature"], "abc123sig");
+            }
+            other => panic!("expected ToolCall, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_part_thought_false_is_regular_text() {
+        let part = serde_json::json!({"text": "Regular text", "thought": false});
+        let result = parse_part(&part).expect("should parse text part");
+        match result {
+            ContentPart::Text(text) => assert_eq!(text, "Regular text"),
+            other => panic!("expected Text, got {other:?}"),
+        }
+    }
+}

--- a/lib/crates/fabro-llm/src/codec/gemini_generate/decode.rs
+++ b/lib/crates/fabro-llm/src/codec/gemini_generate/decode.rs
@@ -1,6 +1,8 @@
 //! Response decoding: Gemini `generateContent` body → canonical `Response`,
 //! plus the gRPC-status error mapping behind the codec's `decode_error`.
 
+use serde::Deserialize;
+
 use super::wire::{ApiResponse, CountTokensResponse, UsageMetadata};
 use crate::codec::CodecCtx;
 use crate::error::{
@@ -116,7 +118,9 @@ pub(super) fn decode_response(
     ctx: &CodecCtx<'_>,
     rate_limit: Option<RateLimitInfo>,
 ) -> Result<Response, Error> {
-    let api_resp: ApiResponse = serde_json::from_str(body)
+    let raw: serde_json::Value = serde_json::from_str(body)
+        .map_err(|e| Error::network(format!("failed to parse Gemini response: {e}"), e))?;
+    let api_resp = ApiResponse::deserialize(&raw)
         .map_err(|e| Error::network(format!("failed to parse Gemini response: {e}"), e))?;
 
     let candidate = api_resp
@@ -155,7 +159,7 @@ pub(super) fn decode_response(
         },
         finish_reason,
         usage,
-        raw: serde_json::from_str(body).ok(),
+        raw: Some(raw),
         warnings: vec![],
         rate_limit,
     })

--- a/lib/crates/fabro-llm/src/codec/gemini_generate/decode.rs
+++ b/lib/crates/fabro-llm/src/codec/gemini_generate/decode.rs
@@ -1,0 +1,171 @@
+//! Response decoding: Gemini `generateContent` body → canonical `Response`,
+//! plus the gRPC-status error mapping behind the codec's `decode_error`.
+
+use super::wire::{ApiResponse, CountTokensResponse, UsageMetadata};
+use crate::codec::CodecCtx;
+use crate::error::{
+    Error, ProviderErrorDetail, ProviderErrorKind, error_from_grpc_status, error_from_status_code,
+};
+use crate::types::{
+    ContentPart, FinishReason, Message, RateLimitInfo, Response, Role, ThinkingData, TokenCounts,
+    ToolCall,
+};
+
+/// Map Gemini's finish reason, inferring `ToolCalls` from content when needed.
+pub(super) fn map_finish_reason(reason: Option<&str>, has_function_calls: bool) -> FinishReason {
+    if has_function_calls {
+        return FinishReason::ToolCalls;
+    }
+    match reason {
+        Some("STOP") | None => FinishReason::Stop,
+        Some("MAX_TOKENS") => FinishReason::Length,
+        Some("SAFETY" | "RECITATION") => FinishReason::ContentFilter,
+        Some(other) => FinishReason::Other(other.to_string()),
+    }
+}
+
+pub(super) fn parse_part(part: &serde_json::Value) -> Option<ContentPart> {
+    if let Some(text) = part.get("text").and_then(serde_json::Value::as_str) {
+        let is_thought = part
+            .get("thought")
+            .and_then(serde_json::Value::as_bool)
+            .unwrap_or(false);
+        if is_thought {
+            return Some(ContentPart::Thinking(ThinkingData {
+                text:      text.to_string(),
+                signature: None,
+                redacted:  false,
+            }));
+        }
+        return Some(ContentPart::text(text));
+    }
+    if let Some(fc) = part.get("functionCall") {
+        let name = fc.get("name")?.as_str()?.to_string();
+        let args = fc
+            .get("args")
+            .cloned()
+            .unwrap_or_else(|| serde_json::Value::Object(serde_json::Map::new()));
+        let mut tc = ToolCall::new(uuid::Uuid::new_v4().to_string(), name, args);
+        // Preserve thought_signature for Gemini 3 models (sibling of functionCall in
+        // the part)
+        if let Some(sig) = part.get("thoughtSignature") {
+            tc.provider_metadata = Some(serde_json::json!({"thoughtSignature": sig}));
+        }
+        return Some(ContentPart::ToolCall(tc));
+    }
+    None
+}
+
+/// Check if any parts contain function calls.
+pub(super) fn parts_have_function_calls(parts: &[serde_json::Value]) -> bool {
+    parts.iter().any(|p| p.get("functionCall").is_some())
+}
+
+/// Convert `UsageMetadata` from the Gemini API into a unified `TokenCounts`.
+pub(super) fn parse_usage(metadata: Option<&UsageMetadata>) -> TokenCounts {
+    metadata.map_or_else(TokenCounts::default, |u| {
+        let cache_read_tokens = u.cached_content_token_count.unwrap_or(0);
+        let reasoning_tokens = u.thoughts_token_count.unwrap_or(0);
+        let tool_use_prompt_tokens = u.tool_use_prompt_token_count.unwrap_or(0);
+        TokenCounts {
+            input_tokens: u
+                .prompt_token_count
+                .unwrap_or(0)
+                .saturating_sub(cache_read_tokens)
+                + tool_use_prompt_tokens,
+            output_tokens: u.candidates_token_count.unwrap_or(0),
+            reasoning_tokens,
+            cache_read_tokens,
+            ..TokenCounts::default()
+        }
+    })
+}
+
+/// Map a Gemini error response using gRPC status when available, falling back
+/// to HTTP status.
+pub(super) fn gemini_error(
+    status_code: u16,
+    msg: String,
+    provider: &str,
+    grpc_status: Option<String>,
+    raw: Option<serde_json::Value>,
+    retry_after: Option<f64>,
+) -> Error {
+    match grpc_status {
+        Some(grpc_code) => error_from_grpc_status(
+            &grpc_code,
+            msg,
+            provider.to_string(),
+            Some(grpc_code.clone()),
+            raw,
+            retry_after,
+        ),
+        None => error_from_status_code(
+            status_code,
+            msg,
+            provider.to_string(),
+            None,
+            raw,
+            retry_after,
+        ),
+    }
+}
+
+pub(super) fn decode_response(
+    body: &str,
+    ctx: &CodecCtx<'_>,
+    rate_limit: Option<RateLimitInfo>,
+) -> Result<Response, Error> {
+    let api_resp: ApiResponse = serde_json::from_str(body)
+        .map_err(|e| Error::network(format!("failed to parse Gemini response: {e}"), e))?;
+
+    let candidate = api_resp
+        .candidates
+        .as_ref()
+        .and_then(|c| c.first())
+        .ok_or_else(|| Error::Provider {
+            kind:   ProviderErrorKind::Server,
+            detail: Box::new(ProviderErrorDetail::new(
+                "no candidates in Gemini response",
+                ctx.provider_name,
+            )),
+        })?;
+
+    let raw_parts = candidate.content.as_ref().and_then(|c| c.parts.as_ref());
+
+    let content_parts: Vec<ContentPart> = raw_parts
+        .map(|parts| parts.iter().filter_map(parse_part).collect())
+        .unwrap_or_default();
+
+    // Gemini has no dedicated tool_calls finish reason; infer from parts
+    let has_tool_calls = raw_parts.is_some_and(|p| parts_have_function_calls(p));
+    let finish_reason = map_finish_reason(candidate.finish_reason.as_deref(), has_tool_calls);
+
+    let usage = parse_usage(api_resp.usage_metadata.as_ref());
+
+    Ok(Response {
+        id: uuid::Uuid::new_v4().to_string(),
+        model: ctx.request.model.clone(),
+        provider: ctx.provider_name.to_string(),
+        message: Message {
+            role:         Role::Assistant,
+            content:      content_parts,
+            name:         None,
+            tool_call_id: None,
+        },
+        finish_reason,
+        usage,
+        raw: serde_json::from_str(body).ok(),
+        warnings: vec![],
+        rate_limit,
+    })
+}
+
+pub(super) fn decode_count_tokens(body: &str) -> Result<i64, Error> {
+    let response: CountTokensResponse =
+        serde_json::from_str(body).map_err(|e| Error::Configuration {
+            message: format!("failed to parse Gemini token count: {e}"),
+            source:  None,
+        })?;
+    Ok(response.total_tokens)
+}

--- a/lib/crates/fabro-llm/src/codec/gemini_generate/encode.rs
+++ b/lib/crates/fabro-llm/src/codec/gemini_generate/encode.rs
@@ -345,7 +345,7 @@ mod tests {
     /// Build the request body the way the adapter's encode path does (no
     /// catalog: the wire model id is the request model).
     fn body_for(request: &Request) -> serde_json::Value {
-        let params = CodecParams;
+        let params = CodecParams::default();
         let ctx = CodecCtx {
             request,
             provider_name: "gemini",
@@ -367,7 +367,7 @@ mod tests {
     #[test]
     fn encode_endpoints_carry_model_and_streaming_variant() {
         let request = minimal_request();
-        let params = CodecParams;
+        let params = CodecParams::default();
         let ctx = CodecCtx {
             request:       &request,
             provider_name: "gemini",
@@ -398,7 +398,7 @@ mod tests {
             "Search files",
             serde_json::json!({"type": "object"}),
         )]);
-        let params = CodecParams;
+        let params = CodecParams::default();
         let ctx = CodecCtx {
             request:       &request,
             provider_name: "gemini",

--- a/lib/crates/fabro-llm/src/codec/gemini_generate/encode.rs
+++ b/lib/crates/fabro-llm/src/codec/gemini_generate/encode.rs
@@ -1,0 +1,319 @@
+//! Request encoding: canonical request → Gemini `generateContent` body +
+//! fully-formed endpoint (model-in-path, `?alt=sse` for streaming).
+//!
+//! Pure and sync. File-backed Image/Audio/Document attachments are resolved
+//! to inline data by `attachments::resolve` in the adapter *before* encode
+//! runs, so the content translation here never touches the filesystem.
+
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
+
+use super::wire::{
+    ApiRequest, Content, GeminiFunctionDecl, GeminiToolGroup, GenerationOptions, SystemInstruction,
+};
+use crate::codec::{CodecCtx, EncodedRequest};
+use crate::providers::common::extract_system_prompt;
+use crate::types::{
+    ContentPart, Message, ResponseFormat, ResponseFormatType, Role, ToolChoice, ToolDefinition,
+};
+
+// --- Public entry points -----------------------------------------------------
+
+pub(super) fn encode(ctx: &CodecCtx<'_>, stream: bool) -> EncodedRequest {
+    let endpoint = if stream {
+        format!(
+            "/models/{}:streamGenerateContent?alt=sse",
+            ctx.deployment_id
+        )
+    } else {
+        format!("/models/{}:generateContent", ctx.deployment_id)
+    };
+    EncodedRequest {
+        body: build_body(ctx),
+        endpoint,
+        headers: Vec::new(),
+    }
+}
+
+pub(super) fn encode_count_tokens(ctx: &CodecCtx<'_>) -> EncodedRequest {
+    EncodedRequest {
+        body:     serde_json::json!({ "generateContentRequest": build_body(ctx) }),
+        endpoint: format!("/models/{}:countTokens", ctx.deployment_id),
+        headers:  Vec::new(),
+    }
+}
+
+/// Build the Gemini API request body from the canonical request.
+///
+/// Returns a `serde_json::Value` so that `provider_options.gemini` fields can
+/// be merged into the request before sending.
+pub(super) fn build_body(ctx: &CodecCtx<'_>) -> serde_json::Value {
+    let request = ctx.request;
+    let (system_text, other_messages) = extract_system_prompt(&request.messages);
+
+    let system_instruction = system_text.map(|text| SystemInstruction {
+        parts: vec![serde_json::json!({"text": text})],
+    });
+
+    let contents = translate_messages(&other_messages);
+
+    let (response_mime_type, response_schema) = request
+        .response_format
+        .as_ref()
+        .map_or((None, None), translate_response_format);
+
+    let generation_config = GenerationOptions {
+        temperature: request.temperature,
+        max_output_tokens: request.max_tokens,
+        top_p: request.top_p,
+        stop_sequences: request.stop_sequences.clone(),
+        response_mime_type,
+        response_schema,
+    };
+
+    let api_tools = request.tools.as_ref().map(|t| translate_tools(t));
+    let tool_config = request.tool_choice.as_ref().map(translate_tool_choice);
+
+    let api_request = ApiRequest {
+        contents,
+        system_instruction,
+        generation_config: Some(generation_config),
+        tools: api_tools,
+        tool_config,
+    };
+
+    let mut body = serde_json::to_value(&api_request).unwrap_or_default();
+    merge_provider_options(&mut body, request.provider_options.as_ref());
+    apply_default_safety_settings(&mut body);
+    body
+}
+
+// --- Content / message / tool translation ------------------------------------
+
+/// Build a mapping from tool call ID to function name by scanning assistant
+/// messages.
+///
+/// Gemini uses function names (not call IDs) in `functionResponse`. Since the
+/// decoder generates synthetic UUIDs as tool call IDs, we need this mapping to
+/// recover the original function name when sending tool results back.
+fn build_tool_call_id_to_name(messages: &[&Message]) -> std::collections::HashMap<String, String> {
+    let mut map = std::collections::HashMap::new();
+    for msg in messages {
+        if msg.role == Role::Assistant {
+            for part in &msg.content {
+                if let ContentPart::ToolCall(tc) = part {
+                    map.insert(tc.id.clone(), tc.name.clone());
+                }
+            }
+        }
+    }
+    map
+}
+
+/// Translate unified messages to Gemini content format. Sync: file-backed
+/// attachments are already resolved to inline data upstream.
+pub(super) fn translate_messages(messages: &[&Message]) -> Vec<Content> {
+    let id_to_name = build_tool_call_id_to_name(messages);
+    let mut contents: Vec<Content> = Vec::new();
+
+    for msg in messages {
+        let role = match msg.role {
+            Role::Assistant => "model",
+            Role::User | Role::Tool => "user",
+            Role::System | Role::Developer => continue,
+        };
+
+        let mut parts = Vec::new();
+        for part in &msg.content {
+            let maybe_part = match part {
+                ContentPart::Text(text) => Some(serde_json::json!({"text": text})),
+                ContentPart::ToolCall(tc) => {
+                    let mut part_json = serde_json::json!({
+                        "functionCall": {
+                            "name": tc.name,
+                            "args": tc.arguments,
+                        }
+                    });
+                    // Re-attach thought_signature as sibling of functionCall
+                    if let Some(sig) = tc
+                        .provider_metadata
+                        .as_ref()
+                        .and_then(|m| m.get("thoughtSignature"))
+                    {
+                        part_json["thoughtSignature"] = sig.clone();
+                    }
+                    Some(part_json)
+                }
+                ContentPart::Image(img) => match &img.url {
+                    Some(url) => {
+                        let mime = img.media_type.as_deref().unwrap_or("image/png");
+                        Some(serde_json::json!({
+                            "fileData": {"mimeType": mime, "fileUri": url}
+                        }))
+                    }
+                    None => img.data.as_ref().map(|data| {
+                        let mime = img.media_type.as_deref().unwrap_or("image/png");
+                        let b64 = BASE64_STANDARD.encode(data);
+                        serde_json::json!({"inlineData": {"mimeType": mime, "data": b64}})
+                    }),
+                },
+                ContentPart::Audio(audio) => match &audio.url {
+                    Some(url) => {
+                        let mime = audio.media_type.as_deref().unwrap_or("audio/wav");
+                        Some(serde_json::json!({
+                            "fileData": {"mimeType": mime, "fileUri": url}
+                        }))
+                    }
+                    None => audio.data.as_ref().map(|data| {
+                        let mime = audio.media_type.as_deref().unwrap_or("audio/wav");
+                        let b64 = BASE64_STANDARD.encode(data);
+                        serde_json::json!({"inlineData": {"mimeType": mime, "data": b64}})
+                    }),
+                },
+                ContentPart::Document(doc) => match &doc.url {
+                    Some(url) => {
+                        let mime = doc.media_type.as_deref().unwrap_or("application/pdf");
+                        Some(serde_json::json!({
+                            "fileData": {"mimeType": mime, "fileUri": url}
+                        }))
+                    }
+                    None => doc.data.as_ref().map(|data| {
+                        let mime = doc.media_type.as_deref().unwrap_or("application/pdf");
+                        let b64 = BASE64_STANDARD.encode(data);
+                        serde_json::json!({"inlineData": {"mimeType": mime, "data": b64}})
+                    }),
+                },
+                ContentPart::ToolResult(tr) => {
+                    // Gemini's functionResponse uses the function *name*, not the call ID.
+                    // Look up the original function name from the tool call mapping.
+                    let function_name = id_to_name
+                        .get(&tr.tool_call_id)
+                        .cloned()
+                        .unwrap_or_else(|| tr.tool_call_id.clone());
+                    let response = tr.content.as_str().map_or_else(
+                        || {
+                            if tr.content.is_object() {
+                                tr.content.clone()
+                            } else {
+                                serde_json::json!({"result": tr.content.to_string()})
+                            }
+                        },
+                        |s| serde_json::json!({"result": s}),
+                    );
+                    Some(serde_json::json!({
+                        "functionResponse": {
+                            "name": function_name,
+                            "response": response,
+                        }
+                    }))
+                }
+                _ => None,
+            };
+            if let Some(part_json) = maybe_part {
+                parts.push(part_json);
+            }
+        }
+
+        if parts.is_empty() {
+            continue;
+        }
+
+        contents.push(Content {
+            role: role.to_string(),
+            parts,
+        });
+    }
+
+    contents
+}
+
+/// Translate unified tool definitions to Gemini's format.
+fn translate_tools(tools: &[ToolDefinition]) -> Vec<GeminiToolGroup> {
+    vec![GeminiToolGroup {
+        function_declarations: tools
+            .iter()
+            .map(|t| GeminiFunctionDecl {
+                name:        t.name.clone(),
+                description: t.description.clone(),
+                parameters:  t.parameters.clone(),
+            })
+            .collect(),
+    }]
+}
+
+/// Translate unified `ToolChoice` to Gemini's `toolConfig`.
+fn translate_tool_choice(choice: &ToolChoice) -> serde_json::Value {
+    match choice {
+        ToolChoice::Auto => serde_json::json!({
+            "functionCallingConfig": {"mode": "AUTO"}
+        }),
+        ToolChoice::None => serde_json::json!({
+            "functionCallingConfig": {"mode": "NONE"}
+        }),
+        ToolChoice::Required => serde_json::json!({
+            "functionCallingConfig": {"mode": "ANY"}
+        }),
+        ToolChoice::Named { tool_name } => serde_json::json!({
+            "functionCallingConfig": {
+                "mode": "ANY",
+                "allowedFunctionNames": [tool_name],
+            }
+        }),
+    }
+}
+
+/// Translate unified `ResponseFormat` to Gemini generation config fields.
+///
+/// Returns `(response_mime_type, response_schema)`.
+fn translate_response_format(
+    format: &ResponseFormat,
+) -> (Option<String>, Option<serde_json::Value>) {
+    match format.kind {
+        ResponseFormatType::Text => (None, None),
+        ResponseFormatType::JsonObject => (Some("application/json".to_string()), None),
+        ResponseFormatType::JsonSchema => (
+            Some("application/json".to_string()),
+            format.json_schema.clone(),
+        ),
+    }
+}
+
+/// Merge `provider_options.gemini` fields into the serialized API request body.
+///
+/// Known fields like `safety_settings` and `cached_content` are set directly.
+/// Any other fields are merged at the top level, allowing pass-through of
+/// Gemini-specific options not covered by the unified schema.
+fn merge_provider_options(
+    body: &mut serde_json::Value,
+    provider_options: Option<&serde_json::Value>,
+) {
+    let Some(gemini_opts) = provider_options.and_then(|opts| opts.get("gemini")) else {
+        return;
+    };
+    let Some(body_map) = body.as_object_mut() else {
+        return;
+    };
+    let Some(gemini_map) = gemini_opts.as_object() else {
+        return;
+    };
+
+    for (key, value) in gemini_map {
+        body_map.insert(key.clone(), value.clone());
+    }
+}
+
+/// Apply default safety settings if none were provided via provider_options.
+fn apply_default_safety_settings(body: &mut serde_json::Value) {
+    if body.get("safety_settings").is_some() {
+        return;
+    }
+    if let Some(body_map) = body.as_object_mut() {
+        body_map.insert(
+            "safety_settings".to_string(),
+            serde_json::json!([{
+                "category": "HARM_CATEGORY_DANGEROUS_CONTENT",
+                "threshold": "BLOCK_ONLY_HIGH"
+            }]),
+        );
+    }
+}

--- a/lib/crates/fabro-llm/src/codec/gemini_generate/encode.rs
+++ b/lib/crates/fabro-llm/src/codec/gemini_generate/encode.rs
@@ -110,6 +110,26 @@ fn build_tool_call_id_to_name(messages: &[&Message]) -> std::collections::HashMa
     map
 }
 
+/// Encode a media attachment part: URL-backed attachments become `fileData`,
+/// inline bytes become base64 `inlineData`.
+fn media_part(
+    url: Option<&str>,
+    data: Option<&[u8]>,
+    media_type: Option<&str>,
+    default_mime: &str,
+) -> Option<serde_json::Value> {
+    let mime = media_type.unwrap_or(default_mime);
+    match url {
+        Some(url) => Some(serde_json::json!({
+            "fileData": {"mimeType": mime, "fileUri": url}
+        })),
+        None => data.map(|data| {
+            let b64 = BASE64_STANDARD.encode(data);
+            serde_json::json!({"inlineData": {"mimeType": mime, "data": b64}})
+        }),
+    }
+}
+
 /// Translate unified messages to Gemini content format. Sync: file-backed
 /// attachments are already resolved to inline data upstream.
 pub(super) fn translate_messages(messages: &[&Message]) -> Vec<Content> {
@@ -144,45 +164,24 @@ pub(super) fn translate_messages(messages: &[&Message]) -> Vec<Content> {
                     }
                     Some(part_json)
                 }
-                ContentPart::Image(img) => match &img.url {
-                    Some(url) => {
-                        let mime = img.media_type.as_deref().unwrap_or("image/png");
-                        Some(serde_json::json!({
-                            "fileData": {"mimeType": mime, "fileUri": url}
-                        }))
-                    }
-                    None => img.data.as_ref().map(|data| {
-                        let mime = img.media_type.as_deref().unwrap_or("image/png");
-                        let b64 = BASE64_STANDARD.encode(data);
-                        serde_json::json!({"inlineData": {"mimeType": mime, "data": b64}})
-                    }),
-                },
-                ContentPart::Audio(audio) => match &audio.url {
-                    Some(url) => {
-                        let mime = audio.media_type.as_deref().unwrap_or("audio/wav");
-                        Some(serde_json::json!({
-                            "fileData": {"mimeType": mime, "fileUri": url}
-                        }))
-                    }
-                    None => audio.data.as_ref().map(|data| {
-                        let mime = audio.media_type.as_deref().unwrap_or("audio/wav");
-                        let b64 = BASE64_STANDARD.encode(data);
-                        serde_json::json!({"inlineData": {"mimeType": mime, "data": b64}})
-                    }),
-                },
-                ContentPart::Document(doc) => match &doc.url {
-                    Some(url) => {
-                        let mime = doc.media_type.as_deref().unwrap_or("application/pdf");
-                        Some(serde_json::json!({
-                            "fileData": {"mimeType": mime, "fileUri": url}
-                        }))
-                    }
-                    None => doc.data.as_ref().map(|data| {
-                        let mime = doc.media_type.as_deref().unwrap_or("application/pdf");
-                        let b64 = BASE64_STANDARD.encode(data);
-                        serde_json::json!({"inlineData": {"mimeType": mime, "data": b64}})
-                    }),
-                },
+                ContentPart::Image(img) => media_part(
+                    img.url.as_deref(),
+                    img.data.as_deref(),
+                    img.media_type.as_deref(),
+                    "image/png",
+                ),
+                ContentPart::Audio(audio) => media_part(
+                    audio.url.as_deref(),
+                    audio.data.as_deref(),
+                    audio.media_type.as_deref(),
+                    "audio/wav",
+                ),
+                ContentPart::Document(doc) => media_part(
+                    doc.url.as_deref(),
+                    doc.data.as_deref(),
+                    doc.media_type.as_deref(),
+                    "application/pdf",
+                ),
                 ContentPart::ToolResult(tr) => {
                     // Gemini's functionResponse uses the function *name*, not the call ID.
                     // Look up the original function name from the tool call mapping.

--- a/lib/crates/fabro-llm/src/codec/gemini_generate/encode.rs
+++ b/lib/crates/fabro-llm/src/codec/gemini_generate/encode.rs
@@ -317,3 +317,342 @@ fn apply_default_safety_settings(body: &mut serde_json::Value) {
         );
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::codec::CodecParams;
+    use crate::types::{AudioData, DocumentData, Request, ToolCall};
+
+    fn minimal_request() -> Request {
+        Request {
+            model:            "gemini-2.0-flash".to_string(),
+            messages:         vec![Message::user("Hello")],
+            provider:         None,
+            tools:            None,
+            tool_choice:      None,
+            response_format:  None,
+            temperature:      None,
+            top_p:            None,
+            max_tokens:       None,
+            stop_sequences:   None,
+            reasoning_effort: None,
+            speed:            None,
+            metadata:         None,
+            provider_options: None,
+        }
+    }
+
+    /// Build the request body the way the adapter's encode path does (no
+    /// catalog: the wire model id is the request model).
+    fn body_for(request: &Request) -> serde_json::Value {
+        let params = CodecParams;
+        let ctx = CodecCtx {
+            request,
+            provider_name: "gemini",
+            deployment_id: &request.model,
+            model: None,
+            params: &params,
+        };
+        build_body(&ctx)
+    }
+
+    #[test]
+    fn provider_options_none_produces_standard_body() {
+        let request = minimal_request();
+        let body = body_for(&request);
+        assert!(body.get("safetySettings").is_none());
+        assert!(body.get("cachedContent").is_none());
+    }
+
+    #[test]
+    fn encode_endpoints_carry_model_and_streaming_variant() {
+        let request = minimal_request();
+        let params = CodecParams;
+        let ctx = CodecCtx {
+            request:       &request,
+            provider_name: "gemini",
+            deployment_id: &request.model,
+            model:         None,
+            params:        &params,
+        };
+
+        assert_eq!(
+            encode(&ctx, false).endpoint,
+            "/models/gemini-2.0-flash:generateContent"
+        );
+        assert_eq!(
+            encode(&ctx, true).endpoint,
+            "/models/gemini-2.0-flash:streamGenerateContent?alt=sse"
+        );
+        assert_eq!(
+            encode_count_tokens(&ctx).endpoint,
+            "/models/gemini-2.0-flash:countTokens"
+        );
+    }
+
+    #[test]
+    fn count_tokens_body_uses_only_generate_content_request_top_level() {
+        let mut request = minimal_request();
+        request.tools = Some(vec![ToolDefinition::function(
+            "search",
+            "Search files",
+            serde_json::json!({"type": "object"}),
+        )]);
+        let params = CodecParams;
+        let ctx = CodecCtx {
+            request:       &request,
+            provider_name: "gemini",
+            deployment_id: &request.model,
+            model:         None,
+            params:        &params,
+        };
+        let count_body = encode_count_tokens(&ctx).body;
+
+        assert!(count_body.get("generateContentRequest").is_some());
+        assert!(count_body.get("contents").is_none());
+        assert!(
+            count_body["generateContentRequest"]
+                .get("contents")
+                .is_some()
+        );
+        assert!(count_body["generateContentRequest"].get("tools").is_some());
+    }
+
+    #[test]
+    fn provider_options_gemini_safety_settings_merged() {
+        let mut request = minimal_request();
+        request.provider_options = Some(serde_json::json!({
+            "gemini": {
+                "safetySettings": [
+                    {"category": "HARM_CATEGORY_HARASSMENT", "threshold": "BLOCK_NONE"}
+                ]
+            }
+        }));
+
+        let body = body_for(&request);
+        let safety = body
+            .get("safetySettings")
+            .expect("safetySettings should be present");
+        let arr = safety.as_array().expect("should be an array");
+        assert_eq!(arr.len(), 1);
+        assert_eq!(arr[0]["category"], "HARM_CATEGORY_HARASSMENT");
+    }
+
+    #[test]
+    fn provider_options_gemini_cached_content_merged() {
+        let mut request = minimal_request();
+        request.provider_options = Some(serde_json::json!({
+            "gemini": {
+                "cachedContent": "projects/my-project/cachedContents/abc123"
+            }
+        }));
+
+        let body = body_for(&request);
+        assert_eq!(
+            body.get("cachedContent")
+                .and_then(serde_json::Value::as_str),
+            Some("projects/my-project/cachedContents/abc123")
+        );
+    }
+
+    #[test]
+    fn provider_options_gemini_multiple_fields_merged() {
+        let mut request = minimal_request();
+        request.provider_options = Some(serde_json::json!({
+            "gemini": {
+                "safetySettings": [{"category": "HARM_CATEGORY_HATE_SPEECH", "threshold": "BLOCK_LOW_AND_ABOVE"}],
+                "cachedContent": "cache-id",
+                "customField": "custom-value"
+            }
+        }));
+
+        let body = body_for(&request);
+        assert!(body.get("safetySettings").is_some());
+        assert_eq!(
+            body.get("cachedContent")
+                .and_then(serde_json::Value::as_str),
+            Some("cache-id")
+        );
+        assert_eq!(
+            body.get("customField").and_then(serde_json::Value::as_str),
+            Some("custom-value")
+        );
+    }
+
+    #[test]
+    fn provider_options_other_provider_ignored() {
+        let mut request = minimal_request();
+        request.provider_options = Some(serde_json::json!({
+            "anthropic": {
+                "auto_cache": false
+            }
+        }));
+
+        let body = body_for(&request);
+        assert!(body.get("auto_cache").is_none());
+    }
+
+    #[test]
+    fn provider_options_gemini_preserves_standard_fields() {
+        let mut request = minimal_request();
+        request.temperature = Some(0.5);
+        request.max_tokens = Some(100);
+        request.provider_options = Some(serde_json::json!({
+            "gemini": {
+                "cachedContent": "cache-id"
+            }
+        }));
+
+        let body = body_for(&request);
+        let gen_config = body
+            .get("generationConfig")
+            .expect("generationConfig should exist");
+        assert_eq!(
+            gen_config
+                .get("temperature")
+                .and_then(serde_json::Value::as_f64),
+            Some(0.5)
+        );
+        assert_eq!(
+            gen_config
+                .get("maxOutputTokens")
+                .and_then(serde_json::Value::as_i64),
+            Some(100)
+        );
+        assert_eq!(
+            body.get("cachedContent")
+                .and_then(serde_json::Value::as_str),
+            Some("cache-id")
+        );
+    }
+
+    #[test]
+    fn merge_provider_options_with_non_object_gemini_value() {
+        let mut body = serde_json::json!({"contents": []});
+        let opts = serde_json::json!({"gemini": "not-an-object"});
+        merge_provider_options(&mut body, Some(&opts));
+        // Should not crash and body should be unchanged
+        assert!(body.get("contents").is_some());
+    }
+
+    #[test]
+    fn audio_url_translates_to_file_data() {
+        let msg = Message {
+            role:         Role::User,
+            content:      vec![ContentPart::Audio(AudioData {
+                url:        Some("https://example.com/audio.wav".to_string()),
+                data:       None,
+                media_type: Some("audio/wav".to_string()),
+            })],
+            name:         None,
+            tool_call_id: None,
+        };
+        let contents = translate_messages(&[&msg]);
+        assert_eq!(contents.len(), 1);
+        let part = &contents[0].parts[0];
+        assert_eq!(part["fileData"]["mimeType"], "audio/wav");
+        assert_eq!(part["fileData"]["fileUri"], "https://example.com/audio.wav");
+    }
+
+    #[test]
+    fn audio_base64_translates_to_inline_data() {
+        let msg = Message {
+            role:         Role::User,
+            content:      vec![ContentPart::Audio(AudioData {
+                url:        None,
+                data:       Some(vec![0xFF, 0xFB, 0x90]),
+                media_type: None,
+            })],
+            name:         None,
+            tool_call_id: None,
+        };
+        let contents = translate_messages(&[&msg]);
+        let part = &contents[0].parts[0];
+        assert_eq!(part["inlineData"]["mimeType"], "audio/wav");
+        assert!(part["inlineData"]["data"].as_str().is_some());
+    }
+
+    #[test]
+    fn document_url_translates_to_file_data() {
+        let msg = Message {
+            role:         Role::User,
+            content:      vec![ContentPart::Document(DocumentData {
+                url:        Some("https://example.com/doc.pdf".to_string()),
+                data:       None,
+                media_type: Some("application/pdf".to_string()),
+                file_name:  Some("doc.pdf".to_string()),
+            })],
+            name:         None,
+            tool_call_id: None,
+        };
+        let contents = translate_messages(&[&msg]);
+        let part = &contents[0].parts[0];
+        assert_eq!(part["fileData"]["mimeType"], "application/pdf");
+        assert_eq!(part["fileData"]["fileUri"], "https://example.com/doc.pdf");
+    }
+
+    #[test]
+    fn document_base64_translates_to_inline_data() {
+        let msg = Message {
+            role:         Role::User,
+            content:      vec![ContentPart::Document(DocumentData {
+                url:        None,
+                data:       Some(vec![0x25, 0x50, 0x44, 0x46]),
+                media_type: None,
+                file_name:  None,
+            })],
+            name:         None,
+            tool_call_id: None,
+        };
+        let contents = translate_messages(&[&msg]);
+        let part = &contents[0].parts[0];
+        assert_eq!(part["inlineData"]["mimeType"], "application/pdf");
+        assert!(part["inlineData"]["data"].as_str().is_some());
+    }
+
+    #[test]
+    fn translate_messages_function_call_includes_thought_signature() {
+        let mut tc = ToolCall::new(
+            "call-1",
+            "get_weather",
+            serde_json::json!({"location": "NYC"}),
+        );
+        tc.provider_metadata = Some(serde_json::json!({"thoughtSignature": "sig456"}));
+
+        let msg = Message {
+            role:         Role::Assistant,
+            content:      vec![ContentPart::ToolCall(tc)],
+            name:         None,
+            tool_call_id: None,
+        };
+        let contents = translate_messages(&[&msg]);
+        assert_eq!(contents.len(), 1);
+
+        let part = &contents[0].parts[0];
+        assert!(part.get("functionCall").is_some());
+        assert_eq!(part["thoughtSignature"], "sig456");
+    }
+
+    #[test]
+    fn translate_messages_function_call_without_thought_signature() {
+        let tc = ToolCall::new(
+            "call-1",
+            "get_weather",
+            serde_json::json!({"location": "NYC"}),
+        );
+
+        let msg = Message {
+            role:         Role::Assistant,
+            content:      vec![ContentPart::ToolCall(tc)],
+            name:         None,
+            tool_call_id: None,
+        };
+        let contents = translate_messages(&[&msg]);
+        assert_eq!(contents.len(), 1);
+
+        let part = &contents[0].parts[0];
+        assert!(part.get("functionCall").is_some());
+        assert!(part.get("thoughtSignature").is_none());
+    }
+}

--- a/lib/crates/fabro-llm/src/codec/gemini_generate/mod.rs
+++ b/lib/crates/fabro-llm/src/codec/gemini_generate/mod.rs
@@ -8,13 +8,6 @@
 //! Gemini keys `functionResponse` on the function *name*, recovered via an
 //! id→name map built from the request's assistant turns.
 
-// TODO(gateway-refactor PR 5): remove once the gemini adapter is rewired to
-// this codec in the next commit — until then the module is unused.
-#![allow(
-    dead_code,
-    reason = "Gemini codec added ahead of the adapter rewire; wired in the next commit of PR 5."
-)]
-
 mod decode;
 mod encode;
 mod stream;

--- a/lib/crates/fabro-llm/src/codec/gemini_generate/mod.rs
+++ b/lib/crates/fabro-llm/src/codec/gemini_generate/mod.rs
@@ -1,0 +1,73 @@
+//! The Gemini `generateContent` codec.
+//!
+//! Pure translation: no HTTP, auth, or base URL — the adapter shell owns
+//! those. The codec is distinctive in two ways: it fully forms its endpoints
+//! (model-in-path plus `?alt=sse` for streaming), and it overrides
+//! `decode_error` to map Gemini's gRPC status codes out of error bodies
+//! (falling back to the HTTP status). Tool-call ids are synthetic UUIDs —
+//! Gemini keys `functionResponse` on the function *name*, recovered via an
+//! id→name map built from the request's assistant turns.
+
+// TODO(gateway-refactor PR 5): remove once the gemini adapter is rewired to
+// this codec in the next commit — until then the module is unused.
+#![allow(
+    dead_code,
+    reason = "Gemini codec added ahead of the adapter rewire; wired in the next commit of PR 5."
+)]
+
+mod decode;
+mod encode;
+mod stream;
+mod wire;
+
+use crate::codec::{Codec, CodecCtx, EncodedRequest, StreamDecoder};
+use crate::error::Error;
+use crate::providers::common::parse_error_body;
+use crate::types::{RateLimitInfo, Response};
+
+/// Codec for the Gemini `generateContent` wire dialect.
+pub(crate) struct GeminiGenerate;
+
+impl Codec for GeminiGenerate {
+    fn encode(&self, ctx: &CodecCtx<'_>, stream: bool) -> Result<EncodedRequest, Error> {
+        Ok(encode::encode(ctx, stream))
+    }
+
+    fn decode_response(
+        &self,
+        body: &str,
+        ctx: &CodecCtx<'_>,
+        rate_limit: Option<RateLimitInfo>,
+    ) -> Result<Response, Error> {
+        decode::decode_response(body, ctx, rate_limit)
+    }
+
+    fn stream_decoder(
+        &self,
+        ctx: &CodecCtx<'_>,
+        rate_limit: Option<RateLimitInfo>,
+    ) -> Box<dyn StreamDecoder> {
+        Box::new(stream::SseAccumulator::new(ctx, rate_limit))
+    }
+
+    fn encode_count_tokens(&self, ctx: &CodecCtx<'_>) -> Option<Result<EncodedRequest, Error>> {
+        Some(Ok(encode::encode_count_tokens(ctx)))
+    }
+
+    fn decode_count_tokens(&self, body: &str) -> Result<i64, Error> {
+        decode::decode_count_tokens(body)
+    }
+
+    /// Gemini errors carry a gRPC status in the body's `status` field; map it
+    /// when present, falling back to the HTTP status code.
+    fn decode_error(
+        &self,
+        status: u16,
+        body: &str,
+        ctx: &CodecCtx<'_>,
+        retry_after: Option<f64>,
+    ) -> Error {
+        let (msg, code, raw) = parse_error_body(body, "status");
+        decode::gemini_error(status, msg, ctx.provider_name, code, raw, retry_after)
+    }
+}

--- a/lib/crates/fabro-llm/src/codec/gemini_generate/stream.rs
+++ b/lib/crates/fabro-llm/src/codec/gemini_generate/stream.rs
@@ -244,3 +244,222 @@ impl StreamDecoder for SseAccumulator {
         vec![self.build_finish_event()]
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::FinishReason;
+
+    /// Build an accumulator without threading a `CodecCtx`/`Request`: the test
+    /// module sees the private fields, so the few that matter are set
+    /// directly. `stream_started` is true so event assertions don't see the
+    /// initial `StreamStart`.
+    fn empty_accumulator() -> SseAccumulator {
+        SseAccumulator {
+            model:                  "gemini-2.0-flash".to_string(),
+            provider:               "gemini".to_string(),
+            stream_started:         true,
+            text_started:           false,
+            reasoning_started:      false,
+            accumulated_thinking:   String::new(),
+            accumulated_text:       String::new(),
+            accumulated_tool_calls: Vec::new(),
+            text_id:                "text-1".to_string(),
+            usage:                  TokenCounts::default(),
+            finish_reason_str:      None,
+            finished:               false,
+            rate_limit:             None,
+        }
+    }
+
+    fn on_data(acc: &mut SseAccumulator, data: &str) -> Result<Vec<StreamEvent>, Error> {
+        acc.on_event(RawEvent { event: None, data })
+    }
+
+    #[test]
+    fn first_chunk_emits_stream_start() {
+        let mut acc = empty_accumulator();
+        acc.stream_started = false;
+
+        let events = on_data(
+            &mut acc,
+            r#"{"candidates":[{"content":{"parts":[{"text":"Hi"}]}}]}"#,
+        )
+        .expect("chunk should parse");
+
+        assert!(matches!(events[0], StreamEvent::StreamStart));
+        assert!(matches!(events[1], StreamEvent::TextStart { .. }));
+    }
+
+    #[test]
+    fn text_deltas_accumulate_with_stable_text_id() {
+        let mut acc = empty_accumulator();
+
+        let first = on_data(
+            &mut acc,
+            r#"{"candidates":[{"content":{"parts":[{"text":"Hel"}]}}]}"#,
+        )
+        .expect("first chunk should parse");
+        let second = on_data(
+            &mut acc,
+            r#"{"candidates":[{"content":{"parts":[{"text":"lo"}]}}]}"#,
+        )
+        .expect("second chunk should parse");
+
+        assert!(
+            matches!(&first[0], StreamEvent::TextStart { text_id: Some(id) } if id == "text-1")
+        );
+        assert!(
+            matches!(&first[1], StreamEvent::TextDelta { delta, text_id: Some(id) } if delta == "Hel" && id == "text-1")
+        );
+        // Second chunk: no duplicate TextStart.
+        assert_eq!(second.len(), 1);
+        assert!(matches!(&second[0], StreamEvent::TextDelta { delta, .. } if delta == "lo"));
+        assert_eq!(acc.accumulated_text, "Hello");
+    }
+
+    #[test]
+    fn thought_then_text_transitions_reasoning_to_text() {
+        let mut acc = empty_accumulator();
+
+        let thought = on_data(
+            &mut acc,
+            r#"{"candidates":[{"content":{"parts":[{"text":"Pondering...","thought":true}]}}]}"#,
+        )
+        .expect("thought chunk should parse");
+        let text = on_data(
+            &mut acc,
+            r#"{"candidates":[{"content":{"parts":[{"text":"Answer"}]}}]}"#,
+        )
+        .expect("text chunk should parse");
+
+        assert!(matches!(thought[0], StreamEvent::ReasoningStart));
+        assert!(
+            matches!(&thought[1], StreamEvent::ReasoningDelta { delta } if delta == "Pondering...")
+        );
+        // Transition closes the reasoning segment before text begins.
+        assert!(matches!(text[0], StreamEvent::ReasoningEnd));
+        assert!(matches!(text[1], StreamEvent::TextStart { .. }));
+        assert!(matches!(&text[2], StreamEvent::TextDelta { delta, .. } if delta == "Answer"));
+        assert_eq!(acc.accumulated_thinking, "Pondering...");
+    }
+
+    #[test]
+    fn function_call_emits_start_and_end_in_one_chunk() {
+        let mut acc = empty_accumulator();
+
+        let events = on_data(
+            &mut acc,
+            r#"{"candidates":[{"content":{"parts":[{"functionCall":{"name":"get_weather","args":{"location":"NYC"}},"thoughtSignature":"sig1"}]}}]}"#,
+        )
+        .expect("function call chunk should parse");
+
+        assert_eq!(events.len(), 2);
+        let (start_tc, end_tc) = match (&events[0], &events[1]) {
+            (
+                StreamEvent::ToolCallStart { tool_call: start },
+                StreamEvent::ToolCallEnd { tool_call: end },
+            ) => (start, end),
+            other => panic!("expected ToolCallStart + ToolCallEnd, got {other:?}"),
+        };
+        assert_eq!(start_tc.name, "get_weather");
+        assert_eq!(start_tc.id, end_tc.id);
+        assert_eq!(
+            start_tc.provider_metadata.as_ref().unwrap()["thoughtSignature"],
+            "sig1"
+        );
+        assert_eq!(acc.accumulated_tool_calls.len(), 1);
+    }
+
+    #[test]
+    fn finish_reason_chunk_emits_text_end_and_records_reason() {
+        let mut acc = empty_accumulator();
+        on_data(
+            &mut acc,
+            r#"{"candidates":[{"content":{"parts":[{"text":"Hi"}]}}]}"#,
+        )
+        .expect("text chunk should parse");
+
+        let events = on_data(
+            &mut acc,
+            r#"{"candidates":[{"content":{"parts":[]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":10,"candidatesTokenCount":5}}"#,
+        )
+        .expect("finish chunk should parse");
+
+        assert!(matches!(&events[0], StreamEvent::TextEnd { text_id: Some(id) } if id == "text-1"));
+        assert_eq!(acc.finish_reason_str.as_deref(), Some("STOP"));
+        assert_eq!(acc.usage.input_tokens, 10);
+        assert_eq!(acc.usage.output_tokens, 5);
+    }
+
+    #[test]
+    fn finish_synthesizes_final_response_exactly_once() {
+        let mut acc = empty_accumulator();
+        on_data(
+            &mut acc,
+            r#"{"candidates":[{"content":{"parts":[{"text":"Hello"}]},"finishReason":"STOP"}]}"#,
+        )
+        .expect("chunk should parse");
+
+        let events = acc.finish();
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            StreamEvent::Finish {
+                finish_reason,
+                response,
+                ..
+            } => {
+                assert_eq!(*finish_reason, FinishReason::Stop);
+                assert_eq!(response.text(), "Hello");
+                assert_eq!(response.provider, "gemini");
+                assert_eq!(response.model, "gemini-2.0-flash");
+            }
+            other => panic!("expected Finish, got {other:?}"),
+        }
+
+        // A second finish() (defensive) synthesizes nothing.
+        assert!(acc.finish().is_empty());
+    }
+
+    #[test]
+    fn finish_without_any_finish_reason_still_synthesizes() {
+        // Gemini has no terminal wire event; byte-stream end must produce a
+        // Finish even when no chunk carried a finishReason.
+        let mut acc = empty_accumulator();
+        on_data(
+            &mut acc,
+            r#"{"candidates":[{"content":{"parts":[{"text":"partial"}]}}]}"#,
+        )
+        .expect("chunk should parse");
+
+        let events = acc.finish();
+        assert_eq!(events.len(), 1);
+        assert!(
+            matches!(&events[0], StreamEvent::Finish { finish_reason, .. }
+            if *finish_reason == FinishReason::Stop)
+        );
+    }
+
+    #[test]
+    fn finish_infers_tool_calls_finish_reason() {
+        let mut acc = empty_accumulator();
+        on_data(
+            &mut acc,
+            r#"{"candidates":[{"content":{"parts":[{"functionCall":{"name":"search","args":{}}}]},"finishReason":"STOP"}]}"#,
+        )
+        .expect("chunk should parse");
+
+        let events = acc.finish();
+        assert!(
+            matches!(&events[0], StreamEvent::Finish { finish_reason, .. }
+            if *finish_reason == FinishReason::ToolCalls)
+        );
+    }
+
+    #[test]
+    fn malformed_chunk_yields_stream_error() {
+        let mut acc = empty_accumulator();
+        let err = on_data(&mut acc, "not json").expect_err("bad chunk should error");
+        assert!(matches!(err, Error::Stream { .. }));
+    }
+}

--- a/lib/crates/fabro-llm/src/codec/gemini_generate/stream.rs
+++ b/lib/crates/fabro-llm/src/codec/gemini_generate/stream.rs
@@ -1,0 +1,246 @@
+//! Streaming decoder: Gemini SSE chunks → canonical `StreamEvent`s.
+//!
+//! Byte reading and line framing live in the transport; this decoder is fed
+//! framed `RawEvent`s carrying bare `data:` payloads (Gemini uses data-only
+//! SSE — no event types, no `[DONE]` sentinel). Gemini has no terminal wire
+//! event, so `finish()` synthesizes the `Finish` from accumulated state
+//! unconditionally at byte-stream end.
+
+use super::decode::{map_finish_reason, parse_usage};
+use super::wire::ApiResponse;
+use crate::codec::{CodecCtx, RawEvent, StreamDecoder};
+use crate::error::Error;
+use crate::types::{
+    ContentPart, Message, RateLimitInfo, Response, Role, StreamEvent, ThinkingData, TokenCounts,
+    ToolCall,
+};
+
+/// Accumulated state across SSE chunks during streaming.
+pub(super) struct SseAccumulator {
+    /// Requested model, stamped into the synthesized final `Response`.
+    model:                  String,
+    /// Configured provider name stamped into the final `Response.provider`.
+    provider:               String,
+    /// Whether we have emitted a `StreamStart` event.
+    stream_started:         bool,
+    /// Whether we have emitted a `TextStart` event.
+    text_started:           bool,
+    /// Whether we are currently inside a reasoning (thought) segment.
+    reasoning_started:      bool,
+    /// Accumulated thinking text across all chunks.
+    accumulated_thinking:   String,
+    /// Accumulated text across all chunks.
+    accumulated_text:       String,
+    /// Accumulated tool calls across all chunks.
+    accumulated_tool_calls: Vec<ToolCall>,
+    /// The `text_id` used for `TextStart`/`TextDelta`/`TextEnd`.
+    text_id:                String,
+    /// Latest usage metadata (updated per chunk; final chunk has totals).
+    usage:                  TokenCounts,
+    /// The finish reason string from the candidate, if received.
+    finish_reason_str:      Option<String>,
+    /// Whether we have emitted the `Finish` event.
+    finished:               bool,
+    /// Rate limit info parsed from HTTP response headers.
+    rate_limit:             Option<RateLimitInfo>,
+}
+
+impl SseAccumulator {
+    pub(super) fn new(ctx: &CodecCtx<'_>, rate_limit: Option<RateLimitInfo>) -> Self {
+        Self {
+            model: ctx.request.model.clone(),
+            provider: ctx.provider_name.to_string(),
+            stream_started: false,
+            text_started: false,
+            reasoning_started: false,
+            accumulated_thinking: String::new(),
+            accumulated_text: String::new(),
+            accumulated_tool_calls: Vec::new(),
+            text_id: uuid::Uuid::new_v4().to_string(),
+            usage: TokenCounts::default(),
+            finish_reason_str: None,
+            finished: false,
+            rate_limit,
+        }
+    }
+
+    /// Extract stream events from a parsed SSE chunk.
+    fn process_chunk(&mut self, chunk: &ApiResponse) -> Vec<StreamEvent> {
+        let mut events = Vec::new();
+
+        if !self.stream_started {
+            self.stream_started = true;
+            events.push(StreamEvent::StreamStart);
+        }
+
+        let parts = chunk
+            .candidates
+            .as_ref()
+            .and_then(|c| c.first())
+            .and_then(|c| c.content.as_ref())
+            .and_then(|c| c.parts.as_ref());
+
+        if let Some(parts) = parts {
+            for part in parts {
+                let is_thought = part
+                    .get("thought")
+                    .and_then(serde_json::Value::as_bool)
+                    .unwrap_or(false);
+
+                if let Some(text) = part.get("text").and_then(serde_json::Value::as_str) {
+                    if is_thought {
+                        if !self.reasoning_started {
+                            self.reasoning_started = true;
+                            events.push(StreamEvent::ReasoningStart);
+                        }
+                        self.accumulated_thinking.push_str(text);
+                        events.push(StreamEvent::ReasoningDelta {
+                            delta: text.to_string(),
+                        });
+                    } else {
+                        // Transition from reasoning to text: close reasoning segment.
+                        if self.reasoning_started {
+                            self.reasoning_started = false;
+                            events.push(StreamEvent::ReasoningEnd);
+                        }
+                        if !self.text_started {
+                            self.text_started = true;
+                            events.push(StreamEvent::TextStart {
+                                text_id: Some(self.text_id.clone()),
+                            });
+                        }
+                        self.accumulated_text.push_str(text);
+                        events.push(StreamEvent::text_delta(text, Some(self.text_id.clone())));
+                    }
+                } else if let Some(fc) = part.get("functionCall") {
+                    let name = fc
+                        .get("name")
+                        .and_then(serde_json::Value::as_str)
+                        .unwrap_or("")
+                        .to_string();
+                    let args = fc
+                        .get("args")
+                        .cloned()
+                        .unwrap_or_else(|| serde_json::Value::Object(serde_json::Map::new()));
+                    let mut tool_call = ToolCall::new(uuid::Uuid::new_v4().to_string(), name, args);
+                    // Preserve thought_signature for Gemini 3 models (sibling of
+                    // functionCall)
+                    if let Some(sig) = part.get("thoughtSignature") {
+                        tool_call.provider_metadata =
+                            Some(serde_json::json!({"thoughtSignature": sig}));
+                    }
+
+                    // Gemini delivers function calls as complete objects in a single
+                    // chunk.
+                    events.push(StreamEvent::ToolCallStart {
+                        tool_call: tool_call.clone(),
+                    });
+                    events.push(StreamEvent::ToolCallEnd {
+                        tool_call: tool_call.clone(),
+                    });
+                    self.accumulated_tool_calls.push(tool_call);
+                }
+            }
+        }
+
+        // If a finish reason is present on this chunk's candidate, emit TextEnd.
+        let has_finish_reason = chunk
+            .candidates
+            .as_ref()
+            .and_then(|c| c.first())
+            .and_then(|c| c.finish_reason.as_ref())
+            .is_some();
+
+        if has_finish_reason {
+            if self.reasoning_started {
+                self.reasoning_started = false;
+                events.push(StreamEvent::ReasoningEnd);
+            }
+            if self.text_started {
+                events.push(StreamEvent::TextEnd {
+                    text_id: Some(self.text_id.clone()),
+                });
+            }
+        }
+
+        events
+    }
+
+    /// Build the final `Finish` event from accumulated state.
+    fn build_finish_event(&self) -> StreamEvent {
+        let has_tool_calls = !self.accumulated_tool_calls.is_empty();
+        let finish_reason = map_finish_reason(self.finish_reason_str.as_deref(), has_tool_calls);
+
+        let mut content_parts: Vec<ContentPart> = Vec::new();
+        if !self.accumulated_thinking.is_empty() {
+            content_parts.push(ContentPart::Thinking(ThinkingData {
+                text:      self.accumulated_thinking.clone(),
+                signature: None,
+                redacted:  false,
+            }));
+        }
+        if !self.accumulated_text.is_empty() {
+            content_parts.push(ContentPart::text(&self.accumulated_text));
+        }
+        for tc in &self.accumulated_tool_calls {
+            content_parts.push(ContentPart::ToolCall(tc.clone()));
+        }
+
+        let response = Response {
+            id:            uuid::Uuid::new_v4().to_string(),
+            model:         self.model.clone(),
+            provider:      self.provider.clone(),
+            message:       Message {
+                role:         Role::Assistant,
+                content:      content_parts,
+                name:         None,
+                tool_call_id: None,
+            },
+            finish_reason: finish_reason.clone(),
+            usage:         self.usage.clone(),
+            raw:           None,
+            warnings:      vec![],
+            rate_limit:    self.rate_limit.clone(),
+        };
+
+        StreamEvent::finish(finish_reason, self.usage.clone(), response)
+    }
+}
+
+impl StreamDecoder for SseAccumulator {
+    fn on_event(&mut self, ev: RawEvent<'_>) -> Result<Vec<StreamEvent>, Error> {
+        // Parse the JSON chunk.
+        let chunk: ApiResponse = serde_json::from_str(ev.data).map_err(|e| {
+            Error::stream_error(format!("failed to parse Gemini SSE chunk: {e}"), e)
+        })?;
+
+        let events = self.process_chunk(&chunk);
+
+        // Track usage from every chunk; the final one will have the totals.
+        if let Some(ref usage_meta) = chunk.usage_metadata {
+            self.usage = parse_usage(Some(usage_meta));
+        }
+
+        // Extract finish reason from the candidate if present.
+        let candidate_finish = chunk
+            .candidates
+            .as_ref()
+            .and_then(|c| c.first())
+            .and_then(|c| c.finish_reason.clone());
+        if let Some(reason) = candidate_finish {
+            self.finish_reason_str = Some(reason);
+        }
+
+        Ok(events)
+    }
+
+    fn finish(&mut self) -> Vec<StreamEvent> {
+        // Gemini has no terminal wire event: synthesize the Finish from
+        // accumulated state, exactly once, at byte-stream end.
+        if self.finished {
+            return Vec::new();
+        }
+        self.finished = true;
+        vec![self.build_finish_event()]
+    }
+}

--- a/lib/crates/fabro-llm/src/codec/gemini_generate/wire.rs
+++ b/lib/crates/fabro-llm/src/codec/gemini_generate/wire.rs
@@ -1,0 +1,98 @@
+//! Serde types mirroring the Gemini `generateContent` wire shapes.
+
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct ApiRequest {
+    pub contents:           Vec<Content>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub system_instruction: Option<SystemInstruction>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub generation_config:  Option<GenerationOptions>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tools:              Option<Vec<GeminiToolGroup>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_config:        Option<serde_json::Value>,
+}
+
+#[derive(serde::Serialize)]
+pub(super) struct Content {
+    pub role:  String,
+    pub parts: Vec<serde_json::Value>,
+}
+
+#[derive(serde::Serialize)]
+pub(super) struct SystemInstruction {
+    pub parts: Vec<serde_json::Value>,
+}
+
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct GenerationOptions {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub temperature:        Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_output_tokens:  Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub top_p:              Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stop_sequences:     Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub response_mime_type: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub response_schema:    Option<serde_json::Value>,
+}
+
+/// Gemini groups function declarations under a `tools` array.
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct GeminiToolGroup {
+    pub function_declarations: Vec<GeminiFunctionDecl>,
+}
+
+#[derive(serde::Serialize)]
+pub(super) struct GeminiFunctionDecl {
+    pub name:        String,
+    pub description: String,
+    pub parameters:  serde_json::Value,
+}
+
+// --- Response types ---
+
+#[derive(serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct ApiResponse {
+    pub candidates:     Option<Vec<Candidate>>,
+    pub usage_metadata: Option<UsageMetadata>,
+}
+
+#[derive(serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct Candidate {
+    pub content:       Option<CandidateContent>,
+    pub finish_reason: Option<String>,
+}
+
+#[derive(serde::Deserialize)]
+pub(super) struct CandidateContent {
+    pub parts: Option<Vec<serde_json::Value>>,
+}
+
+#[derive(serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[allow(
+    clippy::struct_field_names,
+    reason = "Field names mirror the provider API payload."
+)]
+pub(super) struct UsageMetadata {
+    pub prompt_token_count:          Option<i64>,
+    pub candidates_token_count:      Option<i64>,
+    pub thoughts_token_count:        Option<i64>,
+    pub cached_content_token_count:  Option<i64>,
+    pub tool_use_prompt_token_count: Option<i64>,
+}
+
+#[derive(serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct CountTokensResponse {
+    pub total_tokens: i64,
+}

--- a/lib/crates/fabro-llm/src/codec/mod.rs
+++ b/lib/crates/fabro-llm/src/codec/mod.rs
@@ -11,6 +11,7 @@
 //! methods, never extend the contract.
 
 pub(crate) mod anthropic_messages;
+pub(crate) mod gemini_generate;
 pub(crate) mod openai_compatible;
 pub(crate) mod openai_responses;
 

--- a/lib/crates/fabro-llm/src/providers/gemini.rs
+++ b/lib/crates/fabro-llm/src/providers/gemini.rs
@@ -91,6 +91,23 @@ impl Adapter {
         attachments::resolve(request, policy).await
     }
 
+    /// Build the borrowed codec context. `deployment_id` and `params` are
+    /// created by the caller so their borrows outlive the context.
+    fn codec_ctx<'a>(
+        &'a self,
+        request: &'a Request,
+        deployment_id: &'a str,
+        params: &'a CodecParams,
+    ) -> CodecCtx<'a> {
+        CodecCtx {
+            request,
+            provider_name: &self.provider_name,
+            deployment_id,
+            model: common::catalog_model(self.catalog.as_deref(), &request.model),
+            params,
+        }
+    }
+
     /// Apply the base URL, auth (`x-goog-api-key`), and codec-emitted headers
     /// to an encoded request.
     fn build_http_request(&self, encoded: &EncodedRequest) -> fabro_http::RequestBuilder {
@@ -174,13 +191,7 @@ impl ProviderAdapter for Adapter {
         let codec = GeminiGenerate;
         let deployment_id = common::api_model_id(self.catalog.as_deref(), &resolved.model);
         let params = CodecParams;
-        let ctx = CodecCtx {
-            request:       &resolved,
-            provider_name: &self.provider_name,
-            deployment_id: &deployment_id,
-            model:         common::catalog_model(self.catalog.as_deref(), &resolved.model),
-            params:        &params,
-        };
+        let ctx = self.codec_ctx(&resolved, &deployment_id, &params);
 
         let Some(encoded) = codec.encode_count_tokens(&ctx).transpose()? else {
             return Ok(None);
@@ -209,13 +220,7 @@ impl ProviderAdapter for Adapter {
         let codec = GeminiGenerate;
         let deployment_id = common::api_model_id(self.catalog.as_deref(), &resolved.model);
         let params = CodecParams;
-        let ctx = CodecCtx {
-            request:       &resolved,
-            provider_name: &self.provider_name,
-            deployment_id: &deployment_id,
-            model:         common::catalog_model(self.catalog.as_deref(), &resolved.model),
-            params:        &params,
-        };
+        let ctx = self.codec_ctx(&resolved, &deployment_id, &params);
 
         let encoded = codec.encode(&ctx, false)?;
         let mut req = self.build_http_request(&encoded);
@@ -235,48 +240,26 @@ impl ProviderAdapter for Adapter {
         let deployment_id = common::api_model_id(self.catalog.as_deref(), &resolved.model);
         let params = CodecParams;
         let stream_read_timeout = self.http.stream_read_timeout;
-        let rate_limit;
+        let ctx = self.codec_ctx(&resolved, &deployment_id, &params);
 
-        let http_resp = {
-            let ctx = CodecCtx {
-                request:       &resolved,
-                provider_name: &self.provider_name,
-                deployment_id: &deployment_id,
-                model:         common::catalog_model(self.catalog.as_deref(), &resolved.model),
-                params:        &params,
-            };
-            let encoded = codec.encode(&ctx, true)?;
-            let resp = self
-                .build_http_request(&encoded)
-                .send()
+        let encoded = codec.encode(&ctx, true)?;
+        let http_resp = self
+            .build_http_request(&encoded)
+            .send()
+            .await
+            .map_err(|e| Error::network(e.to_string(), e))?;
+
+        let status = http_resp.status();
+        if !status.is_success() {
+            let retry_after = parse_retry_after(http_resp.headers());
+            let body = http_resp
+                .text()
                 .await
                 .map_err(|e| Error::network(e.to_string(), e))?;
-
-            let status = resp.status();
-            if !status.is_success() {
-                let retry_after = parse_retry_after(resp.headers());
-                let body = resp
-                    .text()
-                    .await
-                    .map_err(|e| Error::network(e.to_string(), e))?;
-                return Err(codec.decode_error(status.as_u16(), &body, &ctx, retry_after));
-            }
-            rate_limit = parse_rate_limit_headers(resp.headers());
-            resp
-        };
-
-        // Build the decoder while the ctx is still in scope; it captures owned
-        // state and does not borrow ctx beyond construction.
-        let decoder = {
-            let ctx = CodecCtx {
-                request:       &resolved,
-                provider_name: &self.provider_name,
-                deployment_id: &deployment_id,
-                model:         common::catalog_model(self.catalog.as_deref(), &resolved.model),
-                params:        &params,
-            };
-            codec.stream_decoder(&ctx, rate_limit)
-        };
+            return Err(codec.decode_error(status.as_u16(), &body, &ctx, retry_after));
+        }
+        let rate_limit = parse_rate_limit_headers(http_resp.headers());
+        let decoder = codec.stream_decoder(&ctx, rate_limit);
 
         let out = stream::unfold(
             StreamLoop {

--- a/lib/crates/fabro-llm/src/providers/gemini.rs
+++ b/lib/crates/fabro-llm/src/providers/gemini.rs
@@ -80,8 +80,8 @@ impl Adapter {
     }
 
     /// Build the canonical request for the codec, resolving file-backed
-    /// attachments to inline data first.
-    async fn resolve_request(&self, request: &Request) -> Request {
+    /// attachments to inline data first. Borrowed when nothing needs loading.
+    async fn resolve_request<'a>(&self, request: &'a Request) -> std::borrow::Cow<'a, Request> {
         // Gemini loads all three attachment kinds inline.
         let policy = AttachmentPolicy {
             images:    true,
@@ -190,7 +190,7 @@ impl ProviderAdapter for Adapter {
         let resolved = self.resolve_request(request).await;
         let codec = GeminiGenerate;
         let deployment_id = common::api_model_id(self.catalog.as_deref(), &resolved.model);
-        let params = CodecParams;
+        let params = CodecParams::default();
         let ctx = self.codec_ctx(&resolved, &deployment_id, &params);
 
         let Some(encoded) = codec.encode_count_tokens(&ctx).transpose()? else {
@@ -219,7 +219,7 @@ impl ProviderAdapter for Adapter {
         let resolved = self.resolve_request(request).await;
         let codec = GeminiGenerate;
         let deployment_id = common::api_model_id(self.catalog.as_deref(), &resolved.model);
-        let params = CodecParams;
+        let params = CodecParams::default();
         let ctx = self.codec_ctx(&resolved, &deployment_id, &params);
 
         let encoded = codec.encode(&ctx, false)?;
@@ -238,7 +238,7 @@ impl ProviderAdapter for Adapter {
         let resolved = self.resolve_request(request).await;
         let codec = GeminiGenerate;
         let deployment_id = common::api_model_id(self.catalog.as_deref(), &resolved.model);
-        let params = CodecParams;
+        let params = CodecParams::default();
         let stream_read_timeout = self.http.stream_read_timeout;
         let ctx = self.codec_ctx(&resolved, &deployment_id, &params);
 

--- a/lib/crates/fabro-llm/src/providers/gemini.rs
+++ b/lib/crates/fabro-llm/src/providers/gemini.rs
@@ -1,31 +1,29 @@
 use std::sync::Arc;
 
-use base64::Engine;
-use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
 use fabro_http::HeaderMap;
 use fabro_model::Catalog;
 use futures::stream;
 
-use crate::error::{
-    Error, ProviderErrorDetail, ProviderErrorKind, error_from_grpc_status, error_from_status_code,
-};
+use crate::attachments::{self, AttachmentPolicy};
+use crate::codec::gemini_generate::GeminiGenerate;
+use crate::codec::{Codec, CodecCtx, CodecParams, EncodedRequest, RawEvent, StreamDecoder};
+use crate::error::Error;
 use crate::provider::{
     ProviderAdapter, StreamEventStream, validate_standard_speed, validate_tool_choice,
 };
-use crate::providers::common::{
-    self as common, extract_system_prompt, parse_error_body, parse_rate_limit_headers,
-    parse_retry_after,
-};
+use crate::providers::common::{self as common, parse_rate_limit_headers, parse_retry_after};
 use crate::token_count::{InputTokenCount, InputTokenCountMethod};
-use crate::types::{
-    AdapterTimeout, ContentPart, FinishReason, Message, RateLimitInfo, Request, Response,
-    ResponseFormat, ResponseFormatType, Role, StreamEvent, ThinkingData, TokenCounts, ToolCall,
-    ToolChoice, ToolDefinition,
-};
+use crate::types::{AdapterTimeout, Request, Response, StreamEvent};
 
 const DEFAULT_BASE_URL: &str = "https://generativelanguage.googleapis.com/v1beta";
 
 /// Provider adapter for the Google Gemini `generateContent` API.
+///
+/// A thin transport shell over the `gemini_generate` codec: it owns auth
+/// (`x-goog-api-key`), base URL, and the streaming byte loop. All wire
+/// translation — including the model-in-path endpoints — lives in the codec.
+/// Gemini has no route variance (single auth scheme, count-tokens always
+/// available, no forced streaming), so there is no route config.
 pub struct Adapter {
     pub(crate) http: super::http_api::HttpApi,
     provider_name:   String,
@@ -80,873 +78,76 @@ impl Adapter {
             ..self
         }
     }
-}
 
-// --- Request types ---
-
-#[derive(serde::Serialize)]
-#[serde(rename_all = "camelCase")]
-struct ApiRequest {
-    contents:           Vec<Content>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    system_instruction: Option<SystemInstruction>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    generation_config:  Option<GenerationOptions>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    tools:              Option<Vec<GeminiToolGroup>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    tool_config:        Option<serde_json::Value>,
-}
-
-#[derive(serde::Serialize)]
-struct Content {
-    role:  String,
-    parts: Vec<serde_json::Value>,
-}
-
-#[derive(serde::Serialize)]
-struct SystemInstruction {
-    parts: Vec<serde_json::Value>,
-}
-
-#[derive(serde::Serialize)]
-#[serde(rename_all = "camelCase")]
-struct GenerationOptions {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    temperature:        Option<f64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    max_output_tokens:  Option<i64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    top_p:              Option<f64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    stop_sequences:     Option<Vec<String>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    response_mime_type: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    response_schema:    Option<serde_json::Value>,
-}
-
-/// Gemini groups function declarations under a `tools` array.
-#[derive(serde::Serialize)]
-#[serde(rename_all = "camelCase")]
-struct GeminiToolGroup {
-    function_declarations: Vec<GeminiFunctionDecl>,
-}
-
-#[derive(serde::Serialize)]
-struct GeminiFunctionDecl {
-    name:        String,
-    description: String,
-    parameters:  serde_json::Value,
-}
-
-// --- Response types ---
-
-#[derive(serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct ApiResponse {
-    candidates:     Option<Vec<Candidate>>,
-    usage_metadata: Option<UsageMetadata>,
-}
-
-#[derive(serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct Candidate {
-    content:       Option<CandidateContent>,
-    finish_reason: Option<String>,
-}
-
-#[derive(serde::Deserialize)]
-struct CandidateContent {
-    parts: Option<Vec<serde_json::Value>>,
-}
-
-#[derive(serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
-#[allow(
-    clippy::struct_field_names,
-    reason = "Field names mirror the provider API payload."
-)]
-struct UsageMetadata {
-    prompt_token_count:          Option<i64>,
-    candidates_token_count:      Option<i64>,
-    thoughts_token_count:        Option<i64>,
-    cached_content_token_count:  Option<i64>,
-    tool_use_prompt_token_count: Option<i64>,
-}
-
-#[derive(serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct CountTokensResponse {
-    total_tokens: i64,
-}
-
-/// Map Gemini's finish reason, inferring `ToolCalls` from content when needed.
-fn map_finish_reason(reason: Option<&str>, has_function_calls: bool) -> FinishReason {
-    if has_function_calls {
-        return FinishReason::ToolCalls;
-    }
-    match reason {
-        Some("STOP") | None => FinishReason::Stop,
-        Some("MAX_TOKENS") => FinishReason::Length,
-        Some("SAFETY" | "RECITATION") => FinishReason::ContentFilter,
-        Some(other) => FinishReason::Other(other.to_string()),
-    }
-}
-
-fn parse_part(part: &serde_json::Value) -> Option<ContentPart> {
-    if let Some(text) = part.get("text").and_then(serde_json::Value::as_str) {
-        let is_thought = part
-            .get("thought")
-            .and_then(serde_json::Value::as_bool)
-            .unwrap_or(false);
-        if is_thought {
-            return Some(ContentPart::Thinking(ThinkingData {
-                text:      text.to_string(),
-                signature: None,
-                redacted:  false,
-            }));
-        }
-        return Some(ContentPart::text(text));
-    }
-    if let Some(fc) = part.get("functionCall") {
-        let name = fc.get("name")?.as_str()?.to_string();
-        let args = fc
-            .get("args")
-            .cloned()
-            .unwrap_or_else(|| serde_json::Value::Object(serde_json::Map::new()));
-        let mut tc = ToolCall::new(uuid::Uuid::new_v4().to_string(), name, args);
-        // Preserve thought_signature for Gemini 3 models (sibling of functionCall in
-        // the part)
-        if let Some(sig) = part.get("thoughtSignature") {
-            tc.provider_metadata = Some(serde_json::json!({"thoughtSignature": sig}));
-        }
-        return Some(ContentPart::ToolCall(tc));
-    }
-    None
-}
-
-/// Check if any parts contain function calls.
-fn parts_have_function_calls(parts: &[serde_json::Value]) -> bool {
-    parts.iter().any(|p| p.get("functionCall").is_some())
-}
-
-/// Build a mapping from tool call ID to function name by scanning assistant
-/// messages.
-///
-/// Gemini uses function names (not call IDs) in `functionResponse`. Since the
-/// adapter generates synthetic UUIDs as tool call IDs, we need this mapping to
-/// recover the original function name when sending tool results back.
-fn build_tool_call_id_to_name(messages: &[&Message]) -> std::collections::HashMap<String, String> {
-    let mut map = std::collections::HashMap::new();
-    for msg in messages {
-        if msg.role == Role::Assistant {
-            for part in &msg.content {
-                if let ContentPart::ToolCall(tc) = part {
-                    map.insert(tc.id.clone(), tc.name.clone());
-                }
-            }
-        }
-    }
-    map
-}
-
-/// Translate unified messages to Gemini content format.
-async fn translate_messages(messages: &[&Message]) -> Vec<Content> {
-    let id_to_name = build_tool_call_id_to_name(messages);
-    let mut contents: Vec<Content> = Vec::new();
-
-    for msg in messages {
-        let role = match msg.role {
-            Role::Assistant => "model",
-            Role::User | Role::Tool => "user",
-            Role::System | Role::Developer => continue,
+    /// Build the canonical request for the codec, resolving file-backed
+    /// attachments to inline data first.
+    async fn resolve_request(&self, request: &Request) -> Request {
+        // Gemini loads all three attachment kinds inline.
+        let policy = AttachmentPolicy {
+            images:    true,
+            documents: true,
+            audio:     true,
         };
+        attachments::resolve(request, policy).await
+    }
 
-        let mut parts = Vec::new();
-        for part in &msg.content {
-            let maybe_part = match part {
-                ContentPart::Text(text) => Some(serde_json::json!({"text": text})),
-                ContentPart::ToolCall(tc) => {
-                    let mut part_json = serde_json::json!({
-                        "functionCall": {
-                            "name": tc.name,
-                            "args": tc.arguments,
-                        }
-                    });
-                    // Re-attach thought_signature as sibling of functionCall
-                    if let Some(sig) = tc
-                        .provider_metadata
-                        .as_ref()
-                        .and_then(|m| m.get("thoughtSignature"))
-                    {
-                        part_json["thoughtSignature"] = sig.clone();
-                    }
-                    Some(part_json)
-                }
-                ContentPart::Image(img) => match &img.url {
-                    Some(url) => {
-                        if common::is_file_path(url) {
-                            match common::load_file_as_base64(url).await {
-                                Ok((b64, mime)) => Some(serde_json::json!({
-                                    "inlineData": {"mimeType": mime, "data": b64}
-                                })),
-                                Err(_) => None,
-                            }
-                        } else {
-                            let mime = img.media_type.as_deref().unwrap_or("image/png");
-                            Some(serde_json::json!({
-                                "fileData": {"mimeType": mime, "fileUri": url}
-                            }))
-                        }
-                    }
-                    None => img.data.as_ref().map(|data| {
-                        let mime = img.media_type.as_deref().unwrap_or("image/png");
-                        let b64 = BASE64_STANDARD.encode(data);
-                        serde_json::json!({"inlineData": {"mimeType": mime, "data": b64}})
-                    }),
-                },
-                ContentPart::Audio(audio) => match &audio.url {
-                    Some(url) => {
-                        if common::is_file_path(url) {
-                            match common::load_file_as_base64(url).await {
-                                Ok((b64, mime)) => Some(serde_json::json!({
-                                    "inlineData": {"mimeType": mime, "data": b64}
-                                })),
-                                Err(_) => None,
-                            }
-                        } else {
-                            let mime = audio.media_type.as_deref().unwrap_or("audio/wav");
-                            Some(serde_json::json!({
-                                "fileData": {"mimeType": mime, "fileUri": url}
-                            }))
-                        }
-                    }
-                    None => audio.data.as_ref().map(|data| {
-                        let mime = audio.media_type.as_deref().unwrap_or("audio/wav");
-                        let b64 = BASE64_STANDARD.encode(data);
-                        serde_json::json!({"inlineData": {"mimeType": mime, "data": b64}})
-                    }),
-                },
-                ContentPart::Document(doc) => match &doc.url {
-                    Some(url) => {
-                        if common::is_file_path(url) {
-                            match common::load_file_as_base64(url).await {
-                                Ok((b64, mime)) => Some(serde_json::json!({
-                                    "inlineData": {"mimeType": mime, "data": b64}
-                                })),
-                                Err(_) => None,
-                            }
-                        } else {
-                            let mime = doc.media_type.as_deref().unwrap_or("application/pdf");
-                            Some(serde_json::json!({
-                                "fileData": {"mimeType": mime, "fileUri": url}
-                            }))
-                        }
-                    }
-                    None => doc.data.as_ref().map(|data| {
-                        let mime = doc.media_type.as_deref().unwrap_or("application/pdf");
-                        let b64 = BASE64_STANDARD.encode(data);
-                        serde_json::json!({"inlineData": {"mimeType": mime, "data": b64}})
-                    }),
-                },
-                ContentPart::ToolResult(tr) => {
-                    // Gemini's functionResponse uses the function *name*, not the call ID.
-                    // Look up the original function name from the tool call mapping.
-                    let function_name = id_to_name
-                        .get(&tr.tool_call_id)
-                        .cloned()
-                        .unwrap_or_else(|| tr.tool_call_id.clone());
-                    let response = tr.content.as_str().map_or_else(
-                        || {
-                            if tr.content.is_object() {
-                                tr.content.clone()
-                            } else {
-                                serde_json::json!({"result": tr.content.to_string()})
-                            }
-                        },
-                        |s| serde_json::json!({"result": s}),
-                    );
-                    Some(serde_json::json!({
-                        "functionResponse": {
-                            "name": function_name,
-                            "response": response,
-                        }
-                    }))
-                }
-                _ => None,
-            };
-            if let Some(part_json) = maybe_part {
-                parts.push(part_json);
+    /// Apply the base URL, auth (`x-goog-api-key`), and codec-emitted headers
+    /// to an encoded request.
+    fn build_http_request(&self, encoded: &EncodedRequest) -> fabro_http::RequestBuilder {
+        let url = format!("{}{}", self.http.base_url, encoded.endpoint);
+        let mut req = self.http.client.post(&url);
+        if let Some(api_key) = &self.http.api_key {
+            req = req.header("x-goog-api-key", api_key);
+        }
+        for (key, value) in &self.http.default_headers {
+            req = req.header(key, value);
+        }
+        for (key, value) in &encoded.headers {
+            req = req.header(key, value);
+        }
+        req.json(&encoded.body)
+    }
+
+    /// Send an HTTP request and read the Gemini response body, mapping non-2xx
+    /// responses through the codec's error decode (gRPC status aware).
+    async fn send_for_body(
+        &self,
+        request: fabro_http::RequestBuilder,
+        codec: &GeminiGenerate,
+        ctx: &CodecCtx<'_>,
+    ) -> Result<(String, HeaderMap), Error> {
+        let http_resp = request.send().await.map_err(|e| {
+            if e.is_timeout() {
+                Error::request_timeout(format!("gemini: {e}"), e)
+            } else {
+                Error::network(e.to_string(), e)
             }
-        }
+        })?;
 
-        if parts.is_empty() {
-            continue;
-        }
-
-        contents.push(Content {
-            role: role.to_string(),
-            parts,
-        });
-    }
-
-    contents
-}
-
-/// Translate unified tool definitions to Gemini's format.
-fn translate_tools(tools: &[ToolDefinition]) -> Vec<GeminiToolGroup> {
-    vec![GeminiToolGroup {
-        function_declarations: tools
-            .iter()
-            .map(|t| GeminiFunctionDecl {
-                name:        t.name.clone(),
-                description: t.description.clone(),
-                parameters:  t.parameters.clone(),
-            })
-            .collect(),
-    }]
-}
-
-/// Translate unified `ToolChoice` to Gemini's `toolConfig`.
-fn translate_tool_choice(choice: &ToolChoice) -> serde_json::Value {
-    match choice {
-        ToolChoice::Auto => serde_json::json!({
-            "functionCallingConfig": {"mode": "AUTO"}
-        }),
-        ToolChoice::None => serde_json::json!({
-            "functionCallingConfig": {"mode": "NONE"}
-        }),
-        ToolChoice::Required => serde_json::json!({
-            "functionCallingConfig": {"mode": "ANY"}
-        }),
-        ToolChoice::Named { tool_name } => serde_json::json!({
-            "functionCallingConfig": {
-                "mode": "ANY",
-                "allowedFunctionNames": [tool_name],
-            }
-        }),
-    }
-}
-
-/// Translate unified `ResponseFormat` to Gemini generation config fields.
-///
-/// Returns `(response_mime_type, response_schema)`.
-fn translate_response_format(
-    format: &ResponseFormat,
-) -> (Option<String>, Option<serde_json::Value>) {
-    match format.kind {
-        ResponseFormatType::Text => (None, None),
-        ResponseFormatType::JsonObject => (Some("application/json".to_string()), None),
-        ResponseFormatType::JsonSchema => (
-            Some("application/json".to_string()),
-            format.json_schema.clone(),
-        ),
-    }
-}
-
-/// Build the Gemini API request body from a unified `Request`.
-///
-/// Returns a `serde_json::Value` so that `provider_options.gemini` fields can
-/// be merged into the request before sending.
-async fn build_api_request(request: &Request) -> serde_json::Value {
-    let (system_text, other_messages) = extract_system_prompt(&request.messages);
-
-    let system_instruction = system_text.map(|text| SystemInstruction {
-        parts: vec![serde_json::json!({"text": text})],
-    });
-
-    let contents = translate_messages(&other_messages).await;
-
-    let (response_mime_type, response_schema) = request
-        .response_format
-        .as_ref()
-        .map_or((None, None), translate_response_format);
-
-    let generation_config = GenerationOptions {
-        temperature: request.temperature,
-        max_output_tokens: request.max_tokens,
-        top_p: request.top_p,
-        stop_sequences: request.stop_sequences.clone(),
-        response_mime_type,
-        response_schema,
-    };
-
-    let api_tools = request.tools.as_ref().map(|t| translate_tools(t));
-    let tool_config = request.tool_choice.as_ref().map(translate_tool_choice);
-
-    let api_request = ApiRequest {
-        contents,
-        system_instruction,
-        generation_config: Some(generation_config),
-        tools: api_tools,
-        tool_config,
-    };
-
-    let mut body = serde_json::to_value(&api_request).unwrap_or_default();
-    merge_provider_options(&mut body, request.provider_options.as_ref());
-    apply_default_safety_settings(&mut body);
-    body
-}
-
-/// Merge `provider_options.gemini` fields into the serialized API request body.
-///
-/// Known fields like `safety_settings` and `cached_content` are set directly.
-/// Any other fields are merged at the top level, allowing pass-through of
-/// Gemini-specific options not covered by the unified schema.
-fn merge_provider_options(
-    body: &mut serde_json::Value,
-    provider_options: Option<&serde_json::Value>,
-) {
-    let Some(gemini_opts) = provider_options.and_then(|opts| opts.get("gemini")) else {
-        return;
-    };
-    let Some(body_map) = body.as_object_mut() else {
-        return;
-    };
-    let Some(gemini_map) = gemini_opts.as_object() else {
-        return;
-    };
-
-    for (key, value) in gemini_map {
-        body_map.insert(key.clone(), value.clone());
-    }
-}
-
-/// Apply default safety settings if none were provided via provider_options.
-fn apply_default_safety_settings(body: &mut serde_json::Value) {
-    if body.get("safety_settings").is_some() {
-        return;
-    }
-    if let Some(body_map) = body.as_object_mut() {
-        body_map.insert(
-            "safety_settings".to_string(),
-            serde_json::json!([{
-                "category": "HARM_CATEGORY_DANGEROUS_CONTENT",
-                "threshold": "BLOCK_ONLY_HIGH"
-            }]),
-        );
-    }
-}
-
-/// Convert `UsageMetadata` from the Gemini API into a unified `TokenCounts`.
-fn parse_usage(metadata: Option<&UsageMetadata>) -> TokenCounts {
-    metadata.map_or_else(TokenCounts::default, |u| {
-        let cache_read_tokens = u.cached_content_token_count.unwrap_or(0);
-        let reasoning_tokens = u.thoughts_token_count.unwrap_or(0);
-        let tool_use_prompt_tokens = u.tool_use_prompt_token_count.unwrap_or(0);
-        TokenCounts {
-            input_tokens: u
-                .prompt_token_count
-                .unwrap_or(0)
-                .saturating_sub(cache_read_tokens)
-                + tool_use_prompt_tokens,
-            output_tokens: u.candidates_token_count.unwrap_or(0),
-            reasoning_tokens,
-            cache_read_tokens,
-            ..TokenCounts::default()
-        }
-    })
-}
-
-/// Send an HTTP request and read the Gemini response body.
-///
-/// Like `send_and_read_response` but uses gRPC status code mapping when
-/// available.
-async fn send_gemini_response(
-    request: fabro_http::RequestBuilder,
-    provider: &str,
-) -> Result<(String, HeaderMap), Error> {
-    let http_resp = request.send().await.map_err(|e| {
-        if e.is_timeout() {
-            Error::request_timeout(format!("gemini: {e}"), e)
-        } else {
-            Error::network(e.to_string(), e)
-        }
-    })?;
-
-    let status = http_resp.status();
-    let retry_after = parse_retry_after(http_resp.headers());
-    let headers = http_resp.headers().clone();
-    let body = http_resp
-        .text()
-        .await
-        .map_err(|e| Error::network(e.to_string(), e))?;
-
-    if !status.is_success() {
-        let (msg, code, raw) = parse_error_body(&body, "status");
-        return Err(gemini_error(
-            status.as_u16(),
-            msg,
-            provider,
-            code,
-            raw,
-            retry_after,
-        ));
-    }
-
-    Ok((body, headers))
-}
-
-/// Map Gemini error response using gRPC status when available, falling back to
-/// HTTP status.
-fn gemini_error(
-    status_code: u16,
-    msg: String,
-    provider: &str,
-    grpc_status: Option<String>,
-    raw: Option<serde_json::Value>,
-    retry_after: Option<f64>,
-) -> Error {
-    match grpc_status {
-        Some(grpc_code) => error_from_grpc_status(
-            &grpc_code,
-            msg,
-            provider.to_string(),
-            Some(grpc_code.clone()),
-            raw,
-            retry_after,
-        ),
-        None => error_from_status_code(
-            status_code,
-            msg,
-            provider.to_string(),
-            None,
-            raw,
-            retry_after,
-        ),
-    }
-}
-
-/// Send an HTTP request for streaming and return the `fabro_http::Response`.
-///
-/// Checks for HTTP errors before returning. On error, reads the body and
-/// maps it to `Error` using gRPC status code mapping when available.
-async fn send_streaming_request(
-    request: fabro_http::RequestBuilder,
-    provider: &str,
-) -> Result<fabro_http::Response, Error> {
-    let http_resp = request
-        .send()
-        .await
-        .map_err(|e| Error::network(e.to_string(), e))?;
-
-    let status = http_resp.status();
-    if !status.is_success() {
+        let status = http_resp.status();
         let retry_after = parse_retry_after(http_resp.headers());
+        let headers = http_resp.headers().clone();
         let body = http_resp
             .text()
             .await
             .map_err(|e| Error::network(e.to_string(), e))?;
-        let (msg, code, raw) = parse_error_body(&body, "status");
-        return Err(gemini_error(
-            status.as_u16(),
-            msg,
-            provider,
-            code,
-            raw,
-            retry_after,
-        ));
-    }
 
-    Ok(http_resp)
+        if !status.is_success() {
+            return Err(codec.decode_error(status.as_u16(), &body, ctx, retry_after));
+        }
+
+        Ok((body, headers))
+    }
 }
 
-/// Process a stream of SSE chunks from the Gemini `streamGenerateContent`
-/// endpoint and yield `StreamEvent` values.
-fn process_sse_stream(
-    http_resp: fabro_http::Response,
-    model: String,
-    provider: String,
-    rate_limit: Option<RateLimitInfo>,
-    stream_read_timeout: Option<std::time::Duration>,
-) -> StreamEventStream {
-    Box::pin(stream::unfold(
-        SseStreamState::new(http_resp, model, provider, rate_limit, stream_read_timeout),
-        |mut state| async move {
-            // If we have buffered events, yield them first.
-            if let Some(event) = state.pending_events.pop_front() {
-                return Some((Ok(event), state));
-            }
-
-            // Read SSE lines until we get a data payload or the stream ends.
-            loop {
-                let line = match state.read_line().await {
-                    Ok(Some(line)) => line,
-                    Ok(None) => {
-                        // Stream ended. Emit Finish if we haven't yet.
-                        if !state.finished {
-                            state.finished = true;
-                            let event = state.build_finish_event();
-                            return Some((Ok(event), state));
-                        }
-                        return None;
-                    }
-                    Err(e) => return Some((Err(e), state)),
-                };
-
-                // SSE format: lines starting with "data:" carry the payload.
-                let data = if let Some(stripped) = line.strip_prefix("data:") {
-                    stripped.trim()
-                } else {
-                    // Ignore non-data lines (empty lines, comments, event: lines).
-                    continue;
-                };
-
-                // Skip empty data lines.
-                if data.is_empty() {
-                    continue;
-                }
-
-                // Parse the JSON chunk.
-                let chunk: ApiResponse = match serde_json::from_str(data) {
-                    Ok(v) => v,
-                    Err(e) => {
-                        return Some((
-                            Err(Error::stream_error(
-                                format!("failed to parse Gemini SSE chunk: {e}"),
-                                e,
-                            )),
-                            state,
-                        ));
-                    }
-                };
-
-                // Extract events from this chunk.
-                state.process_chunk(&chunk);
-
-                // Track usage from every chunk; the final one will have the totals.
-                if let Some(ref usage_meta) = chunk.usage_metadata {
-                    state.usage = parse_usage(Some(usage_meta));
-                }
-
-                // Extract finish reason from the candidate if present.
-                let candidate_finish = chunk
-                    .candidates
-                    .as_ref()
-                    .and_then(|c| c.first())
-                    .and_then(|c| c.finish_reason.clone());
-                if let Some(reason) = candidate_finish {
-                    state.finish_reason_str = Some(reason);
-                }
-
-                // Yield the first buffered event if any were produced.
-                if let Some(event) = state.pending_events.pop_front() {
-                    return Some((Ok(event), state));
-                }
-                // If no events were produced from this chunk, continue reading.
-            }
-        },
-    ))
-}
-
-/// Internal state for the SSE stream processor.
-struct SseStreamState {
-    line_reader:            super::common::LineReader,
-    model:                  String,
-    /// Configured provider name stamped into the final `Response.provider`.
-    provider:               String,
-    /// Events extracted from a chunk but not yet yielded.
-    pending_events:         std::collections::VecDeque<StreamEvent>,
-    /// Whether we have emitted a `StreamStart` event.
-    stream_started:         bool,
-    /// Whether we have emitted a `TextStart` event.
-    text_started:           bool,
-    /// Whether we are currently inside a reasoning (thought) segment.
-    reasoning_started:      bool,
-    /// Accumulated thinking text across all chunks.
-    accumulated_thinking:   String,
-    /// Accumulated text across all chunks.
-    accumulated_text:       String,
-    /// Accumulated tool calls across all chunks.
-    accumulated_tool_calls: Vec<ToolCall>,
-    /// The `text_id` used for `TextStart`/`TextDelta`/`TextEnd`.
-    text_id:                String,
-    /// Latest usage metadata (updated per chunk; final chunk has totals).
-    usage:                  TokenCounts,
-    /// The finish reason string from the candidate, if received.
-    finish_reason_str:      Option<String>,
-    /// Whether we have emitted the `Finish` event.
-    finished:               bool,
-    /// Rate limit info parsed from HTTP response headers.
-    rate_limit:             Option<RateLimitInfo>,
-}
-
-impl SseStreamState {
-    fn new(
-        http_resp: fabro_http::Response,
-        model: String,
-        provider: String,
-        rate_limit: Option<RateLimitInfo>,
-        stream_read_timeout: Option<std::time::Duration>,
-    ) -> Self {
-        Self {
-            line_reader: super::common::LineReader::new(http_resp, stream_read_timeout),
-            model,
-            provider,
-            pending_events: std::collections::VecDeque::new(),
-            stream_started: false,
-            text_started: false,
-            reasoning_started: false,
-            accumulated_thinking: String::new(),
-            accumulated_text: String::new(),
-            accumulated_tool_calls: Vec::new(),
-            text_id: uuid::Uuid::new_v4().to_string(),
-            usage: TokenCounts::default(),
-            finish_reason_str: None,
-            finished: false,
-            rate_limit,
-        }
-    }
-
-    /// Read the next complete line from the HTTP byte stream.
-    ///
-    /// Returns `Ok(None)` when the stream is exhausted.
-    async fn read_line(&mut self) -> Result<Option<String>, Error> {
-        self.line_reader
-            .read_next_chunk("\n")
-            .await
-            .map(|opt| opt.map(|s| s.trim_end_matches('\r').to_string()))
-    }
-
-    /// Extract stream events from a parsed SSE chunk and buffer them.
-    fn process_chunk(&mut self, chunk: &ApiResponse) {
-        if !self.stream_started {
-            self.stream_started = true;
-            self.pending_events.push_back(StreamEvent::StreamStart);
-        }
-
-        let parts = chunk
-            .candidates
-            .as_ref()
-            .and_then(|c| c.first())
-            .and_then(|c| c.content.as_ref())
-            .and_then(|c| c.parts.as_ref());
-
-        let Some(parts) = parts else {
-            return;
-        };
-
-        for part in parts {
-            let is_thought = part
-                .get("thought")
-                .and_then(serde_json::Value::as_bool)
-                .unwrap_or(false);
-
-            if let Some(text) = part.get("text").and_then(serde_json::Value::as_str) {
-                if is_thought {
-                    if !self.reasoning_started {
-                        self.reasoning_started = true;
-                        self.pending_events.push_back(StreamEvent::ReasoningStart);
-                    }
-                    self.accumulated_thinking.push_str(text);
-                    self.pending_events.push_back(StreamEvent::ReasoningDelta {
-                        delta: text.to_string(),
-                    });
-                } else {
-                    // Transition from reasoning to text: close reasoning segment.
-                    if self.reasoning_started {
-                        self.reasoning_started = false;
-                        self.pending_events.push_back(StreamEvent::ReasoningEnd);
-                    }
-                    if !self.text_started {
-                        self.text_started = true;
-                        self.pending_events.push_back(StreamEvent::TextStart {
-                            text_id: Some(self.text_id.clone()),
-                        });
-                    }
-                    self.accumulated_text.push_str(text);
-                    self.pending_events
-                        .push_back(StreamEvent::text_delta(text, Some(self.text_id.clone())));
-                }
-            } else if let Some(fc) = part.get("functionCall") {
-                let name = fc
-                    .get("name")
-                    .and_then(serde_json::Value::as_str)
-                    .unwrap_or("")
-                    .to_string();
-                let args = fc
-                    .get("args")
-                    .cloned()
-                    .unwrap_or_else(|| serde_json::Value::Object(serde_json::Map::new()));
-                let mut tool_call = ToolCall::new(uuid::Uuid::new_v4().to_string(), name, args);
-                // Preserve thought_signature for Gemini 3 models (sibling of functionCall)
-                if let Some(sig) = part.get("thoughtSignature") {
-                    tool_call.provider_metadata =
-                        Some(serde_json::json!({"thoughtSignature": sig}));
-                }
-
-                // Gemini delivers function calls as complete objects in a single chunk.
-                self.pending_events.push_back(StreamEvent::ToolCallStart {
-                    tool_call: tool_call.clone(),
-                });
-                self.pending_events.push_back(StreamEvent::ToolCallEnd {
-                    tool_call: tool_call.clone(),
-                });
-                self.accumulated_tool_calls.push(tool_call);
-            }
-        }
-
-        // If a finish reason is present on this chunk's candidate, emit TextEnd.
-        let has_finish_reason = chunk
-            .candidates
-            .as_ref()
-            .and_then(|c| c.first())
-            .and_then(|c| c.finish_reason.as_ref())
-            .is_some();
-
-        if has_finish_reason {
-            if self.reasoning_started {
-                self.reasoning_started = false;
-                self.pending_events.push_back(StreamEvent::ReasoningEnd);
-            }
-            if self.text_started {
-                self.pending_events.push_back(StreamEvent::TextEnd {
-                    text_id: Some(self.text_id.clone()),
-                });
-            }
-        }
-    }
-
-    /// Build the final `Finish` event from accumulated state.
-    fn build_finish_event(&self) -> StreamEvent {
-        let has_tool_calls = !self.accumulated_tool_calls.is_empty();
-        let finish_reason = map_finish_reason(self.finish_reason_str.as_deref(), has_tool_calls);
-
-        let mut content_parts: Vec<ContentPart> = Vec::new();
-        if !self.accumulated_thinking.is_empty() {
-            content_parts.push(ContentPart::Thinking(ThinkingData {
-                text:      self.accumulated_thinking.clone(),
-                signature: None,
-                redacted:  false,
-            }));
-        }
-        if !self.accumulated_text.is_empty() {
-            content_parts.push(ContentPart::text(&self.accumulated_text));
-        }
-        for tc in &self.accumulated_tool_calls {
-            content_parts.push(ContentPart::ToolCall(tc.clone()));
-        }
-
-        let response = Response {
-            id:            uuid::Uuid::new_v4().to_string(),
-            model:         self.model.clone(),
-            provider:      self.provider.clone(),
-            message:       Message {
-                role:         Role::Assistant,
-                content:      content_parts,
-                name:         None,
-                tool_call_id: None,
-            },
-            finish_reason: finish_reason.clone(),
-            usage:         self.usage.clone(),
-            raw:           None,
-            warnings:      vec![],
-            rate_limit:    self.rate_limit.clone(),
-        };
-
-        StreamEvent::finish(finish_reason, self.usage.clone(), response)
-    }
+/// State driving the streaming byte loop: the codec's decoder plus the line
+/// reader, with a buffer that flattens batched events into individual items.
+struct StreamLoop {
+    decoder:          Box<dyn StreamDecoder>,
+    line_reader:      super::common::LineReader,
+    pending:          std::collections::VecDeque<StreamEvent>,
+    done:             bool,
+    finished_emitted: bool,
 }
 
 #[async_trait::async_trait]
@@ -968,132 +169,168 @@ impl ProviderAdapter for Adapter {
         request: &Request,
     ) -> Result<Option<InputTokenCount>, Error> {
         self.validate_request(request)?;
-        let api_body = build_api_request(request).await;
-        let api_model = common::api_model_id(self.catalog.as_deref(), &request.model);
-        let url = format!("{}/models/{}:countTokens", self.http.base_url, api_model);
 
-        let mut req = self.http.client.post(&url);
-        if let Some(api_key) = &self.http.api_key {
-            req = req.header("x-goog-api-key", api_key);
-        }
-        for (key, value) in &self.http.default_headers {
-            req = req.header(key, value);
-        }
-        let mut req = req.json(&serde_json::json!({ "generateContentRequest": api_body }));
+        let resolved = self.resolve_request(request).await;
+        let codec = GeminiGenerate;
+        let deployment_id = common::api_model_id(self.catalog.as_deref(), &resolved.model);
+        let params = CodecParams;
+        let ctx = CodecCtx {
+            request:       &resolved,
+            provider_name: &self.provider_name,
+            deployment_id: &deployment_id,
+            model:         common::catalog_model(self.catalog.as_deref(), &resolved.model),
+            params:        &params,
+        };
+
+        let Some(encoded) = codec.encode_count_tokens(&ctx).transpose()? else {
+            return Ok(None);
+        };
+
+        let mut req = self.build_http_request(&encoded);
         if let Some(t) = self.http.request_timeout {
             req = req.timeout(t);
         }
-        let (body, _headers) = send_gemini_response(req, &self.provider_name).await?;
-        let response: CountTokensResponse =
-            serde_json::from_str(&body).map_err(|e| Error::Configuration {
-                message: format!("failed to parse Gemini token count: {e}"),
-                source:  None,
-            })?;
+        let (body, _headers) = self.send_for_body(req, &codec, &ctx).await?;
+        let input_tokens = codec.decode_count_tokens(&body)?;
 
         Ok(Some(InputTokenCount {
-            input_tokens: response.total_tokens,
-            method:       InputTokenCountMethod::ProviderApi,
-            provider:     self.provider_name.clone(),
-            model:        request.model.clone(),
-            warnings:     vec![],
+            input_tokens,
+            method: InputTokenCountMethod::ProviderApi,
+            provider: self.provider_name.clone(),
+            model: request.model.clone(),
+            warnings: vec![],
         }))
     }
 
     async fn complete(&self, request: &Request) -> Result<Response, Error> {
         self.validate_request(request)?;
-        let api_body = build_api_request(request).await;
 
-        let api_model = common::api_model_id(self.catalog.as_deref(), &request.model);
-        let url = format!(
-            "{}/models/{}:generateContent",
-            self.http.base_url, api_model
-        );
+        let resolved = self.resolve_request(request).await;
+        let codec = GeminiGenerate;
+        let deployment_id = common::api_model_id(self.catalog.as_deref(), &resolved.model);
+        let params = CodecParams;
+        let ctx = CodecCtx {
+            request:       &resolved,
+            provider_name: &self.provider_name,
+            deployment_id: &deployment_id,
+            model:         common::catalog_model(self.catalog.as_deref(), &resolved.model),
+            params:        &params,
+        };
 
-        let mut req = self.http.client.post(&url);
-        if let Some(api_key) = &self.http.api_key {
-            req = req.header("x-goog-api-key", api_key);
-        }
-        for (key, value) in &self.http.default_headers {
-            req = req.header(key, value);
-        }
-        let mut gemini_req = req.json(&api_body);
+        let encoded = codec.encode(&ctx, false)?;
+        let mut req = self.build_http_request(&encoded);
         if let Some(t) = self.http.request_timeout {
-            gemini_req = gemini_req.timeout(t);
+            req = req.timeout(t);
         }
-        let (body, headers) = send_gemini_response(gemini_req, &self.provider_name).await?;
-
-        let api_resp: ApiResponse = serde_json::from_str(&body)
-            .map_err(|e| Error::network(format!("failed to parse Gemini response: {e}"), e))?;
-
-        let candidate = api_resp
-            .candidates
-            .as_ref()
-            .and_then(|c| c.first())
-            .ok_or_else(|| Error::Provider {
-                kind:   ProviderErrorKind::Server,
-                detail: Box::new(ProviderErrorDetail::new(
-                    "no candidates in Gemini response",
-                    self.provider_name.as_str(),
-                )),
-            })?;
-
-        let raw_parts = candidate.content.as_ref().and_then(|c| c.parts.as_ref());
-
-        let content_parts: Vec<ContentPart> = raw_parts
-            .map(|parts| parts.iter().filter_map(parse_part).collect())
-            .unwrap_or_default();
-
-        // Gemini has no dedicated tool_calls finish reason; infer from parts
-        let has_tool_calls = raw_parts.is_some_and(|p| parts_have_function_calls(p));
-        let finish_reason = map_finish_reason(candidate.finish_reason.as_deref(), has_tool_calls);
-
-        let usage = parse_usage(api_resp.usage_metadata.as_ref());
-
-        Ok(Response {
-            id: uuid::Uuid::new_v4().to_string(),
-            model: request.model.clone(),
-            provider: self.provider_name.clone(),
-            message: Message {
-                role:         Role::Assistant,
-                content:      content_parts,
-                name:         None,
-                tool_call_id: None,
-            },
-            finish_reason,
-            usage,
-            raw: serde_json::from_str(&body).ok(),
-            warnings: vec![],
-            rate_limit: parse_rate_limit_headers(&headers),
-        })
+        let (body, headers) = self.send_for_body(req, &codec, &ctx).await?;
+        let rate_limit = parse_rate_limit_headers(&headers);
+        codec.decode_response(&body, &ctx, rate_limit)
     }
 
     async fn stream(&self, request: &Request) -> Result<StreamEventStream, Error> {
         self.validate_request(request)?;
-        let api_body = build_api_request(request).await;
 
-        let api_model = common::api_model_id(self.catalog.as_deref(), &request.model);
-        let url = format!(
-            "{}/models/{}:streamGenerateContent?alt=sse",
-            self.http.base_url, api_model
+        let resolved = self.resolve_request(request).await;
+        let codec = GeminiGenerate;
+        let deployment_id = common::api_model_id(self.catalog.as_deref(), &resolved.model);
+        let params = CodecParams;
+        let stream_read_timeout = self.http.stream_read_timeout;
+        let rate_limit;
+
+        let http_resp = {
+            let ctx = CodecCtx {
+                request:       &resolved,
+                provider_name: &self.provider_name,
+                deployment_id: &deployment_id,
+                model:         common::catalog_model(self.catalog.as_deref(), &resolved.model),
+                params:        &params,
+            };
+            let encoded = codec.encode(&ctx, true)?;
+            let resp = self
+                .build_http_request(&encoded)
+                .send()
+                .await
+                .map_err(|e| Error::network(e.to_string(), e))?;
+
+            let status = resp.status();
+            if !status.is_success() {
+                let retry_after = parse_retry_after(resp.headers());
+                let body = resp
+                    .text()
+                    .await
+                    .map_err(|e| Error::network(e.to_string(), e))?;
+                return Err(codec.decode_error(status.as_u16(), &body, &ctx, retry_after));
+            }
+            rate_limit = parse_rate_limit_headers(resp.headers());
+            resp
+        };
+
+        // Build the decoder while the ctx is still in scope; it captures owned
+        // state and does not borrow ctx beyond construction.
+        let decoder = {
+            let ctx = CodecCtx {
+                request:       &resolved,
+                provider_name: &self.provider_name,
+                deployment_id: &deployment_id,
+                model:         common::catalog_model(self.catalog.as_deref(), &resolved.model),
+                params:        &params,
+            };
+            codec.stream_decoder(&ctx, rate_limit)
+        };
+
+        let out = stream::unfold(
+            StreamLoop {
+                decoder,
+                line_reader: super::common::LineReader::new(http_resp, stream_read_timeout),
+                pending: std::collections::VecDeque::new(),
+                done: false,
+                finished_emitted: false,
+            },
+            |mut state| async move {
+                loop {
+                    if let Some(event) = state.pending.pop_front() {
+                        return Some((Ok(event), state));
+                    }
+
+                    if state.done {
+                        if state.finished_emitted {
+                            return None;
+                        }
+                        state.finished_emitted = true;
+                        let events = state.decoder.finish();
+                        if events.is_empty() {
+                            return None;
+                        }
+                        state.pending.extend(events);
+                        continue;
+                    }
+
+                    match state.line_reader.read_next_chunk("\n").await {
+                        Ok(Some(line)) => {
+                            // Gemini uses data-only SSE: lines starting with
+                            // "data:" carry the payload; everything else
+                            // (empty lines, comments, event: lines) is
+                            // ignored.
+                            let line = line.trim_end_matches('\r');
+                            let Some(data) = line.strip_prefix("data:").map(str::trim) else {
+                                continue;
+                            };
+                            if data.is_empty() {
+                                continue;
+                            }
+                            match state.decoder.on_event(RawEvent { event: None, data }) {
+                                Ok(events) => state.pending.extend(events),
+                                Err(e) => return Some((Err(e), state)),
+                            }
+                        }
+                        Ok(None) => state.done = true,
+                        Err(e) => return Some((Err(e), state)),
+                    }
+                }
+            },
         );
 
-        let mut req = self.http.client.post(&url);
-        if let Some(api_key) = &self.http.api_key {
-            req = req.header("x-goog-api-key", api_key);
-        }
-        for (key, value) in &self.http.default_headers {
-            req = req.header(key, value);
-        }
-        let http_resp = send_streaming_request(req.json(&api_body), &self.provider_name).await?;
-
-        let rate_limit = parse_rate_limit_headers(http_resp.headers());
-        Ok(process_sse_stream(
-            http_resp,
-            request.model.clone(),
-            self.provider_name.clone(),
-            rate_limit,
-            self.http.stream_read_timeout,
-        ))
+        Ok(Box::pin(out))
     }
 }
 
@@ -1102,7 +339,7 @@ mod tests {
     use httpmock::prelude::*;
 
     use super::*;
-    use crate::types::{AudioData, DocumentData};
+    use crate::types::Message;
 
     fn minimal_request() -> Request {
         Request {
@@ -1121,34 +358,6 @@ mod tests {
             metadata:         None,
             provider_options: None,
         }
-    }
-
-    #[test]
-    fn token_counts_disjoint_with_cache_thoughts_and_tool_use() {
-        let body = serde_json::json!({
-            "promptTokenCount": 200,
-            "cachedContentTokenCount": 180,
-            "candidatesTokenCount": 200,
-            "thoughtsTokenCount": 300,
-            "toolUsePromptTokenCount": 400
-        });
-        let meta: UsageMetadata = serde_json::from_value(body).unwrap();
-        let usage = parse_usage(Some(&meta));
-
-        assert_eq!(usage.input_tokens, 420);
-        assert_eq!(usage.cache_read_tokens, 180);
-        assert_eq!(usage.output_tokens, 200);
-        assert_eq!(usage.reasoning_tokens, 300);
-        assert_eq!(usage.cache_write_tokens, 0);
-        assert_eq!(usage.total_tokens(), 1100);
-    }
-
-    #[tokio::test]
-    async fn provider_options_none_produces_standard_body() {
-        let request = minimal_request();
-        let body = build_api_request(&request).await;
-        assert!(body.get("safetySettings").is_none());
-        assert!(body.get("cachedContent").is_none());
     }
 
     #[tokio::test]
@@ -1173,435 +382,5 @@ mod tests {
         mock.assert();
         assert_eq!(count.input_tokens, 456);
         assert_eq!(count.method, InputTokenCountMethod::ProviderApi);
-    }
-
-    #[tokio::test]
-    async fn count_tokens_body_uses_only_generate_content_request_top_level() {
-        let mut request = minimal_request();
-        request.tools = Some(vec![ToolDefinition::function(
-            "search",
-            "Search files",
-            serde_json::json!({"type": "object"}),
-        )]);
-        let api_body = build_api_request(&request).await;
-        let count_body = serde_json::json!({ "generateContentRequest": api_body });
-
-        assert!(count_body.get("generateContentRequest").is_some());
-        assert!(count_body.get("contents").is_none());
-        assert!(
-            count_body["generateContentRequest"]
-                .get("contents")
-                .is_some()
-        );
-        assert!(count_body["generateContentRequest"].get("tools").is_some());
-    }
-
-    #[tokio::test]
-    async fn provider_options_gemini_safety_settings_merged() {
-        let mut request = minimal_request();
-        request.provider_options = Some(serde_json::json!({
-            "gemini": {
-                "safetySettings": [
-                    {"category": "HARM_CATEGORY_HARASSMENT", "threshold": "BLOCK_NONE"}
-                ]
-            }
-        }));
-
-        let body = build_api_request(&request).await;
-        let safety = body
-            .get("safetySettings")
-            .expect("safetySettings should be present");
-        let arr = safety.as_array().expect("should be an array");
-        assert_eq!(arr.len(), 1);
-        assert_eq!(arr[0]["category"], "HARM_CATEGORY_HARASSMENT");
-    }
-
-    #[tokio::test]
-    async fn provider_options_gemini_cached_content_merged() {
-        let mut request = minimal_request();
-        request.provider_options = Some(serde_json::json!({
-            "gemini": {
-                "cachedContent": "projects/my-project/cachedContents/abc123"
-            }
-        }));
-
-        let body = build_api_request(&request).await;
-        assert_eq!(
-            body.get("cachedContent")
-                .and_then(serde_json::Value::as_str),
-            Some("projects/my-project/cachedContents/abc123")
-        );
-    }
-
-    #[tokio::test]
-    async fn provider_options_gemini_multiple_fields_merged() {
-        let mut request = minimal_request();
-        request.provider_options = Some(serde_json::json!({
-            "gemini": {
-                "safetySettings": [{"category": "HARM_CATEGORY_HATE_SPEECH", "threshold": "BLOCK_LOW_AND_ABOVE"}],
-                "cachedContent": "cache-id",
-                "customField": "custom-value"
-            }
-        }));
-
-        let body = build_api_request(&request).await;
-        assert!(body.get("safetySettings").is_some());
-        assert_eq!(
-            body.get("cachedContent")
-                .and_then(serde_json::Value::as_str),
-            Some("cache-id")
-        );
-        assert_eq!(
-            body.get("customField").and_then(serde_json::Value::as_str),
-            Some("custom-value")
-        );
-    }
-
-    #[tokio::test]
-    async fn provider_options_other_provider_ignored() {
-        let mut request = minimal_request();
-        request.provider_options = Some(serde_json::json!({
-            "anthropic": {
-                "auto_cache": false
-            }
-        }));
-
-        let body = build_api_request(&request).await;
-        assert!(body.get("auto_cache").is_none());
-    }
-
-    #[tokio::test]
-    async fn provider_options_gemini_preserves_standard_fields() {
-        let mut request = minimal_request();
-        request.temperature = Some(0.5);
-        request.max_tokens = Some(100);
-        request.provider_options = Some(serde_json::json!({
-            "gemini": {
-                "cachedContent": "cache-id"
-            }
-        }));
-
-        let body = build_api_request(&request).await;
-        let gen_config = body
-            .get("generationConfig")
-            .expect("generationConfig should exist");
-        assert_eq!(
-            gen_config
-                .get("temperature")
-                .and_then(serde_json::Value::as_f64),
-            Some(0.5)
-        );
-        assert_eq!(
-            gen_config
-                .get("maxOutputTokens")
-                .and_then(serde_json::Value::as_i64),
-            Some(100)
-        );
-        assert_eq!(
-            body.get("cachedContent")
-                .and_then(serde_json::Value::as_str),
-            Some("cache-id")
-        );
-    }
-
-    #[test]
-    fn merge_provider_options_with_non_object_gemini_value() {
-        let mut body = serde_json::json!({"contents": []});
-        let opts = serde_json::json!({"gemini": "not-an-object"});
-        merge_provider_options(&mut body, Some(&opts));
-        // Should not crash and body should be unchanged
-        assert!(body.get("contents").is_some());
-    }
-
-    #[tokio::test]
-    async fn audio_url_translates_to_file_data() {
-        let msg = Message {
-            role:         Role::User,
-            content:      vec![ContentPart::Audio(AudioData {
-                url:        Some("https://example.com/audio.wav".to_string()),
-                data:       None,
-                media_type: Some("audio/wav".to_string()),
-            })],
-            name:         None,
-            tool_call_id: None,
-        };
-        let contents = translate_messages(&[&msg]).await;
-        assert_eq!(contents.len(), 1);
-        let part = &contents[0].parts[0];
-        assert_eq!(part["fileData"]["mimeType"], "audio/wav");
-        assert_eq!(part["fileData"]["fileUri"], "https://example.com/audio.wav");
-    }
-
-    #[tokio::test]
-    async fn audio_base64_translates_to_inline_data() {
-        let msg = Message {
-            role:         Role::User,
-            content:      vec![ContentPart::Audio(AudioData {
-                url:        None,
-                data:       Some(vec![0xFF, 0xFB, 0x90]),
-                media_type: None,
-            })],
-            name:         None,
-            tool_call_id: None,
-        };
-        let contents = translate_messages(&[&msg]).await;
-        let part = &contents[0].parts[0];
-        assert_eq!(part["inlineData"]["mimeType"], "audio/wav");
-        assert!(part["inlineData"]["data"].as_str().is_some());
-    }
-
-    #[tokio::test]
-    async fn document_url_translates_to_file_data() {
-        let msg = Message {
-            role:         Role::User,
-            content:      vec![ContentPart::Document(DocumentData {
-                url:        Some("https://example.com/doc.pdf".to_string()),
-                data:       None,
-                media_type: Some("application/pdf".to_string()),
-                file_name:  Some("doc.pdf".to_string()),
-            })],
-            name:         None,
-            tool_call_id: None,
-        };
-        let contents = translate_messages(&[&msg]).await;
-        let part = &contents[0].parts[0];
-        assert_eq!(part["fileData"]["mimeType"], "application/pdf");
-        assert_eq!(part["fileData"]["fileUri"], "https://example.com/doc.pdf");
-    }
-
-    #[tokio::test]
-    async fn document_base64_translates_to_inline_data() {
-        let msg = Message {
-            role:         Role::User,
-            content:      vec![ContentPart::Document(DocumentData {
-                url:        None,
-                data:       Some(vec![0x25, 0x50, 0x44, 0x46]),
-                media_type: None,
-                file_name:  None,
-            })],
-            name:         None,
-            tool_call_id: None,
-        };
-        let contents = translate_messages(&[&msg]).await;
-        let part = &contents[0].parts[0];
-        assert_eq!(part["inlineData"]["mimeType"], "application/pdf");
-        assert!(part["inlineData"]["data"].as_str().is_some());
-    }
-
-    #[test]
-    fn gemini_error_uses_grpc_status_when_available() {
-        use crate::error::ProviderErrorKind;
-
-        let err = gemini_error(
-            400,
-            "model not found".into(),
-            "gemini",
-            Some("NOT_FOUND".into()),
-            None,
-            None,
-        );
-        assert!(matches!(err, Error::Provider {
-            kind: ProviderErrorKind::NotFound,
-            ..
-        }));
-
-        let err = gemini_error(
-            400,
-            "bad args".into(),
-            "gemini",
-            Some("INVALID_ARGUMENT".into()),
-            None,
-            None,
-        );
-        assert!(matches!(err, Error::Provider {
-            kind: ProviderErrorKind::InvalidRequest,
-            ..
-        }));
-
-        let err = gemini_error(
-            429,
-            "rate limited".into(),
-            "gemini",
-            Some("RESOURCE_EXHAUSTED".into()),
-            None,
-            None,
-        );
-        assert!(matches!(err, Error::Provider {
-            kind: ProviderErrorKind::RateLimit,
-            ..
-        }));
-
-        let err = gemini_error(
-            401,
-            "bad key".into(),
-            "gemini",
-            Some("UNAUTHENTICATED".into()),
-            None,
-            None,
-        );
-        assert!(matches!(err, Error::Provider {
-            kind: ProviderErrorKind::Authentication,
-            ..
-        }));
-
-        let err = gemini_error(
-            403,
-            "denied".into(),
-            "gemini",
-            Some("PERMISSION_DENIED".into()),
-            None,
-            None,
-        );
-        assert!(matches!(err, Error::Provider {
-            kind: ProviderErrorKind::AccessDenied,
-            ..
-        }));
-
-        let err = gemini_error(
-            504,
-            "timeout".into(),
-            "gemini",
-            Some("DEADLINE_EXCEEDED".into()),
-            None,
-            None,
-        );
-        assert!(matches!(err, Error::RequestTimeout { .. }));
-    }
-
-    #[test]
-    fn gemini_error_falls_back_to_http_status_without_grpc() {
-        use crate::error::ProviderErrorKind;
-
-        let err = gemini_error(429, "rate limited".into(), "gemini", None, None, None);
-        assert!(matches!(err, Error::Provider {
-            kind: ProviderErrorKind::RateLimit,
-            ..
-        }));
-
-        let err = gemini_error(500, "internal".into(), "gemini", None, None, None);
-        assert!(matches!(err, Error::Provider {
-            kind: ProviderErrorKind::Server,
-            ..
-        }));
-    }
-
-    #[test]
-    fn parse_part_handles_thought_text() {
-        let part = serde_json::json!({"text": "Let me think about this...", "thought": true});
-        let result = parse_part(&part).expect("should parse thought part");
-        match result {
-            ContentPart::Thinking(td) => {
-                assert_eq!(td.text, "Let me think about this...");
-                assert!(td.signature.is_none());
-                assert!(!td.redacted);
-            }
-            other => panic!("expected Thinking, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn parse_part_text_without_thought_flag() {
-        let part = serde_json::json!({"text": "Hello world"});
-        let result = parse_part(&part).expect("should parse text part");
-        match result {
-            ContentPart::Text(text) => assert_eq!(text, "Hello world"),
-            other => panic!("expected Text, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn parse_part_function_call() {
-        let part = serde_json::json!({
-            "functionCall": {
-                "name": "get_weather",
-                "args": {"location": "NYC"}
-            }
-        });
-        let result = parse_part(&part).expect("should parse function call");
-        match result {
-            ContentPart::ToolCall(tc) => {
-                assert_eq!(tc.name, "get_weather");
-                assert_eq!(tc.arguments, serde_json::json!({"location": "NYC"}));
-                assert!(tc.provider_metadata.is_none());
-            }
-            other => panic!("expected ToolCall, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn parse_part_function_call_with_thought_signature() {
-        let part = serde_json::json!({
-            "functionCall": {
-                "name": "get_weather",
-                "args": {"location": "NYC"}
-            },
-            "thoughtSignature": "abc123sig"
-        });
-        let result = parse_part(&part).expect("should parse function call with thought signature");
-        match result {
-            ContentPart::ToolCall(tc) => {
-                assert_eq!(tc.name, "get_weather");
-                let meta = tc
-                    .provider_metadata
-                    .expect("provider_metadata should be set");
-                assert_eq!(meta["thoughtSignature"], "abc123sig");
-            }
-            other => panic!("expected ToolCall, got {other:?}"),
-        }
-    }
-
-    #[tokio::test]
-    async fn translate_messages_function_call_includes_thought_signature() {
-        let mut tc = ToolCall::new(
-            "call-1",
-            "get_weather",
-            serde_json::json!({"location": "NYC"}),
-        );
-        tc.provider_metadata = Some(serde_json::json!({"thoughtSignature": "sig456"}));
-
-        let msg = Message {
-            role:         Role::Assistant,
-            content:      vec![ContentPart::ToolCall(tc)],
-            name:         None,
-            tool_call_id: None,
-        };
-        let contents = translate_messages(&[&msg]).await;
-        assert_eq!(contents.len(), 1);
-
-        let part = &contents[0].parts[0];
-        assert!(part.get("functionCall").is_some());
-        assert_eq!(part["thoughtSignature"], "sig456");
-    }
-
-    #[tokio::test]
-    async fn translate_messages_function_call_without_thought_signature() {
-        let tc = ToolCall::new(
-            "call-1",
-            "get_weather",
-            serde_json::json!({"location": "NYC"}),
-        );
-
-        let msg = Message {
-            role:         Role::Assistant,
-            content:      vec![ContentPart::ToolCall(tc)],
-            name:         None,
-            tool_call_id: None,
-        };
-        let contents = translate_messages(&[&msg]).await;
-        assert_eq!(contents.len(), 1);
-
-        let part = &contents[0].parts[0];
-        assert!(part.get("functionCall").is_some());
-        assert!(part.get("thoughtSignature").is_none());
-    }
-
-    #[test]
-    fn parse_part_thought_false_is_regular_text() {
-        let part = serde_json::json!({"text": "Regular text", "thought": false});
-        let result = parse_part(&part).expect("should parse text part");
-        match result {
-            ContentPart::Text(text) => assert_eq!(text, "Regular text"),
-            other => panic!("expected Text, got {other:?}"),
-        }
     }
 }


### PR DESCRIPTION
## Summary

Final dialect extraction in the gateway refactor series (after #481 / #485, sibling of #487 and #488): the Gemini `generateContent` wire translation moves out of `providers/gemini.rs` into `codec/gemini_generate/`, behind the `Codec` / `StreamDecoder` traits. The adapter becomes a thin transport shell (1,607 → ~400 lines) owning auth (`x-goog-api-key`), base URL, and the streaming byte loop; all translation is in the codec.

Two commits, each independently green:
1. **Add the codec** (`wire`/`encode`/`decode`/`stream`/`mod`) — compiling but unused behind a scoped `dead_code` allow.
2. **Rewire the adapter** to it, migrate the ~22 unit tests, and add the previously missing stream-decoder tests.

Gemini is the simplest route story in the series — no provider-name branching, no mode flags, count-tokens always available, no forced streaming — so there is no route config and **no `CodecParams` changes** (this PR is conflict-free with #487/#488 apart from one `mod` line; if it lands after them, the unit-struct `CodecParams` literals become `::default()` on rebase, mechanical).

It does exercise two trait seams the other codecs don't:
- **Fully-formed endpoints from the codec**: model-in-path `:generateContent` / `:streamGenerateContent?alt=sse` / `:countTokens` ride on `EncodedRequest.endpoint` (the count body wraps the request in `generateContentRequest`).
- **The first `decode_error` override**: Gemini's gRPC-status mapping (`error_from_grpc_status` with HTTP-status fallback) moves behind the codec; the adapter feeds it status + body + retry-after. The send-side timeout mapping stays transport-side.

Other moves, wholesale and already pure: synthetic-UUID tool-call/response ids, the id→name recovery map for `functionResponse`, usage arithmetic (cache subtraction + tool-use addition + thoughts→reasoning), default `safety_settings` injection (flagged profile-ish in a comment, unchanged), `thoughtSignature` round-trip, and the `provider_options.gemini` merge. `translate_messages` goes sync: file-backed Image/Audio/Document attachments resolve via the shared `attachments::resolve` (#485) before encode.

The streaming decoder preserves Gemini's distinct stream-end contract exactly: data-only SSE (no event types, no `[DONE]`), and `finish()` synthesizes the `Finish` from accumulated state unconditionally at byte-stream end — there is no terminal wire event.

## Behavior preservation

No behavior change. The 32 gemini wire snapshots from #471 (encode round-trips, attachments, response_format, provider_options merges, streaming happy path / tool deltas / reasoning deltas / the unconditional-Finish stream-end pin) pass unmodified, and the full fabro-llm suite is green at 525: all 22 migrated tests plus 10 new ones — 9 stream-decoder unit tests (gemini previously had **zero**: text/thought deltas, reasoning→text transition, single-chunk function calls, finish-reason handling, Finish synthesis with and without a wire finish reason, ToolCalls inference, malformed-chunk errors) and 1 pinning the three model-in-path endpoints.

## Testing

- `cargo nextest run -p fabro-llm` — 525 passed (126 wire snapshots included)
- `cargo check --workspace`
- `cargo +nightly-2026-04-14 clippy -p fabro-llm --all-targets -- -D warnings`
- `cargo +nightly-2026-04-14 fmt --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)