### PR TITLE
Demote non-interpolating config fields to plain String

### DIFF
--- a/lib/crates/fabro-checkpoint/src/author.rs
+++ b/lib/crates/fabro-checkpoint/src/author.rs
@@ -1,7 +1,6 @@
 use std::fmt::Write;
 
 use fabro_config::GitAuthorLayer;
-use fabro_types::settings::InterpString;
 use fabro_types::settings::run::GitAuthorSettings;
 
 /// Resolved git author identity for checkpoint commits.
@@ -51,30 +50,14 @@ impl GitAuthor {
     }
 }
 
-#[expect(
-    clippy::disallowed_methods,
-    reason = "raw source is today's behavior; run.git.author.* is slated for demotion to plain String in the \
-              interpolation unification (D2)"
-)]
 impl From<&GitAuthorLayer> for GitAuthor {
     fn from(value: &GitAuthorLayer) -> Self {
-        Self::from_options(
-            value.name.as_ref().map(InterpString::as_source),
-            value.email.as_ref().map(InterpString::as_source),
-        )
+        Self::from_options(value.name.clone(), value.email.clone())
     }
 }
 
-#[expect(
-    clippy::disallowed_methods,
-    reason = "raw source is today's behavior; run.git.author.* is slated for demotion to plain String in the \
-              interpolation unification (D2)"
-)]
 impl From<&GitAuthorSettings> for GitAuthor {
     fn from(value: &GitAuthorSettings) -> Self {
-        Self::from_options(
-            value.name.as_ref().map(InterpString::as_source),
-            value.email.as_ref().map(InterpString::as_source),
-        )
+        Self::from_options(value.name.clone(), value.email.clone())
     }
 }

--- a/lib/crates/fabro-cli/src/commands/exec.rs
+++ b/lib/crates/fabro-cli/src/commands/exec.rs
@@ -282,8 +282,8 @@ pub(crate) async fn execute(mut args: ExecArgs, ctx: &CommandContext) -> AnyResu
     let cli = &ctx.user_settings().cli;
     #[cfg(feature = "sleep_inhibitor")]
     let _sleep_guard = sleep_inhibitor::guard(cli.exec.prevent_idle_sleep);
-    let provider_str = cli.exec.model.provider.clone();
-    let model_str = cli.exec.model.name.clone();
+    let provider_str = cli.exec.model.provider.as_deref();
+    let model_str = cli.exec.model.name.as_deref();
     let permissions = cli.exec.agent.permissions.map(|p| match p {
         AgentPermissions::ReadOnly => AgentPermissionLevel::ReadOnly,
         AgentPermissions::ReadWrite => AgentPermissionLevel::ReadWrite,
@@ -293,12 +293,8 @@ pub(crate) async fn execute(mut args: ExecArgs, ctx: &CommandContext) -> AnyResu
         SettingsOutputFormat::Text => OutputFormat::Text,
         SettingsOutputFormat::Json => OutputFormat::Json,
     });
-    args.agent.apply_cli_defaults(
-        provider_str.as_deref(),
-        model_str.as_deref(),
-        permissions,
-        output_format,
-    );
+    args.agent
+        .apply_cli_defaults(provider_str, model_str, permissions, output_format);
     let server_target = user_config::exec_server_target(&args.server)?;
     // v2 MCPs live under `cli.exec.agent.mcps` (owner-specific) or
     // `run.agent.mcps`. For `fabro exec` we use the cli.exec path, falling

--- a/lib/crates/fabro-cli/src/commands/exec.rs
+++ b/lib/crates/fabro-cli/src/commands/exec.rs
@@ -16,7 +16,6 @@ use fabro_llm::types::{
 };
 use fabro_mcp::config::McpServerSettings;
 use fabro_model::ProviderId;
-use fabro_types::settings::InterpString;
 use fabro_types::settings::cli::OutputFormat as SettingsOutputFormat;
 use fabro_util::exit::{self, ErrorExt, ExitClass};
 use futures::stream;
@@ -276,11 +275,6 @@ impl ProviderAdapter for AuthenticatedFabroServerAdapter {
     }
 }
 
-#[expect(
-    clippy::disallowed_methods,
-    reason = "raw source is today's behavior; cli.exec.model.* is slated for demotion to plain String in the \
-              interpolation unification (D2)"
-)]
 pub(crate) async fn execute(mut args: ExecArgs, ctx: &CommandContext) -> AnyResult<()> {
     use fabro_agent::cli::PermissionLevel as AgentPermissionLevel;
     use fabro_types::settings::run::AgentPermissions;
@@ -288,13 +282,8 @@ pub(crate) async fn execute(mut args: ExecArgs, ctx: &CommandContext) -> AnyResu
     let cli = &ctx.user_settings().cli;
     #[cfg(feature = "sleep_inhibitor")]
     let _sleep_guard = sleep_inhibitor::guard(cli.exec.prevent_idle_sleep);
-    let provider_str = cli
-        .exec
-        .model
-        .provider
-        .as_ref()
-        .map(InterpString::as_source);
-    let model_str = cli.exec.model.name.as_ref().map(InterpString::as_source);
+    let provider_str = cli.exec.model.provider.clone();
+    let model_str = cli.exec.model.name.clone();
     let permissions = cli.exec.agent.permissions.map(|p| match p {
         AgentPermissions::ReadOnly => AgentPermissionLevel::ReadOnly,
         AgentPermissions::ReadWrite => AgentPermissionLevel::ReadWrite,

--- a/lib/crates/fabro-cli/src/user_config.rs
+++ b/lib/crates/fabro-cli/src/user_config.rs
@@ -11,7 +11,7 @@ use fabro_config::{
 use fabro_static::EnvVars;
 use fabro_types::settings::cli::CliTargetSettings;
 use fabro_types::settings::server::LogDestination;
-use fabro_types::settings::{CliNamespace, InterpString, RunNamespace};
+use fabro_types::settings::{InterpString, RunNamespace};
 use fabro_types::{ServerSettings, UserSettings};
 use fabro_util::error::SharedError;
 use fabro_util::version::FABRO_VERSION;
@@ -220,21 +220,12 @@ fn value_at_path<'a>(document: &'a toml::Value, path: &[&str]) -> Option<&'a tom
     Some(current)
 }
 
-/// Pull the resolved CLI target configuration out of `[cli.target]`.
-/// Returns either an http(s) URL or a unix socket path.
-fn cli_target_from_settings(settings: &CliNamespace) -> Option<String> {
-    let target = settings.target.as_ref()?;
-    match target {
-        CliTargetSettings::Http { url } => Some(url.clone()),
-        CliTargetSettings::Unix { path } => Some(path.clone()),
-    }
-}
-
 fn configured_server_target(settings: &UserSettings) -> Result<Option<ServerTarget>> {
-    let Some(value) = cli_target_from_settings(&settings.cli) else {
-        return Ok(None);
-    };
-    parse_server_target(&value).map(Some)
+    match settings.cli.target.as_ref() {
+        Some(CliTargetSettings::Http { url }) => ServerTarget::http_url(url).map(Some),
+        Some(CliTargetSettings::Unix { path }) => ServerTarget::unix_socket_path(path).map(Some),
+        None => Ok(None),
+    }
 }
 
 pub(crate) fn default_server_target() -> ServerTarget {

--- a/lib/crates/fabro-cli/src/user_config.rs
+++ b/lib/crates/fabro-cli/src/user_config.rs
@@ -222,17 +222,11 @@ fn value_at_path<'a>(document: &'a toml::Value, path: &[&str]) -> Option<&'a tom
 
 /// Pull the resolved CLI target configuration out of `[cli.target]`.
 /// Returns either an http(s) URL or a unix socket path.
-#[expect(
-    clippy::disallowed_methods,
-    reason = "known leak: cli.target.* is a url/connection field that should resolve {{ env.* }} \
-              tokens but consumes them raw today; strict resolution scheduled in the \
-              interpolation unification (Phase 2 keep-rows)"
-)]
 fn cli_target_from_settings(settings: &CliNamespace) -> Option<String> {
     let target = settings.target.as_ref()?;
     match target {
-        CliTargetSettings::Http { url } => Some(url.as_source()),
-        CliTargetSettings::Unix { path } => Some(path.as_source()),
+        CliTargetSettings::Http { url } => Some(url.clone()),
+        CliTargetSettings::Unix { path } => Some(path.clone()),
     }
 }
 

--- a/lib/crates/fabro-cli/tests/it/cmd/create.rs
+++ b/lib/crates/fabro-cli/tests/it/cmd/create.rs
@@ -411,8 +411,8 @@ fn create_persists_requested_overrides_into_store() {
             "dry_run": resolved_run.execution.mode == fabro_types::settings::run::RunMode::DryRun,
             "auto_approve": resolved_run.execution.approval == fabro_types::settings::run::ApprovalMode::Auto,
             "llm": {
-                "model": resolved_run.model.name.as_ref().map(fabro_types::settings::InterpString::as_source),
-                "provider": resolved_run.model.provider.as_ref().map(fabro_types::settings::InterpString::as_source),
+                "model": resolved_run.model.name.clone(),
+                "provider": resolved_run.model.provider.clone(),
             },
             "environment": {
                 "id": resolved_run.environment.id,

--- a/lib/crates/fabro-config/src/builders.rs
+++ b/lib/crates/fabro-config/src/builders.rs
@@ -651,7 +651,6 @@ fn finish_dense_result<T>(
 mod tests {
     use std::collections::HashMap;
 
-    use fabro_types::settings::InterpString;
     use fabro_types::settings::cli::OutputVerbosity;
     use fabro_types::settings::run::{ApprovalMode, EnvironmentProvider, RunMode};
 
@@ -694,10 +693,6 @@ command = ["demo-mcp"]
         );
     }
 
-    #[expect(
-        clippy::disallowed_methods,
-        reason = "test asserts the raw template source"
-    )]
     #[test]
     fn workflow_builder_preserves_run_overrides_when_cli_overrides_are_added() {
         let settings = WorkflowSettingsBuilder::new()
@@ -705,8 +700,8 @@ command = ["demo-mcp"]
             .run_overrides(RunLayer {
                 metadata: ReplaceMap::from(HashMap::from([("env".to_string(), "cli".to_string())])),
                 model: Some(RunModelLayer {
-                    provider:  Some(InterpString::parse("openai")),
-                    name:      Some(InterpString::parse("gpt-5")),
+                    provider:  Some("openai".to_string()),
+                    name:      Some("gpt-5".to_string()),
                     fallbacks: Vec::new(),
                     controls:  None,
                 }),
@@ -730,24 +725,8 @@ command = ["demo-mcp"]
             settings.run.metadata.get("env").map(String::as_str),
             Some("cli")
         );
-        assert_eq!(
-            settings
-                .run
-                .model
-                .provider
-                .as_ref()
-                .map(InterpString::as_source),
-            Some("openai".to_string())
-        );
-        assert_eq!(
-            settings
-                .run
-                .model
-                .name
-                .as_ref()
-                .map(InterpString::as_source),
-            Some("gpt-5".to_string())
-        );
+        assert_eq!(settings.run.model.provider.as_deref(), Some("openai"));
+        assert_eq!(settings.run.model.name.as_deref(), Some("gpt-5"));
         assert_eq!(settings.run.execution.mode, RunMode::DryRun);
         assert_eq!(settings.run.execution.approval, ApprovalMode::Auto);
     }

--- a/lib/crates/fabro-config/src/layers/cli.rs
+++ b/lib/crates/fabro-config/src/layers/cli.rs
@@ -1,6 +1,5 @@
 //! Sparse `[cli]` settings layer definitions.
 
-use fabro_types::settings::InterpString;
 use fabro_types::settings::cli::{CliAuthStrategy, OutputFormat, OutputVerbosity};
 use fabro_types::settings::run::AgentPermissions;
 use serde::{Deserialize, Serialize};
@@ -32,11 +31,11 @@ pub struct CliLayer {
 pub enum CliTargetLayer {
     Http {
         #[serde(default)]
-        url: Option<InterpString>,
+        url: Option<String>,
     },
     Unix {
         #[serde(default)]
-        path: Option<InterpString>,
+        path: Option<String>,
     },
 }
 

--- a/lib/crates/fabro-config/src/layers/cli.rs
+++ b/lib/crates/fabro-config/src/layers/cli.rs
@@ -87,11 +87,11 @@ pub struct CliExecModelLayer {
     /// LLM provider for `fabro exec`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[option(value_type = "string")]
-    pub provider: Option<InterpString>,
+    pub provider: Option<String>,
     /// Model name for `fabro exec`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[option(value_type = "string")]
-    pub name:     Option<InterpString>,
+    pub name:     Option<String>,
 }
 
 #[derive(

--- a/lib/crates/fabro-config/src/layers/run.rs
+++ b/lib/crates/fabro-config/src/layers/run.rs
@@ -19,7 +19,7 @@ pub struct RunLayer {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub goal:          Option<RunGoalLayer>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub working_dir:   Option<InterpString>,
+    pub working_dir:   Option<String>,
     /// Flat string-to-string map. Replaces wholesale across layers.
     #[serde(default, skip_serializing_if = "ReplaceMap::is_empty")]
     pub metadata:      ReplaceMap<String>,

--- a/lib/crates/fabro-config/src/layers/run.rs
+++ b/lib/crates/fabro-config/src/layers/run.rs
@@ -142,11 +142,11 @@ pub struct RunModelLayer {
     /// Provider name for workflow model selection.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[option(value_type = "string")]
-    pub provider:  Option<InterpString>,
+    pub provider:  Option<String>,
     /// Model name for workflow runs.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[option(value_type = "string")]
-    pub name:      Option<InterpString>,
+    pub name:      Option<String>,
     /// Ordered list of fallback model references. Supports `...` splice marker
     /// at layering time — see [`super::splice_array`].
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -236,11 +236,11 @@ pub struct GitAuthorLayer {
     /// Git author name for checkpoint commits.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[option(default = "\"fabro\"", value_type = "string")]
-    pub name:  Option<InterpString>,
+    pub name:  Option<String>,
     /// Git author email for checkpoint commits.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[option(default = "\"fabro@local\"", value_type = "string")]
-    pub email: Option<InterpString>,
+    pub email: Option<String>,
 }
 
 /// `[run.prepare]` — ordered list of preparation steps. Whole list replaces
@@ -537,9 +537,9 @@ pub struct RunScmLayer {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub provider:   Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub owner:      Option<InterpString>,
+    pub owner:      Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub repository: Option<InterpString>,
+    pub repository: Option<String>,
     /// Provider-specific SCM leaves. First-pass providers.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub github:     Option<ScmGitHubLayer>,

--- a/lib/crates/fabro-config/src/project.rs
+++ b/lib/crates/fabro-config/src/project.rs
@@ -12,7 +12,7 @@
 use std::fmt::Write;
 use std::path::{Path, PathBuf};
 
-use fabro_types::settings::{InterpString, RunNamespace};
+use fabro_types::settings::RunNamespace;
 use serde::Serialize;
 
 use crate::{Error, Result, WorkflowSettingsBuilder, run};
@@ -144,14 +144,8 @@ fn sibling_workflow_toml_for(graph: &Path) -> Option<PathBuf> {
     (toml_graph == graph).then_some(candidate)
 }
 
-#[expect(
-    clippy::disallowed_methods,
-    reason = "known leak: run.working_dir is a path kept as InterpString (not demoted); it should \
-              resolve {{ env.* }}/{{ vars.* }} tokens but consumes them raw today; strict \
-              resolution scheduled in the interpolation unification (Phase 2 keep-rows)"
-)]
 pub fn resolve_working_directory_from_run(run: &RunNamespace, caller_cwd: &Path) -> PathBuf {
-    let Some(work_dir) = run.working_dir.as_ref().map(InterpString::as_source) else {
+    let Some(work_dir) = run.working_dir.as_deref() else {
         return caller_cwd.to_path_buf();
     };
     let path = PathBuf::from(work_dir);
@@ -557,7 +551,7 @@ directory = "../custom"
         let cwd = Path::new("/tmp/workspace");
         let resolved = resolve_working_directory_from_run(
             &RunNamespace {
-                working_dir: Some(InterpString::parse("repo")),
+                working_dir: Some("repo".to_string()),
                 ..RunNamespace::default()
             },
             cwd,

--- a/lib/crates/fabro-config/src/resolve/cli.rs
+++ b/lib/crates/fabro-config/src/resolve/cli.rs
@@ -47,13 +47,13 @@ fn resolve_target(
 ) -> Option<CliTargetSettings> {
     match target {
         Some(CliTargetLayer::Http { url }) => {
-            super::warn_if_demoted_template("cli.target.http.url", url.as_deref());
+            super::warn_if_demoted_template("cli.target.url", url.as_deref());
             Some(CliTargetSettings::Http {
                 url: require_string(url.as_ref(), "cli.target.url", errors),
             })
         }
         Some(CliTargetLayer::Unix { path }) => {
-            super::warn_if_demoted_template("cli.target.unix.path", path.as_deref());
+            super::warn_if_demoted_template("cli.target.path", path.as_deref());
             Some(CliTargetSettings::Unix {
                 path: require_string(path.as_ref(), "cli.target.path", errors),
             })
@@ -80,8 +80,8 @@ fn resolve_exec(exec: Option<&CliExecLayer>) -> CliExecSettings {
             .prevent_idle_sleep
             .expect("defaults.toml should provide cli.exec.prevent_idle_sleep"),
         model:              CliExecModelSettings {
-            provider: exec.model.as_ref().and_then(|model| model.provider.clone()),
-            name:     exec.model.as_ref().and_then(|model| model.name.clone()),
+            provider: model.and_then(|model| model.provider.clone()),
+            name:     model.and_then(|model| model.name.clone()),
         },
         agent:              CliExecAgentSettings {
             permissions: exec.agent.as_ref().and_then(|agent| agent.permissions),

--- a/lib/crates/fabro-config/src/resolve/cli.rs
+++ b/lib/crates/fabro-config/src/resolve/cli.rs
@@ -59,6 +59,16 @@ fn resolve_target(
 fn resolve_exec(exec: Option<&CliExecLayer>) -> CliExecSettings {
     let exec = exec.expect("defaults.toml should provide cli.exec defaults");
 
+    let model = exec.model.as_ref();
+    super::warn_if_demoted_template(
+        "cli.exec.model.provider",
+        model.and_then(|model| model.provider.as_deref()),
+    );
+    super::warn_if_demoted_template(
+        "cli.exec.model.name",
+        model.and_then(|model| model.name.as_deref()),
+    );
+
     CliExecSettings {
         prevent_idle_sleep: exec
             .prevent_idle_sleep

--- a/lib/crates/fabro-config/src/resolve/cli.rs
+++ b/lib/crates/fabro-config/src/resolve/cli.rs
@@ -3,7 +3,7 @@ use fabro_types::settings::cli::{
     CliLoggingSettings, CliNamespace, CliOutputSettings, CliTargetSettings, CliUpdatesSettings,
 };
 
-use super::{ResolveError, require_interp};
+use super::{ResolveError, require_string};
 use crate::{CliExecLayer, CliLayer, CliTargetLayer};
 
 pub fn resolve_cli(layer: &CliLayer, errors: &mut Vec<ResolveError>) -> CliNamespace {
@@ -46,12 +46,18 @@ fn resolve_target(
     errors: &mut Vec<ResolveError>,
 ) -> Option<CliTargetSettings> {
     match target {
-        Some(CliTargetLayer::Http { url }) => Some(CliTargetSettings::Http {
-            url: require_interp(url.as_ref(), "cli.target.url", errors),
-        }),
-        Some(CliTargetLayer::Unix { path }) => Some(CliTargetSettings::Unix {
-            path: require_interp(path.as_ref(), "cli.target.path", errors),
-        }),
+        Some(CliTargetLayer::Http { url }) => {
+            super::warn_if_demoted_template("cli.target.http.url", url.as_deref());
+            Some(CliTargetSettings::Http {
+                url: require_string(url.as_ref(), "cli.target.url", errors),
+            })
+        }
+        Some(CliTargetLayer::Unix { path }) => {
+            super::warn_if_demoted_template("cli.target.unix.path", path.as_deref());
+            Some(CliTargetSettings::Unix {
+                path: require_string(path.as_ref(), "cli.target.path", errors),
+            })
+        }
         None => None,
     }
 }

--- a/lib/crates/fabro-config/src/resolve/mod.rs
+++ b/lib/crates/fabro-config/src/resolve/mod.rs
@@ -21,12 +21,7 @@ pub(crate) fn require_interp(
     path: &str,
     errors: &mut Vec<ResolveError>,
 ) -> InterpString {
-    value.cloned().unwrap_or_else(|| {
-        errors.push(ResolveError::Missing {
-            path: path.to_string(),
-        });
-        InterpString::parse("")
-    })
+    require_value(value, path, errors, || InterpString::parse(""))
 }
 
 pub(crate) fn require_string(
@@ -34,11 +29,20 @@ pub(crate) fn require_string(
     path: &str,
     errors: &mut Vec<ResolveError>,
 ) -> String {
+    require_value(value, path, errors, String::new)
+}
+
+fn require_value<T: Clone>(
+    value: Option<&T>,
+    path: &str,
+    errors: &mut Vec<ResolveError>,
+    missing: impl FnOnce() -> T,
+) -> T {
     value.cloned().unwrap_or_else(|| {
         errors.push(ResolveError::Missing {
             path: path.to_string(),
         });
-        String::new()
+        missing()
     })
 }
 
@@ -77,13 +81,20 @@ pub(crate) fn default_interp(path: impl AsRef<std::path::Path>) -> InterpString 
 /// String pass itself is retired in a later slice. Unclaimed `{{ ... }}` text
 /// (jq programs, Go templates) never interpolated and does not warn.
 pub(crate) fn warn_if_demoted_template(field: &str, value: Option<&str>) {
-    if value.is_some_and(|value| !InterpString::parse(value).is_literal()) {
-        tracing::warn!(
-            field = %field,
-            "this field no longer interpolates template tokens and uses the value literally; it \
-             was demoted to a plain string in the interpolation unification"
-        );
+    let Some(value) = value else {
+        return;
+    };
+    if !tracing::enabled!(tracing::Level::WARN) || !value.contains("{{") {
+        return;
     }
+    if InterpString::parse(value).is_literal() {
+        return;
+    }
+    tracing::warn!(
+        field = %field,
+        "this field no longer interpolates template tokens and uses the value literally; it \
+         was demoted to a plain string in the interpolation unification"
+    );
 }
 
 #[cfg(test)]

--- a/lib/crates/fabro-config/src/resolve/mod.rs
+++ b/lib/crates/fabro-config/src/resolve/mod.rs
@@ -56,6 +56,22 @@ pub(crate) fn default_interp(path: impl AsRef<std::path::Path>) -> InterpString 
     InterpString::parse(&path.as_ref().to_string_lossy())
 }
 
+/// Warn when a field demoted out of the interpolation set (D2) still contains
+/// claimed template tokens. These fields are plain `String` now — `{{ vars.*
+/// }}` (which previously substituted via the run-scoped String pass, a
+/// now-removed accident) and `{{ env.* }}` are both treated as literal text.
+/// Only `InterpString` fields interpolate. Unclaimed `{{ ... }}` text (jq
+/// programs, Go templates) never interpolated and does not warn.
+pub(crate) fn warn_if_demoted_template(field: &str, value: Option<&str>) {
+    if value.is_some_and(|value| !InterpString::parse(value).is_literal()) {
+        tracing::warn!(
+            field = %field,
+            "this field no longer interpolates template tokens and uses the value literally; it \
+             was demoted to a plain string in the interpolation unification"
+        );
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;

--- a/lib/crates/fabro-config/src/resolve/mod.rs
+++ b/lib/crates/fabro-config/src/resolve/mod.rs
@@ -29,6 +29,19 @@ pub(crate) fn require_interp(
     })
 }
 
+pub(crate) fn require_string(
+    value: Option<&String>,
+    path: &str,
+    errors: &mut Vec<ResolveError>,
+) -> String {
+    value.cloned().unwrap_or_else(|| {
+        errors.push(ResolveError::Missing {
+            path: path.to_string(),
+        });
+        String::new()
+    })
+}
+
 #[expect(
     clippy::disallowed_methods,
     reason = "parsed_value special case: the TCP listen address parses the literal source \

--- a/lib/crates/fabro-config/src/resolve/mod.rs
+++ b/lib/crates/fabro-config/src/resolve/mod.rs
@@ -60,8 +60,9 @@ pub(crate) fn default_interp(path: impl AsRef<std::path::Path>) -> InterpString 
 /// claimed template tokens. These fields are plain `String` now — `{{ vars.*
 /// }}` (which previously substituted via the run-scoped String pass, a
 /// now-removed accident) and `{{ env.* }}` are both treated as literal text.
-/// Only `InterpString` fields interpolate. Unclaimed `{{ ... }}` text (jq
-/// programs, Go templates) never interpolated and does not warn.
+/// Other plain-`String` fields still substitute `{{ vars.* }}` until the
+/// String pass itself is retired in a later slice. Unclaimed `{{ ... }}` text
+/// (jq programs, Go templates) never interpolated and does not warn.
 pub(crate) fn warn_if_demoted_template(field: &str, value: Option<&str>) {
     if value.is_some_and(|value| !InterpString::parse(value).is_literal()) {
         tracing::warn!(

--- a/lib/crates/fabro-config/src/resolve/run.rs
+++ b/lib/crates/fabro-config/src/resolve/run.rs
@@ -108,6 +108,9 @@ fn resolve_model(model: Option<&RunModelLayer>) -> RunModelSettings {
         return RunModelSettings::default();
     };
 
+    super::warn_if_demoted_template("run.model.provider", model.provider.as_deref());
+    super::warn_if_demoted_template("run.model.name", model.name.as_deref());
+
     RunModelSettings {
         provider:  model.provider.clone(),
         name:      model.name.clone(),
@@ -133,9 +136,13 @@ fn resolve_model(model: Option<&RunModelLayer>) -> RunModelSettings {
 fn resolve_git(git: Option<&RunGitLayer>) -> RunGitSettings {
     RunGitSettings {
         author: git.and_then(|git| {
-            git.author.as_ref().map(|author| GitAuthorSettings {
-                name:  author.name.clone(),
-                email: author.email.clone(),
+            git.author.as_ref().map(|author| {
+                super::warn_if_demoted_template("run.git.author.name", author.name.as_deref());
+                super::warn_if_demoted_template("run.git.author.email", author.email.as_deref());
+                GitAuthorSettings {
+                    name:  author.name.clone(),
+                    email: author.email.clone(),
+                }
             })
         }),
     }
@@ -491,6 +498,9 @@ fn resolve_scm(scm: Option<&RunScmLayer>) -> RunScmSettings {
     let Some(scm) = scm else {
         return RunScmSettings::default();
     };
+
+    super::warn_if_demoted_template("run.scm.owner", scm.owner.as_deref());
+    super::warn_if_demoted_template("run.scm.repository", scm.repository.as_deref());
 
     RunScmSettings {
         provider:   scm.provider.clone(),

--- a/lib/crates/fabro-config/src/resolve/run.rs
+++ b/lib/crates/fabro-config/src/resolve/run.rs
@@ -134,16 +134,15 @@ fn resolve_model(model: Option<&RunModelLayer>) -> RunModelSettings {
 }
 
 fn resolve_git(git: Option<&RunGitLayer>) -> RunGitSettings {
+    let author = git.and_then(|git| git.author.as_ref());
+    if let Some(author) = author {
+        super::warn_if_demoted_template("run.git.author.name", author.name.as_deref());
+        super::warn_if_demoted_template("run.git.author.email", author.email.as_deref());
+    }
     RunGitSettings {
-        author: git.and_then(|git| {
-            git.author.as_ref().map(|author| {
-                super::warn_if_demoted_template("run.git.author.name", author.name.as_deref());
-                super::warn_if_demoted_template("run.git.author.email", author.email.as_deref());
-                GitAuthorSettings {
-                    name:  author.name.clone(),
-                    email: author.email.clone(),
-                }
-            })
+        author: author.map(|author| GitAuthorSettings {
+            name:  author.name.clone(),
+            email: author.email.clone(),
         }),
     }
 }

--- a/lib/crates/fabro-config/src/resolve/run.rs
+++ b/lib/crates/fabro-config/src/resolve/run.rs
@@ -49,6 +49,8 @@ pub fn resolve_run(
         });
     }
 
+    super::warn_if_demoted_template("run.working_dir", layer.working_dir.as_deref());
+
     RunNamespace {
         goal: resolve_goal(layer.goal.as_ref()),
         working_dir: layer.working_dir.clone(),

--- a/lib/crates/fabro-config/src/tests/resolve_cli.rs
+++ b/lib/crates/fabro-config/src/tests/resolve_cli.rs
@@ -128,18 +128,8 @@ level = "debug"
     assert_eq!(url.as_source(), "https://config.example.com");
 
     assert!(cli.exec.prevent_idle_sleep);
-    assert_eq!(
-        cli.exec
-            .model
-            .provider
-            .as_ref()
-            .map(InterpString::as_source),
-        Some("openai".to_string())
-    );
-    assert_eq!(
-        cli.exec.model.name.as_ref().map(InterpString::as_source),
-        Some("gpt-5".to_string())
-    );
+    assert_eq!(cli.exec.model.provider.as_deref(), Some("openai"));
+    assert_eq!(cli.exec.model.name.as_deref(), Some("gpt-5"));
     assert_eq!(cli.exec.agent.permissions, Some(AgentPermissions::ReadOnly));
     assert_eq!(cli.exec.agent.mcps["fs"].name, "fs");
     assert_eq!(cli.output.format, OutputFormat::Json);

--- a/lib/crates/fabro-config/src/tests/resolve_cli.rs
+++ b/lib/crates/fabro-config/src/tests/resolve_cli.rs
@@ -3,7 +3,6 @@
     reason = "sync test fixture setup; not on a Tokio path"
 )]
 
-use fabro_types::settings::InterpString;
 use fabro_types::settings::cli::{CliTargetSettings, OutputFormat, OutputVerbosity};
 use fabro_types::settings::run::AgentPermissions;
 use temp_env::with_var;
@@ -42,7 +41,7 @@ url = "https://config.example.com"
     assert_eq!(
         user_settings.cli.target,
         Some(CliTargetSettings::Http {
-            url: InterpString::parse("https://config.example.com"),
+            url: "https://config.example.com".to_string(),
         })
     );
 }
@@ -80,10 +79,6 @@ fn user_settings_resolve_returns_defaults_when_default_settings_file_is_missing(
     });
 }
 
-#[expect(
-    clippy::disallowed_methods,
-    reason = "test asserts the raw template source"
-)]
 #[test]
 fn resolves_cli_target_exec_and_output_settings() {
     let cli = UserSettingsBuilder::from_toml(
@@ -125,7 +120,7 @@ level = "debug"
     let CliTargetSettings::Http { url } = cli.target.expect("target") else {
         panic!("expected http target");
     };
-    assert_eq!(url.as_source(), "https://config.example.com");
+    assert_eq!(url, "https://config.example.com");
 
     assert!(cli.exec.prevent_idle_sleep);
     assert_eq!(cli.exec.model.provider.as_deref(), Some("openai"));

--- a/lib/crates/fabro-config/src/tests/resolve_root.rs
+++ b/lib/crates/fabro-config/src/tests/resolve_root.rs
@@ -1,4 +1,3 @@
-use fabro_types::settings::InterpString;
 use fabro_types::settings::run::RunMode;
 
 use crate::{ServerSettingsBuilder, SettingsLayer};
@@ -118,23 +117,10 @@ name = "gpt-5"
     assert_eq!(workflow_settings.workflow.graph, "graphs/workflow.dot");
     assert_eq!(server.server.storage.root.as_source(), "/srv/fabro");
     assert_eq!(
-        workflow_settings
-            .run
-            .model
-            .provider
-            .as_ref()
-            .map(InterpString::as_source),
-        Some("openai".to_string())
+        workflow_settings.run.model.provider.as_deref(),
+        Some("openai")
     );
-    assert_eq!(
-        workflow_settings
-            .run
-            .model
-            .name
-            .as_ref()
-            .map(InterpString::as_source),
-        Some("gpt-5".to_string())
-    );
+    assert_eq!(workflow_settings.run.model.name.as_deref(), Some("gpt-5"));
 }
 
 #[test]

--- a/lib/crates/fabro-config/src/tests/resolve_run.rs
+++ b/lib/crates/fabro-config/src/tests/resolve_run.rs
@@ -590,11 +590,8 @@ name = "sonnet"
         settings.working_dir,
         Some(InterpString::parse("{{ env.FABRO_WORKDIR }}"))
     );
-    assert_eq!(
-        settings.model.provider,
-        Some(InterpString::parse("anthropic"))
-    );
-    assert_eq!(settings.model.name, Some(InterpString::parse("sonnet")));
+    assert_eq!(settings.model.provider, Some("anthropic".to_string()));
+    assert_eq!(settings.model.name, Some("sonnet".to_string()));
 }
 
 mod run_integrations_github_permissions {

--- a/lib/crates/fabro-config/src/tests/resolve_run.rs
+++ b/lib/crates/fabro-config/src/tests/resolve_run.rs
@@ -586,9 +586,10 @@ name = "sonnet"
         }
         other => panic!("expected file goal, got {other:?}"),
     }
+    // run.working_dir is demoted (D11): the env token stays literal text.
     assert_eq!(
-        settings.working_dir,
-        Some(InterpString::parse("{{ env.FABRO_WORKDIR }}"))
+        settings.working_dir.as_deref(),
+        Some("{{ env.FABRO_WORKDIR }}")
     );
     assert_eq!(settings.model.provider, Some("anthropic".to_string()));
     assert_eq!(settings.model.name, Some("sonnet".to_string()));

--- a/lib/crates/fabro-manifest/src/lib.rs
+++ b/lib/crates/fabro-manifest/src/lib.rs
@@ -74,8 +74,8 @@ pub fn build_run_overrides(input: RunOverrideInput<'_>) -> RunLayer {
         .goal
         .map(|goal| RunGoalLayer::Inline(InterpString::parse(goal)));
     let model = (input.model.is_some() || input.provider.is_some()).then(|| RunModelLayer {
-        provider:  input.provider.map(InterpString::parse),
-        name:      input.model.map(InterpString::parse),
+        provider:  input.provider.map(String::from),
+        name:      input.model.map(String::from),
         fallbacks: Vec::new(),
         controls:  None,
     });
@@ -769,11 +769,6 @@ fn build_git_context(
     })
 }
 
-#[expect(
-    clippy::disallowed_methods,
-    reason = "raw source is today's behavior; run.scm.owner/repository are slated for demotion to plain String in the \
-              interpolation unification (D2)"
-)]
 fn configured_repo_origin_url(settings: &WorkflowSettings) -> Option<String> {
     let scm = &settings.run.scm;
     if !scm
@@ -783,8 +778,8 @@ fn configured_repo_origin_url(settings: &WorkflowSettings) -> Option<String> {
     {
         return None;
     }
-    let owner = scm.owner.as_ref()?.as_source();
-    let repository = scm.repository.as_ref()?.as_source();
+    let owner = scm.owner.clone()?;
+    let repository = scm.repository.clone()?;
     if owner.trim().is_empty() || repository.trim().is_empty() {
         return None;
     }
@@ -902,10 +897,6 @@ mod tests {
         )]))
     }
 
-    #[expect(
-        clippy::disallowed_methods,
-        reason = "test asserts the raw template source"
-    )]
     #[test]
     fn build_run_overrides_sets_common_cli_and_mcp_layers() {
         let overrides = build_run_overrides(RunOverrideInput {
@@ -932,7 +923,7 @@ mod tests {
                 .name
                 .as_ref()
                 .unwrap()
-                .as_source(),
+                .as_str(),
             "gpt-5.4-mini"
         );
         assert_eq!(
@@ -943,7 +934,7 @@ mod tests {
                 .provider
                 .as_ref()
                 .unwrap()
-                .as_source(),
+                .as_str(),
             "openai"
         );
         assert_eq!(

--- a/lib/crates/fabro-manifest/src/lib.rs
+++ b/lib/crates/fabro-manifest/src/lib.rs
@@ -778,8 +778,8 @@ fn configured_repo_origin_url(settings: &WorkflowSettings) -> Option<String> {
     {
         return None;
     }
-    let owner = scm.owner.clone()?;
-    let repository = scm.repository.clone()?;
+    let owner = scm.owner.as_deref()?;
+    let repository = scm.repository.as_deref()?;
     if owner.trim().is_empty() || repository.trim().is_empty() {
         return None;
     }

--- a/lib/crates/fabro-server/src/demo/mod.rs
+++ b/lib/crates/fabro-server/src/demo/mod.rs
@@ -1785,7 +1785,7 @@ mod runs {
                 goal: Some(RunGoal::Inline(InterpString::parse(
                     "Add rate limiting to auth endpoints",
                 ))),
-                working_dir: Some(InterpString::parse("/workspace/api-server")),
+                working_dir: Some("/workspace/api-server".to_string()),
                 model: RunModelSettings {
                     provider: Some("anthropic".to_string()),
                     name: Some("claude-opus-4-6".to_string()),

--- a/lib/crates/fabro-server/src/demo/mod.rs
+++ b/lib/crates/fabro-server/src/demo/mod.rs
@@ -1787,8 +1787,8 @@ mod runs {
                 ))),
                 working_dir: Some(InterpString::parse("/workspace/api-server")),
                 model: RunModelSettings {
-                    provider: Some(InterpString::parse("anthropic")),
-                    name: Some(InterpString::parse("claude-opus-4-6")),
+                    provider: Some("anthropic".to_string()),
+                    name: Some("claude-opus-4-6".to_string()),
                     ..RunModelSettings::default()
                 },
                 prepare: RunPrepareSettings {

--- a/lib/crates/fabro-server/src/run_manifest.rs
+++ b/lib/crates/fabro-server/src/run_manifest.rs
@@ -527,7 +527,6 @@ async fn build_preflight_report(
         &mut checks,
         graph,
         &resolved_run,
-        &configured_providers,
         catalog.as_ref(),
         llm_result,
     )
@@ -987,12 +986,16 @@ async fn run_llm_check(
     checks: &mut Vec<CheckResult>,
     graph: &Graph,
     settings: &RunNamespace,
-    configured_providers: &[ProviderId],
     catalog: &Catalog,
     llm_result: Result<LlmClientResult>,
 ) -> bool {
-    let (model, provider) = resolve_model_provider(settings, graph, configured_providers, catalog);
-    let default_provider = provider.as_deref().unwrap_or("anthropic");
+    let model = settings
+        .model
+        .name
+        .as_deref()
+        .unwrap_or_else(|| catalog.default_for_configured_ids(&[]).id.as_str());
+    let provider = settings.model.provider.as_deref();
+    let default_provider = provider.unwrap_or("anthropic");
     let mut model_providers = std::collections::BTreeSet::new();
     let mut has_llm_nodes = false;
 
@@ -1001,7 +1004,7 @@ async fn run_llm_check(
             continue;
         }
         has_llm_nodes = true;
-        let node_model = node.model().unwrap_or(&model);
+        let node_model = node.model().unwrap_or(model);
         let node_provider = node.provider().unwrap_or(default_provider);
         let (resolved_model, resolved_provider) = if let Some(info) = catalog.get(node_model) {
             (info.id.clone(), info.provider.to_string())
@@ -1140,29 +1143,6 @@ fn canonical_provider_id(catalog: &Catalog, provider_name: &str) -> ProviderId {
     catalog
         .provider(&provider_id)
         .map_or(provider_id, |provider| provider.id.clone())
-}
-
-fn resolve_model_provider(
-    settings: &RunNamespace,
-    _graph: &Graph,
-    configured_providers: &[ProviderId],
-    catalog: &Catalog,
-) -> (String, Option<String>) {
-    let provider = settings.model.provider.clone();
-    let model = settings.model.name.clone().unwrap_or_else(|| {
-        catalog
-            .default_for_configured_ids(configured_providers)
-            .id
-            .clone()
-    });
-
-    match catalog.get(&model) {
-        Some(info) => (
-            info.id.clone(),
-            provider.or(Some(info.provider.to_string())),
-        ),
-        None => (model, provider),
-    }
 }
 
 async fn run_github_token_check(

--- a/lib/crates/fabro-server/src/run_manifest.rs
+++ b/lib/crates/fabro-server/src/run_manifest.rs
@@ -1142,31 +1142,19 @@ fn canonical_provider_id(catalog: &Catalog, provider_name: &str) -> ProviderId {
         .map_or(provider_id, |provider| provider.id.clone())
 }
 
-#[expect(
-    clippy::disallowed_methods,
-    reason = "raw source is today's behavior; run.model.name/provider are slated for demotion to plain String in the \
-              interpolation unification (D2)"
-)]
 fn resolve_model_provider(
     settings: &RunNamespace,
     _graph: &Graph,
     configured_providers: &[ProviderId],
     catalog: &Catalog,
 ) -> (String, Option<String>) {
-    let provider = settings
-        .model
-        .provider
-        .as_ref()
-        .map(InterpString::as_source);
-    let model = settings.model.name.as_ref().map_or_else(
-        || {
-            catalog
-                .default_for_configured_ids(configured_providers)
-                .id
-                .clone()
-        },
-        InterpString::as_source,
-    );
+    let provider = settings.model.provider.clone();
+    let model = settings.model.name.clone().unwrap_or_else(|| {
+        catalog
+            .default_for_configured_ids(configured_providers)
+            .id
+            .clone()
+    });
 
     match catalog.get(&model) {
         Some(info) => (

--- a/lib/crates/fabro-server/src/serve.rs
+++ b/lib/crates/fabro-server/src/serve.rs
@@ -222,7 +222,6 @@ pub struct ServeArgs {
 }
 
 fn serve_overrides(args: &ServeArgs) -> (Option<RunLayer>, Option<ServerLayer>) {
-    use fabro_types::settings::interp::InterpString;
     let mut run = RunLayer::default();
     let mut server = ServerLayer::default();
     if args.web || args.no_web {
@@ -231,11 +230,11 @@ fn serve_overrides(args: &ServeArgs) -> (Option<RunLayer>, Option<ServerLayer>) 
     }
     if let Some(ref model) = args.model {
         let model_layer = run.model.get_or_insert_with(RunModelLayer::default);
-        model_layer.name = Some(InterpString::parse(model));
+        model_layer.name = Some(model.clone());
     }
     if let Some(ref provider) = args.provider {
         let model_layer = run.model.get_or_insert_with(RunModelLayer::default);
-        model_layer.provider = Some(InterpString::parse(provider));
+        model_layer.provider = Some(provider.clone());
     }
     if let Some(environment) = args.environment.as_ref() {
         let environment_layer = run

--- a/lib/crates/fabro-server/src/server/tests.rs
+++ b/lib/crates/fabro-server/src/server/tests.rs
@@ -13534,12 +13534,7 @@ level = "debug"
         "run execution mode should inherit from server settings"
     );
     assert_eq!(
-        resolved_run
-            .model
-            .name
-            .as_ref()
-            .map(fabro_types::settings::InterpString::as_source)
-            .as_deref(),
+        resolved_run.model.name.as_deref(),
         Some("claude-sonnet-4-5"),
     );
 

--- a/lib/crates/fabro-types/src/settings/cli.rs
+++ b/lib/crates/fabro-types/src/settings/cli.rs
@@ -44,8 +44,8 @@ pub struct CliExecSettings {
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct CliExecModelSettings {
-    pub provider: Option<InterpString>,
-    pub name:     Option<InterpString>,
+    pub provider: Option<String>,
+    pub name:     Option<String>,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]

--- a/lib/crates/fabro-types/src/settings/cli.rs
+++ b/lib/crates/fabro-types/src/settings/cli.rs
@@ -9,7 +9,6 @@ use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
 
-use super::interp::InterpString;
 use super::run::{AgentPermissions, McpServerSettings};
 
 /// A structurally resolved `[cli]` view for consumers.
@@ -26,8 +25,8 @@ pub struct CliNamespace {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "lowercase")]
 pub enum CliTargetSettings {
-    Http { url: InterpString },
-    Unix { path: InterpString },
+    Http { url: String },
+    Unix { path: String },
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]

--- a/lib/crates/fabro-types/src/settings/interp.rs
+++ b/lib/crates/fabro-types/src/settings/interp.rs
@@ -15,6 +15,7 @@
 //! the value, via [`InterpString::resolve_with`]. Provenance tracking lets
 //! outward-facing renderers redact env- and secret-sourced values uniformly.
 
+use std::borrow::Cow;
 use std::fmt;
 
 use serde::de::{self, Visitor};
@@ -391,16 +392,26 @@ impl InterpString {
     where
         F: FnMut(&str) -> Option<String>,
     {
+        Self::substitute_variables_in_str_cow(value, lookup).map(Cow::into_owned)
+    }
+
+    pub(crate) fn substitute_variables_in_str_cow<F>(
+        value: &str,
+        lookup: F,
+    ) -> Result<Cow<'_, str>, ResolveError>
+    where
+        F: FnMut(&str) -> Option<String>,
+    {
         let parsed = Self::parse(value);
         if !parsed.references(Namespace::Vars) {
-            return Ok(value.to_owned());
+            return Ok(Cow::Borrowed(value));
         }
         #[expect(
             clippy::disallowed_methods,
             reason = "canonical raw-source round-trip for String-typed settings fields whose \
                       remaining tokens resolve downstream"
         )]
-        Ok(parsed.substitute_variables(lookup)?.as_source())
+        Ok(Cow::Owned(parsed.substitute_variables(lookup)?.as_source()))
     }
 }
 

--- a/lib/crates/fabro-types/src/settings/run.rs
+++ b/lib/crates/fabro-types/src/settings/run.rs
@@ -84,14 +84,11 @@ impl RunNamespace {
         substitute_goal(&mut self.goal, &mut lookup)?;
         substitute_option(&mut self.working_dir, &mut lookup)?;
         substitute_string_map(&mut self.metadata, &mut lookup)?;
-        substitute_option(&mut self.model.provider, &mut lookup)?;
-        substitute_option(&mut self.model.name, &mut lookup)?;
+        // run.model.provider/name and run.git.author.* are plain `String`,
+        // demoted out of the interpolation set (D2): NO variable substitution.
+        // Only InterpString fields access variables — these don't anymore.
         substitute_option_string(&mut self.model.controls.reasoning_effort, &mut lookup)?;
         substitute_option_string(&mut self.model.controls.speed, &mut lookup)?;
-        if let Some(author) = &mut self.git.author {
-            substitute_option(&mut author.name, &mut lookup)?;
-            substitute_option(&mut author.email, &mut lookup)?;
-        }
         substitute_string_vec(&mut self.checkpoint.exclude_globs, &mut lookup)?;
         substitute_environment(&mut self.environment, &mut lookup)?;
         substitute_map(&mut self.environment.env, &mut lookup)?;
@@ -107,8 +104,8 @@ impl RunNamespace {
             substitute_option(&mut slack.channel, &mut lookup)?;
         }
         substitute_map(&mut self.integrations.github.permissions, &mut lookup)?;
-        substitute_option(&mut self.scm.owner, &mut lookup)?;
-        substitute_option(&mut self.scm.repository, &mut lookup)?;
+        // run.scm.owner/repository are plain `String` (demoted, D2): no
+        // variable substitution.
         substitute_string_vec(&mut self.prepare.commands, &mut lookup)?;
         for mcp in self.agent.mcps.values_mut() {
             substitute_string(&mut mcp.name, &mut lookup)?;
@@ -182,9 +179,7 @@ where
     if !may_reference_variable(value) {
         return Ok(());
     }
-    if InterpString::parse(value).references(Namespace::Vars) {
-        *value = InterpString::substitute_variables_in_str(value, lookup)?;
-    }
+    *value = InterpString::substitute_variables_in_str(value, lookup)?;
     Ok(())
 }
 
@@ -413,6 +408,47 @@ mod run_namespace_variable_substitution_tests {
     }
 
     #[test]
+    fn demoted_fields_do_not_interpolate() {
+        // run.model.*, run.git.author.*, run.scm.owner/repository were demoted
+        // out of the interpolation set (D2) to plain `String`. They no longer
+        // access variables at all: `{{ vars.* }}` and `{{ env.* }}` are both
+        // left literal even when a value is available. Only InterpString fields
+        // interpolate — the old run-scoped String `vars` substitution on these
+        // fields was an incidental behavior that is now removed.
+        let mut run = RunNamespace {
+            model: super::RunModelSettings {
+                provider: Some("{{ vars.PROVIDER }}".to_string()),
+                name: Some("{{ vars.MODEL }}".to_string()),
+                ..super::RunModelSettings::default()
+            },
+            git: super::RunGitSettings {
+                author: Some(super::GitAuthorSettings {
+                    name:  Some("{{ vars.AUTHOR }}".to_string()),
+                    email: Some("{{ env.EMAIL }}".to_string()),
+                }),
+            },
+            scm: super::RunScmSettings {
+                owner: Some("{{ vars.OWNER }}".to_string()),
+                repository: Some("{{ env.REPO }}".to_string()),
+                ..super::RunScmSettings::default()
+            },
+            ..RunNamespace::default()
+        };
+
+        // Even with every variable available, demoted fields stay literal.
+        run.substitute_variables(|_| Some("SUBSTITUTED".to_string()))
+            .unwrap();
+
+        assert_eq!(run.model.provider.as_deref(), Some("{{ vars.PROVIDER }}"));
+        assert_eq!(run.model.name.as_deref(), Some("{{ vars.MODEL }}"));
+        let author = run.git.author.as_ref().unwrap();
+        assert_eq!(author.name.as_deref(), Some("{{ vars.AUTHOR }}"));
+        assert_eq!(author.email.as_deref(), Some("{{ env.EMAIL }}"));
+        assert_eq!(run.scm.owner.as_deref(), Some("{{ vars.OWNER }}"));
+        assert_eq!(run.scm.repository.as_deref(), Some("{{ env.REPO }}"));
+    }
+
+    #[test]
     fn substitutes_variables_in_string_backed_settings_families() {
         let mut run = RunNamespace {
             checkpoint: RunCheckpointSettings {
@@ -576,8 +612,8 @@ pub enum RunGoal {
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct RunModelSettings {
-    pub provider:  Option<InterpString>,
-    pub name:      Option<InterpString>,
+    pub provider:  Option<String>,
+    pub name:      Option<String>,
     pub fallbacks: Vec<ModelRef>,
     /// Run-level default values for typed model controls
     /// (`reasoning_effort`, `speed`). Node and style attributes still win
@@ -599,8 +635,8 @@ pub struct RunGitSettings {
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct GitAuthorSettings {
-    pub name:  Option<InterpString>,
-    pub email: Option<InterpString>,
+    pub name:  Option<String>,
+    pub email: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -1214,8 +1250,8 @@ impl HookDefinition {
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct RunScmSettings {
     pub provider:   Option<String>,
-    pub owner:      Option<InterpString>,
-    pub repository: Option<InterpString>,
+    pub owner:      Option<String>,
+    pub repository: Option<String>,
     pub github:     Option<ScmGitHubSettings>,
 }
 

--- a/lib/crates/fabro-types/src/settings/run.rs
+++ b/lib/crates/fabro-types/src/settings/run.rs
@@ -178,7 +178,11 @@ where
     if !may_reference_variable(value) {
         return Ok(());
     }
-    *value = InterpString::substitute_variables_in_str(value, lookup)?;
+    if let std::borrow::Cow::Owned(substituted) =
+        InterpString::substitute_variables_in_str_cow(value, lookup)?
+    {
+        *value = substituted;
+    }
     Ok(())
 }
 

--- a/lib/crates/fabro-types/src/settings/run.rs
+++ b/lib/crates/fabro-types/src/settings/run.rs
@@ -84,9 +84,8 @@ impl RunNamespace {
         substitute_goal(&mut self.goal, &mut lookup)?;
         substitute_option(&mut self.working_dir, &mut lookup)?;
         substitute_string_map(&mut self.metadata, &mut lookup)?;
-        // run.model.provider/name and run.git.author.* are plain `String`,
-        // demoted out of the interpolation set (D2): NO variable substitution.
-        // Only InterpString fields access variables — these don't anymore.
+        // run.model.provider/name and run.git.author.* were demoted to plain
+        // `String` and removed from this pass (D2): values stay literal.
         substitute_option_string(&mut self.model.controls.reasoning_effort, &mut lookup)?;
         substitute_option_string(&mut self.model.controls.speed, &mut lookup)?;
         substitute_string_vec(&mut self.checkpoint.exclude_globs, &mut lookup)?;
@@ -104,8 +103,8 @@ impl RunNamespace {
             substitute_option(&mut slack.channel, &mut lookup)?;
         }
         substitute_map(&mut self.integrations.github.permissions, &mut lookup)?;
-        // run.scm.owner/repository are plain `String` (demoted, D2): no
-        // variable substitution.
+        // run.scm.owner/repository were demoted and removed from this pass
+        // (D2): values stay literal.
         substitute_string_vec(&mut self.prepare.commands, &mut lookup)?;
         for mcp in self.agent.mcps.values_mut() {
             substitute_string(&mut mcp.name, &mut lookup)?;
@@ -409,12 +408,9 @@ mod run_namespace_variable_substitution_tests {
 
     #[test]
     fn demoted_fields_do_not_interpolate() {
-        // run.model.*, run.git.author.*, run.scm.owner/repository were demoted
-        // out of the interpolation set (D2) to plain `String`. They no longer
-        // access variables at all: `{{ vars.* }}` and `{{ env.* }}` are both
-        // left literal even when a value is available. Only InterpString fields
-        // interpolate — the old run-scoped String `vars` substitution on these
-        // fields was an incidental behavior that is now removed.
+        // Demoted fields (run.model.*, run.git.author.*, run.scm.owner/
+        // repository) were removed from the vars pass (D2): `{{ vars.* }}`
+        // and `{{ env.* }}` stay literal even when a value is available.
         let mut run = RunNamespace {
             model: super::RunModelSettings {
                 provider: Some("{{ vars.PROVIDER }}".to_string()),

--- a/lib/crates/fabro-types/src/settings/run.rs
+++ b/lib/crates/fabro-types/src/settings/run.rs
@@ -22,7 +22,7 @@ use super::size::Size;
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct RunNamespace {
     pub goal:          Option<RunGoal>,
-    pub working_dir:   Option<InterpString>,
+    pub working_dir:   Option<String>,
     pub metadata:      HashMap<String, String>,
     pub inputs:        HashMap<String, toml::Value>,
     pub model:         RunModelSettings,
@@ -82,10 +82,10 @@ impl RunNamespace {
         F: FnMut(&str) -> Option<String>,
     {
         substitute_goal(&mut self.goal, &mut lookup)?;
-        substitute_option(&mut self.working_dir, &mut lookup)?;
         substitute_string_map(&mut self.metadata, &mut lookup)?;
-        // run.model.provider/name and run.git.author.* were demoted to plain
-        // `String` and removed from this pass (D2): values stay literal.
+        // run.working_dir, run.model.provider/name, and run.git.author.* were
+        // demoted to plain `String` and removed from this pass (D2/D11):
+        // values stay literal.
         substitute_option_string(&mut self.model.controls.reasoning_effort, &mut lookup)?;
         substitute_option_string(&mut self.model.controls.speed, &mut lookup)?;
         substitute_string_vec(&mut self.checkpoint.exclude_globs, &mut lookup)?;
@@ -317,7 +317,6 @@ mod run_namespace_variable_substitution_tests {
             goal: Some(RunGoal::Inline(InterpString::parse(
                 "deploy {{ vars.ENV }} in {{ env.REGION }}",
             ))),
-            working_dir: Some(InterpString::parse("/workspace/{{ vars.ENV }}")),
             prepare: RunPrepareSettings {
                 commands:   vec!["echo {{ vars.ENV }} {{ env.REGION }}".to_string()],
                 timeout_ms: 1_000,
@@ -376,10 +375,6 @@ mod run_namespace_variable_substitution_tests {
             goal_source,
             Some("deploy prod in {{ env.REGION }}".to_string())
         );
-        assert_eq!(
-            run.working_dir.as_ref().map(InterpString::as_source),
-            Some("/workspace/prod".to_string())
-        );
         assert_eq!(run.prepare.commands, vec![
             "echo prod {{ env.REGION }}".to_string()
         ]);
@@ -408,10 +403,12 @@ mod run_namespace_variable_substitution_tests {
 
     #[test]
     fn demoted_fields_do_not_interpolate() {
-        // Demoted fields (run.model.*, run.git.author.*, run.scm.owner/
-        // repository) were removed from the vars pass (D2): `{{ vars.* }}`
-        // and `{{ env.* }}` stay literal even when a value is available.
+        // Demoted fields (run.working_dir, run.model.*, run.git.author.*,
+        // run.scm.owner/repository) were removed from the vars pass (D2/D11):
+        // `{{ vars.* }}` and `{{ env.* }}` stay literal even when a value is
+        // available.
         let mut run = RunNamespace {
+            working_dir: Some("/workspace/{{ vars.ENV }}".to_string()),
             model: super::RunModelSettings {
                 provider: Some("{{ vars.PROVIDER }}".to_string()),
                 name: Some("{{ vars.MODEL }}".to_string()),
@@ -435,6 +432,10 @@ mod run_namespace_variable_substitution_tests {
         run.substitute_variables(|_| Some("SUBSTITUTED".to_string()))
             .unwrap();
 
+        assert_eq!(
+            run.working_dir.as_deref(),
+            Some("/workspace/{{ vars.ENV }}")
+        );
         assert_eq!(run.model.provider.as_deref(), Some("{{ vars.PROVIDER }}"));
         assert_eq!(run.model.name.as_deref(), Some("{{ vars.MODEL }}"));
         let author = run.git.author.as_ref().unwrap();

--- a/lib/crates/fabro-workflow/src/operations/create.rs
+++ b/lib/crates/fabro-workflow/src/operations/create.rs
@@ -1156,7 +1156,7 @@ mod tests {
                         goal: Some(RunGoalLayer::Inline(InterpString::parse("override goal"))),
                         metadata: ReplaceMap::from(metadata),
                         model: Some(RunModelLayer {
-                            name: Some(InterpString::parse("sonnet")),
+                            name: Some("sonnet".to_string()),
                             ..RunModelLayer::default()
                         }),
                         pull_request: Some(RunPullRequestLayer {
@@ -1207,8 +1207,6 @@ mod tests {
                 .run
                 .model
                 .name
-                .as_ref()
-                .map(fabro_types::settings::InterpString::as_source)
                 .as_deref(),
             Some("claude-sonnet-4-6")
         );
@@ -1220,8 +1218,6 @@ mod tests {
                 .run
                 .model
                 .provider
-                .as_ref()
-                .map(fabro_types::settings::InterpString::as_source)
                 .as_deref(),
             Some("anthropic")
         );

--- a/lib/crates/fabro-workflow/src/operations/create.rs
+++ b/lib/crates/fabro-workflow/src/operations/create.rs
@@ -1276,7 +1276,7 @@ mod tests {
                 },
                 settings: settings_from_run_layer({
                     RunLayer {
-                        working_dir: Some(InterpString::parse("workspace")),
+                        working_dir: Some("workspace".to_string()),
                         execution: Some(RunExecutionLayer {
                             mode: Some(RunMode::DryRun),
                             ..RunExecutionLayer::default()

--- a/lib/crates/fabro-workflow/src/operations/source.rs
+++ b/lib/crates/fabro-workflow/src/operations/source.rs
@@ -126,11 +126,12 @@ fn resolve_goal_override(
 
 #[cfg(test)]
 mod tests {
+    use fabro_types::settings::InterpString;
+
     use super::*;
 
     #[test]
     fn resolve_workflow_uses_explicit_cwd_for_relative_work_dir() {
-        use fabro_types::settings::InterpString;
         use fabro_types::settings::run::RunNamespace;
 
         let dir = tempfile::tempdir().unwrap();
@@ -141,7 +142,7 @@ mod tests {
             },
             settings: WorkflowSettings {
                 run: RunNamespace {
-                    working_dir: Some(InterpString::parse("workspace")),
+                    working_dir: Some("workspace".to_string()),
                     ..RunNamespace::default()
                 },
                 ..WorkflowSettings::default()
@@ -155,7 +156,6 @@ mod tests {
 
     #[test]
     fn resolve_workflow_reads_goal_override_from_dense_run_settings() {
-        use fabro_types::settings::InterpString;
         use fabro_types::settings::run::{RunGoal, RunNamespace};
 
         let dir = tempfile::tempdir().unwrap();

--- a/lib/crates/fabro-workflow/src/operations/start.rs
+++ b/lib/crates/fabro-workflow/src/operations/start.rs
@@ -573,19 +573,15 @@ fn resolve_start_llm(
     let provider = settings
         .model
         .provider
-        .clone()
+        .as_deref()
         .filter(|value| !value.is_empty());
 
     let default_provider_id = catalog
         .default_for_configured_ids(configured)
         .provider
         .clone();
-    let provider_context = routing::resolve_provider_context(
-        catalog,
-        &default_provider_id,
-        &model,
-        provider.as_deref(),
-    )?;
+    let provider_context =
+        routing::resolve_provider_context(catalog, &default_provider_id, &model, provider)?;
     let provider_id = provider_context.provider_id;
     let fallback_chain = resolve_fallback_chain(catalog, &provider_id, &model, &settings.model);
 

--- a/lib/crates/fabro-workflow/src/operations/start.rs
+++ b/lib/crates/fabro-workflow/src/operations/start.rs
@@ -21,7 +21,7 @@ use fabro_types::settings::run::{
     RunModelSettings as ResolvedRunModelSettings, RunNamespace as ResolvedRunSettings,
     TlsMode as ResolvedTlsMode,
 };
-use fabro_types::settings::{InterpString, ModelRegistry, ResolvedModelRef};
+use fabro_types::settings::{ModelRegistry, ResolvedModelRef};
 use fabro_types::{ManifestPath, RunId, RunRunnableSource, SandboxProviderKind};
 use fabro_vault::Vault;
 use tokio::runtime::Handle;
@@ -560,25 +560,20 @@ fn resolve_docker_config(settings: &ResolvedRunSettings) -> DockerSandboxOptions
     docker_config_from_environment(&settings.environment, !settings.clone.enabled)
 }
 
-#[expect(
-    clippy::disallowed_methods,
-    reason = "raw source is today's behavior; run.model.name/provider are slated for demotion to plain String in the \
-              interpolation unification (D2)"
-)]
 fn resolve_start_llm(
     catalog: &Catalog,
     configured: &[ProviderId],
     settings: &ResolvedRunSettings,
 ) -> Result<ResolvedStartLlm, Error> {
-    let model = settings.model.name.as_ref().map_or_else(
-        || catalog.default_for_configured_ids(configured).id.clone(),
-        InterpString::as_source,
-    );
+    let model = settings
+        .model
+        .name
+        .clone()
+        .unwrap_or_else(|| catalog.default_for_configured_ids(configured).id.clone());
     let provider = settings
         .model
         .provider
-        .as_ref()
-        .map(InterpString::as_source)
+        .clone()
         .filter(|value| !value.is_empty());
 
     let default_provider_id = catalog
@@ -1302,7 +1297,7 @@ reasoning = false
         .unwrap();
         let catalog = Catalog::from_builtin_with_overrides(&overrides).unwrap();
         let mut settings = ResolvedRunSettings::default();
-        settings.model.name = Some(InterpString::parse("ac"));
+        settings.model.name = Some("ac".to_string());
 
         let resolved = resolve_start_llm(&catalog, &[], &settings).unwrap();
 

--- a/lib/crates/fabro-workflow/src/run_materialization.rs
+++ b/lib/crates/fabro-workflow/src/run_materialization.rs
@@ -4,29 +4,14 @@ use fabro_types::WorkflowSettings;
 use fabro_types::settings::InterpString;
 use fabro_types::settings::run::RunGoal;
 
-#[expect(
-    clippy::disallowed_methods,
-    reason = "raw source is today's behavior; run.model.name/provider are slated for demotion to plain String in the \
-              interpolation unification (D2)"
-)]
 pub fn materialize_run(
     mut settings: WorkflowSettings,
     graph: &Graph,
     catalog: &Catalog,
     configured_providers: &[ProviderId],
 ) -> WorkflowSettings {
-    let configured_model = settings
-        .run
-        .model
-        .name
-        .as_ref()
-        .map(InterpString::as_source);
-    let configured_provider = settings
-        .run
-        .model
-        .provider
-        .as_ref()
-        .map(InterpString::as_source);
+    let configured_model = settings.run.model.name.clone();
+    let configured_provider = settings.run.model.provider.clone();
     let graph_provider = graph
         .attrs
         .get("default_provider")
@@ -57,8 +42,8 @@ pub fn materialize_run(
         None => (model, provider),
     };
 
-    settings.run.model.name = Some(InterpString::parse(&resolved_model));
-    settings.run.model.provider = resolved_provider.as_deref().map(InterpString::parse);
+    settings.run.model.name = Some(resolved_model);
+    settings.run.model.provider = resolved_provider;
 
     let goal = graph.goal().to_string();
     settings.run.goal = if goal.is_empty() {

--- a/lib/crates/fabro-workflow/src/run_materialization.rs
+++ b/lib/crates/fabro-workflow/src/run_materialization.rs
@@ -10,8 +10,8 @@ pub fn materialize_run(
     catalog: &Catalog,
     configured_providers: &[ProviderId],
 ) -> WorkflowSettings {
-    let configured_model = settings.run.model.name.clone();
-    let configured_provider = settings.run.model.provider.clone();
+    let configured_model = settings.run.model.name.take();
+    let configured_provider = settings.run.model.provider.take();
     let graph_provider = graph
         .attrs
         .get("default_provider")

--- a/lib/crates/fabro-workflow/tests/materialize_run.rs
+++ b/lib/crates/fabro-workflow/tests/materialize_run.rs
@@ -10,10 +10,6 @@ fn graph(source: &str) -> Graph {
     parser::parse(source).expect("graph should parse")
 }
 
-#[expect(
-    clippy::disallowed_methods,
-    reason = "test asserts the raw template source"
-)]
 #[test]
 fn materialize_run_applies_graph_and_catalog_defaults() {
     let source = r#"digraph Test {
@@ -26,7 +22,7 @@ fn materialize_run_applies_graph_and_catalog_defaults() {
     let settings = WorkflowSettings {
         run: RunNamespace {
             model: RunModelSettings {
-                name: Some(InterpString::parse("sonnet")),
+                name: Some("sonnet".to_string()),
                 ..RunModelSettings::default()
             },
             pull_request: Some(PullRequestSettings {
@@ -41,24 +37,8 @@ fn materialize_run_applies_graph_and_catalog_defaults() {
     let materialized = materialize_run(settings, &graph(source), Catalog::builtin(), &[]);
     let resolved = &materialized.run;
 
-    assert_eq!(
-        resolved
-            .model
-            .name
-            .as_ref()
-            .map(InterpString::as_source)
-            .as_deref(),
-        Some("claude-sonnet-4-6")
-    );
-    assert_eq!(
-        resolved
-            .model
-            .provider
-            .as_ref()
-            .map(InterpString::as_source)
-            .as_deref(),
-        Some("anthropic")
-    );
+    assert_eq!(resolved.model.name.as_deref(), Some("claude-sonnet-4-6"));
+    assert_eq!(resolved.model.provider.as_deref(), Some("anthropic"));
     assert_eq!(
         materialized.run.goal.as_ref(),
         Some(&RunGoal::Inline(InterpString::parse("Build feature")))
@@ -66,10 +46,6 @@ fn materialize_run_applies_graph_and_catalog_defaults() {
     assert!(resolved.pull_request.is_none());
 }
 
-#[expect(
-    clippy::disallowed_methods,
-    reason = "test asserts the raw template source"
-)]
 #[test]
 fn materialize_run_uses_configured_provider_defaults() {
     let source = r#"digraph Test {
@@ -87,13 +63,5 @@ fn materialize_run_uses_configured_provider_defaults() {
     );
     let resolved = &materialized.run;
 
-    assert_eq!(
-        resolved
-            .model
-            .provider
-            .as_ref()
-            .map(InterpString::as_source)
-            .as_deref(),
-        Some("openai")
-    );
+    assert_eq!(resolved.model.provider.as_deref(), Some("openai"));
 }


### PR DESCRIPTION
# Demote non-category leak fields to plain `String`

Second slice of the interpolation unification — the first **reducing** PR
stacked on the foundation (#472), per the reduce-first sequencing: narrowing
changes land before capability additions. (The other reducing slice, the DOT
de-templating, already landed independently as #474.)

## Why

The target model gives `InterpString` to fields in five categories —
`command` / `script` / `headers` / `env` / `url` — wherever they appear. A
handful of fields were typed `InterpString` but are *identifiers or commit
content*, not in any category:

- `run.model.provider` / `run.model.name`
- `cli.exec.model.provider` / `cli.exec.model.name`
- `run.git.author.name` / `run.git.author.email`
- `run.scm.owner` / `run.scm.repository`

Their consumers never resolved them — they leaked raw source text via
`as_source()`. This PR demotes them to plain `String` (layer and resolved
structs) with **no interpolation**.

## The principle: only `InterpString` fields access variables

These fields are dropped from the variable substitute pass entirely, so both
`{{ vars.* }}` and `{{ env.* }}` are now literal text. This **removes an
incidental behavior**: run-scoped plain-`String` fields used to get
`{{ vars.* }}` substituted via the String pass (a lucky accident), while
`env` always leaked literally. Variable access becomes deliberate and typed
rather than accidental; if any of these fields should support variables
later, that's a controlled promotion back to `InterpString`.

## Behavior changes (honest list)

- **The incidental run-scoped `{{ vars.* }}` substitution on these eight
  fields stops working.** To keep the removal visible rather than silent, a
  `tracing::warn!` fires at resolve time when a demoted field still contains
  claimed template tokens (`warn_if_demoted_template`). Unclaimed `{{ ... }}`
  text (jq programs, Go templates) never interpolated and does not warn.
- `{{ env.* }}` / `{{ secrets.* }}` / `{{ inputs.* }}` never resolved on
  these fields, so nothing else changes.

## Added in review: D11 demotions (separate commit, revertable)

The rule got refined during review: a field is `InterpString` iff it is in one
of the five categories **and resolved at the run boundary** (the only point
where `vars`/`secrets`/`inputs` exist — they're server state, so connect-time
and startup-time fields can't reach them even in principle). A separate commit
applies the clean subset so it can be cherry-picked out if we change course:

- `cli.target.http.url` / `cli.target.unix.path` — consumed at CLI connect
  time; consumers only ever leaked raw source, so nothing working is removed.
- `run.working_dir` — **the outlier; see the PR comment.** Its `{{ vars.* }}`
  substitution worked; demoted on the category test alone.

## What's deliberately NOT here

- The **control-plane fields** (`server.storage.root` / `listen.unix.path` /
  S3 fields / `github.app_id/client_id/slug` / `server.api.url` /
  `server.web.url`) — untouched here, demoted in a follow-up PR.
  **Resolved during review** (see the resolution comment): `InterpString` was
  conflating the user-facing workflow language with the internal control
  plane. Control-plane fields never interpolate; the few deployment knobs
  that need late binding (e.g. `FABRO_WEB_URL`, whose only real usage is the
  split-web PoC ferrying a compose env var across a file mount) become
  explicit native `EnvVars` reads, and `fabro-server/src/interp.rs` shrinks
  to deletion. `slack.default_channel` stays `InterpString` (consumed with
  run context).

## Implementation notes

- Consumers move from `as_source()` to direct `String` access; the
  foundation's `#[expect(disallowed_methods, ... demotion pending ...)]`
  annotations for these fields are removed (no longer `InterpString`).
- `fabro-checkpoint`'s author plumbing and `fabro-manifest`'s scm fields
  simplify accordingly.

## Verification

- `cargo build --workspace`
- `cargo nextest run --workspace` → 6684 passed, 181 skipped
- `cargo +nightly fmt --check --all`
- `cargo +nightly clippy --workspace --all-targets -- -D warnings` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)



