### PR TITLE
Implement full-fidelity ACP session reuse

### DIFF
--- a/lib/crates/fabro-acp/src/error.rs
+++ b/lib/crates/fabro-acp/src/error.rs
@@ -36,6 +36,9 @@ pub enum AcpError {
     #[error("ACP turn was cancelled")]
     Cancelled,
 
+    #[error("ACP session closed")]
+    SessionClosed,
+
     #[error("ACP turn timed out")]
     TimedOut {
         exec_output_tail: Option<ExecOutputTail>,

--- a/lib/crates/fabro-acp/src/lib.rs
+++ b/lib/crates/fabro-acp/src/lib.rs
@@ -16,5 +16,6 @@ pub use command::{AcpCommandError, AcpProcessSpec};
 pub use error::{AcpError, AcpProcessExit};
 #[cfg(feature = "runtime")]
 pub use session::{
-    AcpControlHandle, AcpLiveControl, AcpRunRequest, AcpRunResult, render_stop_reason, run_acp_turn,
+    AcpControlHandle, AcpLiveControl, AcpPromptRequest, AcpRunRequest, AcpRunResult,
+    AcpSessionHandle, AcpSessionStartRequest, render_stop_reason, run_acp_turn, start_acp_session,
 };

--- a/lib/crates/fabro-acp/src/session.rs
+++ b/lib/crates/fabro-acp/src/session.rs
@@ -12,8 +12,8 @@ use agent_client_protocol::{ActiveSession, Agent, Client, Error as ProtocolError
 use fabro_sandbox::Sandbox;
 use fabro_types::{Principal, SteeringMessage};
 use fabro_util::time::elapsed_ms;
-use tokio::sync::Notify;
 use tokio::sync::futures::Notified;
+use tokio::sync::{Notify, mpsc, oneshot};
 use tokio::time::{sleep, timeout};
 use tokio_util::sync::CancellationToken;
 
@@ -23,6 +23,8 @@ use crate::transport::{SandboxAcpTransport, TransportState};
 
 pub type AcpNaturalCompletionCallback = Arc<dyn Fn() -> bool + Send + Sync>;
 pub type AcpSteerPromptCallback = Arc<dyn Fn(String, Option<Principal>) + Send + Sync>;
+type PermissionCancelSlot = Arc<Mutex<Option<CancellationToken>>>;
+type AcpReadySlot = Arc<Mutex<Option<oneshot::Sender<Result<(), AcpError>>>>>;
 
 const CANCEL_GRACE_PERIOD: Duration = Duration::from_millis(500);
 
@@ -170,12 +172,136 @@ pub struct AcpRunRequest {
     pub live_control: Option<AcpLiveControl>,
 }
 
+pub struct AcpSessionStartRequest {
+    pub command: AcpProcessSpec,
+    pub cwd:     String,
+    pub env:     HashMap<String, String>,
+    pub sandbox: Arc<dyn Sandbox>,
+}
+
+pub struct AcpPromptRequest {
+    pub prompt:       String,
+    pub timeout_ms:   Option<u64>,
+    pub cancel_token: CancellationToken,
+    pub on_activity:  Option<Arc<dyn Fn() + Send + Sync>>,
+    pub live_control: Option<AcpLiveControl>,
+}
+
 #[derive(Debug)]
 pub struct AcpRunResult {
     pub text:        String,
     pub stop_reason: StopReason,
     pub stderr:      String,
     pub duration_ms: u64,
+}
+
+pub struct AcpSessionHandle {
+    commands: mpsc::Sender<AcpSessionCommand>,
+    state:    TransportState,
+}
+
+impl AcpSessionHandle {
+    pub async fn prompt(&self, request: AcpPromptRequest) -> Result<AcpRunResult, AcpError> {
+        let (reply, result) = oneshot::channel();
+        if self
+            .commands
+            .send(AcpSessionCommand::Prompt { request, reply })
+            .await
+            .is_err()
+        {
+            return Err(closed_session_error(&self.state).await);
+        }
+
+        match result.await {
+            Ok(result) => result,
+            Err(_) => Err(closed_session_error(&self.state).await),
+        }
+    }
+
+    pub async fn shutdown(&self) -> Result<(), AcpError> {
+        let (reply, result) = oneshot::channel();
+        if self
+            .commands
+            .send(AcpSessionCommand::Shutdown { reply })
+            .await
+            .is_err()
+        {
+            return Err(closed_session_error(&self.state).await);
+        }
+
+        match result.await {
+            Ok(result) => result,
+            Err(_) => Err(closed_session_error(&self.state).await),
+        }
+    }
+}
+
+enum AcpSessionCommand {
+    Prompt {
+        request: AcpPromptRequest,
+        reply:   oneshot::Sender<Result<AcpRunResult, AcpError>>,
+    },
+    Shutdown {
+        reply: oneshot::Sender<Result<(), AcpError>>,
+    },
+}
+
+struct PermissionCancelGuard {
+    slot: PermissionCancelSlot,
+}
+
+impl PermissionCancelGuard {
+    fn set(slot: &PermissionCancelSlot, token: CancellationToken) -> Self {
+        *slot.lock().expect("ACP permission cancel lock poisoned") = Some(token);
+        Self {
+            slot: Arc::clone(slot),
+        }
+    }
+}
+
+impl Drop for PermissionCancelGuard {
+    fn drop(&mut self) {
+        *self
+            .slot
+            .lock()
+            .expect("ACP permission cancel lock poisoned") = None;
+    }
+}
+
+pub async fn start_acp_session(
+    request: AcpSessionStartRequest,
+) -> Result<AcpSessionHandle, AcpError> {
+    let AcpSessionStartRequest {
+        command,
+        cwd,
+        env,
+        sandbox,
+    } = request;
+    let state = TransportState::new();
+    let transport = SandboxAcpTransport::new(command, cwd.clone(), env, sandbox, state.clone());
+    let permission_cancel_token: PermissionCancelSlot = Arc::new(Mutex::new(None));
+    let (commands, command_rx) = mpsc::channel(1);
+    let (ready, ready_rx) = oneshot::channel();
+    let ready_slot: AcpReadySlot = Arc::new(Mutex::new(Some(ready)));
+    let handle = AcpSessionHandle {
+        commands,
+        state: state.clone(),
+    };
+
+    tokio::spawn(run_acp_session_task(
+        transport,
+        cwd,
+        command_rx,
+        state.clone(),
+        permission_cancel_token,
+        ready_slot,
+    ));
+
+    match ready_rx.await {
+        Ok(Ok(())) => Ok(handle),
+        Ok(Err(error)) => Err(error),
+        Err(_) => Err(closed_session_error(&state).await),
+    }
 }
 
 pub async fn run_acp_turn(request: AcpRunRequest) -> Result<AcpRunResult, AcpError> {
@@ -304,6 +430,210 @@ pub async fn run_acp_turn(request: AcpRunRequest) -> Result<AcpRunResult, AcpErr
         stderr,
         duration_ms: elapsed_ms(start),
     })
+}
+
+async fn run_acp_session_task(
+    transport: SandboxAcpTransport,
+    cwd: String,
+    command_rx: mpsc::Receiver<AcpSessionCommand>,
+    state: TransportState,
+    permission_cancel_token: PermissionCancelSlot,
+    ready_slot: AcpReadySlot,
+) {
+    let permission_cancel_token_for_requests = Arc::clone(&permission_cancel_token);
+    let ready_for_session = Arc::clone(&ready_slot);
+    let state_for_session = state.clone();
+    let result = Client
+        .builder()
+        .name("fabro")
+        .on_receive_request(
+            async move |request: RequestPermissionRequest, responder, _connection| {
+                let is_cancelled = permission_cancel_token_for_requests
+                    .lock()
+                    .expect("ACP permission cancel lock poisoned")
+                    .as_ref()
+                    .is_some_and(CancellationToken::is_cancelled);
+                let outcome = if is_cancelled {
+                    RequestPermissionOutcome::Cancelled
+                } else {
+                    select_permission_outcome(&request)
+                };
+                responder.respond(RequestPermissionResponse::new(outcome))
+            },
+            agent_client_protocol::on_receive_request!(),
+        )
+        .connect_with(transport, async move |cx| {
+            cx.send_request(InitializeRequest::new(ProtocolVersion::V1))
+                .block_task()
+                .await?;
+
+            cx.build_session(&cwd)
+                .block_task()
+                .run_until(async |mut session| {
+                    send_ready(&ready_for_session, Ok(()));
+                    run_session_command_loop(
+                        &mut session,
+                        command_rx,
+                        state_for_session,
+                        permission_cancel_token,
+                    )
+                    .await
+                })
+                .await
+        })
+        .await;
+
+    match result {
+        Ok(()) => send_ready(&ready_slot, Err(AcpError::SessionClosed)),
+        Err(error) => {
+            let error = map_protocol_or_state_error(&state, error).await;
+            send_ready(&ready_slot, Err(error));
+        }
+    }
+}
+
+async fn run_session_command_loop(
+    session: &mut ActiveSession<'_, Agent>,
+    mut command_rx: mpsc::Receiver<AcpSessionCommand>,
+    state: TransportState,
+    permission_cancel_token: PermissionCancelSlot,
+) -> Result<(), ProtocolError> {
+    while let Some(command) = command_rx.recv().await {
+        match command {
+            AcpSessionCommand::Prompt { request, reply } => {
+                let result =
+                    run_prompt_on_session(session, request, &state, &permission_cancel_token).await;
+                let keep_alive = result.is_ok();
+                let _ = reply.send(result);
+                if !keep_alive {
+                    break;
+                }
+            }
+            AcpSessionCommand::Shutdown { reply } => {
+                let result = state.terminate().await.map_err(AcpError::Sandbox);
+                let _ = reply.send(result);
+                break;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+async fn run_prompt_on_session(
+    session: &mut ActiveSession<'_, Agent>,
+    request: AcpPromptRequest,
+    state: &TransportState,
+    permission_cancel_token: &PermissionCancelSlot,
+) -> Result<AcpRunResult, AcpError> {
+    let AcpPromptRequest {
+        prompt,
+        timeout_ms,
+        cancel_token,
+        on_activity,
+        live_control,
+    } = request;
+    if cancel_token.is_cancelled() {
+        state.terminate().await?;
+        return Err(AcpError::Cancelled);
+    }
+
+    let live_control = live_control.unwrap_or_default();
+    let start = std::time::Instant::now();
+    let read_cancel_token = cancel_token.clone();
+    let run_cancel_token = cancel_token.clone();
+    let _permission_cancel_guard =
+        PermissionCancelGuard::set(permission_cancel_token, cancel_token.clone());
+
+    if let Err(error) = session.send_prompt(prompt) {
+        state.terminate().await?;
+        return Err(map_protocol_or_state_error(state, error).await);
+    }
+
+    let run = read_live_session(
+        session,
+        &read_cancel_token,
+        &live_control.handle,
+        live_control.on_natural_completion.as_ref(),
+        live_control.on_steer_prompt.as_ref(),
+        on_activity.as_ref(),
+    );
+    let outcome = match timeout_ms {
+        Some(timeout_ms) => {
+            if let Ok(result) = timeout(Duration::from_millis(timeout_ms), run).await {
+                result
+            } else {
+                state.terminate().await?;
+                if run_cancel_token.is_cancelled() {
+                    return Err(AcpError::Cancelled);
+                }
+                return Err(AcpError::TimedOut {
+                    exec_output_tail: state.exec_output_tail().await,
+                });
+            }
+        }
+        None => run.await,
+    };
+
+    let (text, stop_reason) = match outcome {
+        Ok(result) => result,
+        Err(_) if run_cancel_token.is_cancelled() => {
+            state.terminate().await?;
+            return Err(AcpError::Cancelled);
+        }
+        Err(error) => {
+            state.terminate().await?;
+            return Err(map_protocol_or_state_error(state, error).await);
+        }
+    };
+
+    match stop_reason {
+        StopReason::EndTurn | StopReason::Refusal => {}
+        StopReason::Cancelled => {
+            state.terminate().await?;
+            return Err(AcpError::Cancelled);
+        }
+        _ => {
+            state.terminate().await?;
+            return Err(AcpError::StopReason {
+                stop_reason: render_stop_reason(&stop_reason),
+                text,
+            });
+        }
+    }
+
+    Ok(AcpRunResult {
+        text,
+        stop_reason,
+        stderr: state.stderr_tail().await,
+        duration_ms: elapsed_ms(start),
+    })
+}
+
+async fn map_protocol_or_state_error(state: &TransportState, error: ProtocolError) -> AcpError {
+    if let Some(startup_error) = state.take_startup_error().await {
+        return AcpError::Sandbox(startup_error);
+    }
+    if let Some(process_exit) = state.take_process_exit().await {
+        return AcpError::ProcessExited(process_exit);
+    }
+    map_protocol_error(error)
+}
+
+async fn closed_session_error(state: &TransportState) -> AcpError {
+    if let Some(startup_error) = state.take_startup_error().await {
+        return AcpError::Sandbox(startup_error);
+    }
+    if let Some(process_exit) = state.take_process_exit().await {
+        return AcpError::ProcessExited(process_exit);
+    }
+    AcpError::SessionClosed
+}
+
+fn send_ready(ready_slot: &AcpReadySlot, result: Result<(), AcpError>) {
+    if let Some(ready) = ready_slot.lock().expect("ACP ready lock poisoned").take() {
+        let _ = ready.send(result);
+    }
 }
 
 fn map_protocol_error(error: ProtocolError) -> AcpError {

--- a/lib/crates/fabro-acp/src/test_support.rs
+++ b/lib/crates/fabro-acp/src/test_support.rs
@@ -32,7 +32,10 @@ methods = []
 session_id = "sess-1"
 prompt_count = 0
 
-if os.environ.get("ACP_PID_RECORD"):
+if os.environ.get("ACP_PID_RECORD_APPEND"):
+    with open(os.environ["ACP_PID_RECORD_APPEND"], "a", encoding="utf-8") as record:
+        record.write(str(os.getpid()) + "\n")
+elif os.environ.get("ACP_PID_RECORD"):
     with open(os.environ["ACP_PID_RECORD"], "w", encoding="utf-8") as record:
         record.write(str(os.getpid()))
 
@@ -97,6 +100,24 @@ for line in sys.stdin:
             with open(os.environ["ACP_PROMPT_RECORD"], "w", encoding="utf-8") as record:
                 record.write(json.dumps(message.get("params", {})))
         mode = os.environ.get("ACP_MODE", "normal")
+        if mode == "echo_prompt_count":
+            send({
+                "jsonrpc": "2.0",
+                "method": "session/update",
+                "params": {
+                    "sessionId": session_id,
+                    "update": {
+                        "sessionUpdate": "agent_message_chunk",
+                        "content": {
+                            "type": "text",
+                            "text": str(prompt_count) + ":" + first_prompt_text(message)
+                        }
+                    }
+                }
+            })
+            record_methods()
+            respond(message, {"stopReason": "end_turn"})
+            continue
         if mode == "timeout":
             time.sleep(60)
         if mode == "malformed":

--- a/lib/crates/fabro-server/src/server/tests.rs
+++ b/lib/crates/fabro-server/src/server/tests.rs
@@ -11685,6 +11685,7 @@ async fn steer_with_active_acp_session_forwards_to_worker() {
         visit:       1,
         command:     "python fake_agent.py".to_string(),
         config_name: None,
+        reused:      false,
     });
     update_live_run_from_event(&state, run_id, &started);
     let activated =
@@ -11785,6 +11786,7 @@ async fn active_acp_steerable_marker_clears_on_terminal_paths() {
             visit:       1,
             command:     "python fake_agent.py".to_string(),
             config_name: None,
+            reused:      false,
         });
         update_live_run_from_event(&state, run_id, &started);
         let activated =

--- a/lib/crates/fabro-store/src/run_state.rs
+++ b/lib/crates/fabro-store/src/run_state.rs
@@ -2084,6 +2084,7 @@ mod tests {
                     visit:       1,
                     command:     "python fake_agent.py".to_string(),
                     config_name: Some("fake".to_string()),
+                    reused:      false,
                 }),
                 stage_id.clone(),
             ))
@@ -2106,6 +2107,7 @@ mod tests {
                     visit:       1,
                     command:     "python fake_agent.py".to_string(),
                     config_name: Some("fake".to_string()),
+                    reused:      false,
                 }),
                 stage_id.clone(),
             ))

--- a/lib/crates/fabro-types/src/run_event/misc.rs
+++ b/lib/crates/fabro-types/src/run_event/misc.rs
@@ -228,6 +228,8 @@ pub struct AgentAcpStartedProps {
     pub command:     String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub config_name: Option<String>,
+    #[serde(default)]
+    pub reused:      bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/lib/crates/fabro-validate/src/rules/backend_valid.rs
+++ b/lib/crates/fabro-validate/src/rules/backend_valid.rs
@@ -1,8 +1,10 @@
+use std::collections::HashMap;
+
 use fabro_acp::{AcpCommandError, AcpProcessSpec};
 use fabro_graphviz::graph::{Graph, Node};
 use fabro_types::AgentBackend;
 
-use crate::{Diagnostic, LintRule, Severity};
+use crate::{Diagnostic, LintRule, RelatedDiagnostic, Severity};
 
 pub(super) fn rule() -> Box<dyn LintRule> {
     Box::new(Rule)
@@ -34,8 +36,14 @@ impl LintRule for Rule {
                 }
             }
         }
+        diagnostics.extend(validate_acp_thread_process_consistency(self.name(), graph));
         diagnostics
     }
+}
+
+struct AcpThreadProcess {
+    node_id: String,
+    spec:    AcpProcessSpec,
 }
 
 fn unsupported_backend_diagnostic(rule: &str, node: &Node, backend: &str) -> Diagnostic {
@@ -111,6 +119,71 @@ fn validate_acp_node(rule: &str, node: &Node) -> Vec<Diagnostic> {
 
             ..Diagnostic::default()
         });
+    }
+
+    diagnostics
+}
+
+fn validate_acp_thread_process_consistency(rule: &str, graph: &Graph) -> Vec<Diagnostic> {
+    let mut diagnostics = Vec::new();
+    let graph_default_full = graph.default_fidelity() == Some("full");
+    let graph_default_thread = graph.default_thread();
+    let mut by_thread: HashMap<String, AcpThreadProcess> = HashMap::new();
+
+    for node in graph.nodes.values() {
+        if !matches!(node.agent_backend(), Some(Ok(AgentBackend::Acp))) {
+            continue;
+        }
+        if node.fidelity() != Some("full") && !graph_default_full {
+            continue;
+        }
+        let Some(thread_id) = node.thread_id().or(graph_default_thread) else {
+            continue;
+        };
+        let Ok(spec) = AcpProcessSpec::from_attrs(
+            node.legacy_acp_command_attr(),
+            node.acp_command_attr(),
+            node.acp_config_attr(),
+        ) else {
+            continue;
+        };
+
+        match by_thread.get(thread_id) {
+            Some(first) if first.spec != spec => diagnostics.push(Diagnostic {
+                rule: rule.to_string(),
+                severity: Severity::Error,
+                message: format!(
+                    "backend=\"acp\" full-fidelity nodes sharing thread_id \"{thread_id}\" must \
+                     use the same acp.command/acp.config"
+                ),
+                node_id: Some(node.id.clone()),
+                edge: None,
+                fix: Some(
+                    "Use the same ACP process configuration for that thread_id, or choose a \
+                     different thread_id"
+                        .to_string(),
+                ),
+                related: vec![RelatedDiagnostic {
+                    message:     format!(
+                        "First ACP process configuration for thread_id \"{thread_id}\" is on node \
+                         '{}'",
+                        first.node_id
+                    ),
+                    source_path: None,
+                    line:        None,
+                    column:      None,
+                }],
+
+                ..Diagnostic::default()
+            }),
+            Some(_) => {}
+            None => {
+                by_thread.insert(thread_id.to_string(), AcpThreadProcess {
+                    node_id: node.id.clone(),
+                    spec,
+                });
+            }
+        }
     }
 
     diagnostics
@@ -258,6 +331,67 @@ mod tests {
             AttrValue::String("agent-acp".to_string()),
         );
         graph.nodes.insert("work".to_string(), node);
+
+        assert!(Rule.apply(&graph).is_empty());
+    }
+
+    #[test]
+    fn backend_valid_rejects_mismatched_full_acp_thread_process_configs() {
+        let mut graph = minimal_graph();
+        for (id, command) in [
+            ("plan", "agent-acp --model a"),
+            ("code", "agent-acp --model b"),
+        ] {
+            let mut node = Node::new(id);
+            node.attrs
+                .insert("backend".to_string(), AttrValue::String("acp".to_string()));
+            node.attrs.insert(
+                "acp.command".to_string(),
+                AttrValue::String(command.to_string()),
+            );
+            node.attrs.insert(
+                "fidelity".to_string(),
+                AttrValue::String("full".to_string()),
+            );
+            node.attrs.insert(
+                "thread_id".to_string(),
+                AttrValue::String("shared".to_string()),
+            );
+            graph.nodes.insert(id.to_string(), node);
+        }
+
+        let diagnostics = Rule.apply(&graph);
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].severity, Severity::Error);
+        assert!(
+            diagnostics[0]
+                .message
+                .contains("sharing thread_id \"shared\" must use the same acp.command/acp.config")
+        );
+        assert_eq!(diagnostics[0].related.len(), 1);
+    }
+
+    #[test]
+    fn backend_valid_accepts_matching_full_acp_thread_process_configs() {
+        let mut graph = minimal_graph();
+        for id in ["plan", "code"] {
+            let mut node = Node::new(id);
+            node.attrs
+                .insert("backend".to_string(), AttrValue::String("acp".to_string()));
+            node.attrs.insert(
+                "acp.command".to_string(),
+                AttrValue::String("agent-acp --model a".to_string()),
+            );
+            node.attrs.insert(
+                "fidelity".to_string(),
+                AttrValue::String("full".to_string()),
+            );
+            node.attrs.insert(
+                "thread_id".to_string(),
+                AttrValue::String("shared".to_string()),
+            );
+            graph.nodes.insert(id.to_string(), node);
+        }
 
         assert!(Rule.apply(&graph).is_empty());
     }

--- a/lib/crates/fabro-workflow/src/event/convert.rs
+++ b/lib/crates/fabro-workflow/src/event/convert.rs
@@ -1234,11 +1234,13 @@ fn event_body_from_event(event: &Event) -> EventBody {
             visit,
             command,
             config_name,
+            reused,
             ..
         } => EventBody::AgentAcpStarted(fabro_types::AgentAcpStartedProps {
             visit:       *visit,
             command:     command.clone(),
             config_name: config_name.clone(),
+            reused:      *reused,
         }),
         Event::AgentAcpCompleted {
             stdout,
@@ -2231,6 +2233,7 @@ mod tests {
                 visit:       2,
                 command:     "python fake_agent.py".to_string(),
                 config_name: Some("fake".to_string()),
+                reused:      false,
             },
             Utc::now(),
             Some(&scope),
@@ -2245,6 +2248,7 @@ mod tests {
                 assert_eq!(props.visit, 2);
                 assert_eq!(props.command, "python fake_agent.py");
                 assert_eq!(props.config_name.as_deref(), Some("fake"));
+                assert!(!props.reused);
             }
             other => panic!("expected AgentAcpStarted, got {other:?}"),
         }

--- a/lib/crates/fabro-workflow/src/event/events.rs
+++ b/lib/crates/fabro-workflow/src/event/events.rs
@@ -697,6 +697,8 @@ pub enum Event {
         command:     String,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         config_name: Option<String>,
+        #[serde(default)]
+        reused:      bool,
     },
     AgentAcpCompleted {
         node_id:     String,
@@ -1506,9 +1508,10 @@ impl Event {
                 node_id,
                 command,
                 config_name,
+                reused,
                 ..
             } => {
-                debug!(node_id, command, ?config_name, "Agent ACP started");
+                debug!(node_id, command, ?config_name, reused, "Agent ACP started");
             }
             Self::AgentAcpCompleted {
                 node_id,

--- a/lib/crates/fabro-workflow/src/handler/llm/acp.rs
+++ b/lib/crates/fabro-workflow/src/handler/llm/acp.rs
@@ -5,13 +5,15 @@ use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
 use fabro_acp::{
-    AcpCommandError, AcpControlHandle, AcpError, AcpLiveControl, AcpProcessSpec, AcpRunRequest,
-    render_stop_reason,
+    AcpCommandError, AcpControlHandle, AcpError, AcpLiveControl, AcpProcessSpec, AcpPromptRequest,
+    AcpRunRequest, AcpSessionHandle, AcpSessionStartRequest, render_stop_reason,
 };
 use fabro_agent::{AgentEvent, Sandbox, StaticEnvProvider, SteeringItem, ToolEnvProvider};
+use fabro_graphviz::Fidelity;
 use fabro_graphviz::graph::Node;
 use fabro_types::{
-    AgentBackend, Principal, SessionCapability, StageId, StageTiming, SteeringMessage,
+    AgentBackend, ParallelBranchId, Principal, SessionCapability, StageId, StageTiming,
+    SteeringMessage,
 };
 use fabro_util::time::elapsed_ms;
 use tokio_util::sync::CancellationToken;
@@ -19,15 +21,48 @@ use tokio_util::sync::CancellationToken;
 use super::super::agent::{CodergenBackend, CodergenResult, CodergenRunRequest, OneShotRequest};
 use super::activation_lease::{ActivationLease, ActivationLeaseOptions};
 use super::changed_files;
+use crate::context::{Context, WorkflowContext};
 use crate::error::Error;
 use crate::event::{Emitter, Event, RunNoticeCode, RunNoticeLevel, StageScope};
 use crate::handler::NodeTimeoutPolicy;
 use crate::steering_hub::{ActiveControlHandle, SteeringHub};
 
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+enum AcpSessionReuseKey {
+    Thread {
+        run_id:    String,
+        thread_id: String,
+    },
+    Implicit {
+        run_id:             String,
+        parallel_group_id:  Option<StageId>,
+        parallel_branch_id: Option<ParallelBranchId>,
+    },
+}
+
+#[derive(Clone, Debug)]
+struct AcpSessionReuseTarget {
+    primary_key:  AcpSessionReuseKey,
+    fallback_key: Option<AcpSessionReuseKey>,
+}
+
+#[derive(Clone, PartialEq, Eq)]
+struct AcpSessionFingerprint {
+    process_spec: AcpProcessSpec,
+    cwd:          String,
+}
+
+struct AcpReusableSession {
+    handle:                AcpSessionHandle,
+    fingerprint:           AcpSessionFingerprint,
+    activation_session_id: String,
+}
+
 pub struct AgentAcpBackend {
     tool_env:                     Option<Arc<dyn ToolEnvProvider>>,
     github_token_refresh_managed: bool,
     steering_hub:                 Option<Arc<SteeringHub>>,
+    sessions:                     Mutex<HashMap<AcpSessionReuseKey, AcpReusableSession>>,
 }
 
 impl AgentAcpBackend {
@@ -37,6 +72,7 @@ impl AgentAcpBackend {
             tool_env:                     None,
             github_token_refresh_managed: false,
             steering_hub:                 None,
+            sessions:                     Mutex::new(HashMap::new()),
         }
     }
 
@@ -67,6 +103,8 @@ impl AgentAcpBackend {
         &self,
         node: &Node,
         prompt: String,
+        thread_id: Option<&str>,
+        reuse_target: Option<AcpSessionReuseTarget>,
         emitter: &Arc<Emitter>,
         stage_scope: &StageScope,
         sandbox: &Arc<dyn Sandbox>,
@@ -75,6 +113,21 @@ impl AgentAcpBackend {
         let process_spec = resolve_acp_process_spec(node)?;
         let config_name = process_spec.name().map(str::to_string);
         let launch_env = self.resolve_launch_env(emitter).await?;
+        let cwd = sandbox.working_directory().to_string();
+        let fingerprint = AcpSessionFingerprint {
+            process_spec: process_spec.clone(),
+            cwd:          cwd.clone(),
+        };
+        let cached = self
+            .take_reusable_session(reuse_target.as_ref(), &fingerprint)
+            .await?;
+        let cache_key = cached.as_ref().map(|(key, _)| key.clone()).or_else(|| {
+            reuse_target
+                .as_ref()
+                .map(|target| target.primary_key.clone())
+        });
+        let cached_session = cached.map(|(_, session)| session);
+        let is_reused = cached_session.is_some();
         let on_activity = {
             let emitter = Arc::clone(emitter);
             Arc::new(move || emitter.touch()) as Arc<dyn Fn() + Send + Sync>
@@ -86,15 +139,20 @@ impl AgentAcpBackend {
                 visit:       stage_scope.visit,
                 command:     command_display,
                 config_name: config_name.clone(),
+                reused:      is_reused,
             },
             stage_scope,
         );
 
         let control_handle = AcpControlHandle::new();
-        let activation_session_id = format!("acp-{}", uuid::Uuid::new_v4());
+        let activation_session_id = cached_session.as_ref().map_or_else(
+            || format!("acp-{}", uuid::Uuid::new_v4()),
+            |session| session.activation_session_id.clone(),
+        );
         let activation_lease = self.activate_control_session(
             &control_handle,
             &activation_session_id,
+            thread_id,
             node,
             stage_scope,
             emitter,
@@ -139,23 +197,65 @@ impl AgentAcpBackend {
 
         let files_before = changed_files::detect_changed_files(sandbox).await;
         let launch_start = std::time::Instant::now();
-        let result = match fabro_acp::run_acp_turn(AcpRunRequest {
-            command: process_spec,
-            prompt,
-            cwd: sandbox.working_directory().to_string(),
-            timeout_ms: node.timeout().map(crate::millis_u64),
-            env: launch_env,
-            sandbox: Arc::clone(sandbox),
-            cancel_token: cancel_token.child_token(),
-            on_activity: Some(on_activity),
-            live_control: Some(AcpLiveControl {
-                handle: control_handle.clone(),
-                on_natural_completion,
-                on_steer_prompt,
-            }),
-        })
-        .await
-        {
+        let live_control = AcpLiveControl {
+            handle: control_handle.clone(),
+            on_natural_completion,
+            on_steer_prompt,
+        };
+        let mut session_to_cache = None;
+        let prompt_result = if let Some(key) = cache_key {
+            let reusable_session = if let Some(session) = cached_session {
+                session
+            } else {
+                let handle = fabro_acp::start_acp_session(AcpSessionStartRequest {
+                    command: process_spec,
+                    cwd:     cwd.clone(),
+                    env:     launch_env,
+                    sandbox: Arc::clone(sandbox),
+                })
+                .await
+                .map_err(acp_error_to_workflow)?;
+                AcpReusableSession {
+                    handle,
+                    fingerprint: fingerprint.clone(),
+                    activation_session_id: activation_session_id.clone(),
+                }
+            };
+            match reusable_session
+                .handle
+                .prompt(AcpPromptRequest {
+                    prompt,
+                    timeout_ms: node.timeout().map(crate::millis_u64),
+                    cancel_token: cancel_token.child_token(),
+                    on_activity: Some(on_activity),
+                    live_control: Some(live_control),
+                })
+                .await
+            {
+                Ok(result) => {
+                    session_to_cache = Some((key, reusable_session));
+                    Ok(result)
+                }
+                Err(error) => {
+                    let _ = reusable_session.handle.shutdown().await;
+                    Err(error)
+                }
+            }
+        } else {
+            fabro_acp::run_acp_turn(AcpRunRequest {
+                command: process_spec,
+                prompt,
+                cwd,
+                timeout_ms: node.timeout().map(crate::millis_u64),
+                env: launch_env,
+                sandbox: Arc::clone(sandbox),
+                cancel_token: cancel_token.child_token(),
+                on_activity: Some(on_activity),
+                live_control: Some(live_control),
+            })
+            .await
+        };
+        let result = match prompt_result {
             Ok(result) => {
                 emitter.emit_scoped(
                     &Event::AgentAcpCompleted {
@@ -228,6 +328,10 @@ impl AgentAcpBackend {
         let (files_touched, last_file_touched) =
             changed_files::files_touched_since(sandbox, &files_before).await;
 
+        if let Some((key, session)) = session_to_cache {
+            self.cache_reusable_session(key, session).await;
+        }
+
         Ok(CodergenResult::Text {
             text: result.text,
             usage: None,
@@ -258,10 +362,68 @@ impl AgentAcpBackend {
             .map_err(|err| Error::handler_with_anyhow("Failed to resolve ACP agent env", err))
     }
 
+    async fn take_reusable_session(
+        &self,
+        reuse_target: Option<&AcpSessionReuseTarget>,
+        fingerprint: &AcpSessionFingerprint,
+    ) -> Result<Option<(AcpSessionReuseKey, AcpReusableSession)>, Error> {
+        let Some(reuse_target) = reuse_target else {
+            return Ok(None);
+        };
+
+        if let Some(session) = self.remove_reusable_session(&reuse_target.primary_key) {
+            if &session.fingerprint == fingerprint {
+                return Ok(Some((reuse_target.primary_key.clone(), session)));
+            }
+
+            let _ = session.handle.shutdown().await;
+            return Err(acp_reuse_mismatch_error());
+        }
+
+        if let Some(fallback_key) = &reuse_target.fallback_key {
+            if let Some(session) = self.remove_reusable_session(fallback_key) {
+                if &session.fingerprint == fingerprint {
+                    return Ok(Some((fallback_key.clone(), session)));
+                }
+
+                let _ = session.handle.shutdown().await;
+                return Err(acp_reuse_mismatch_error());
+            }
+        }
+
+        Ok(None)
+    }
+
+    fn remove_reusable_session(
+        &self,
+        reuse_key: &AcpSessionReuseKey,
+    ) -> Option<AcpReusableSession> {
+        self.sessions
+            .lock()
+            .expect("ACP sessions mutex should not be poisoned")
+            .remove(reuse_key)
+    }
+
+    async fn cache_reusable_session(
+        &self,
+        reuse_key: AcpSessionReuseKey,
+        session: AcpReusableSession,
+    ) {
+        let replaced = self
+            .sessions
+            .lock()
+            .expect("ACP sessions mutex should not be poisoned")
+            .insert(reuse_key, session);
+        if let Some(replaced) = replaced {
+            let _ = replaced.handle.shutdown().await;
+        }
+    }
+
     fn activate_control_session(
         &self,
         handle: &AcpControlHandle,
         session_id: &str,
+        thread_id: Option<&str>,
         node: &Node,
         stage_scope: &StageScope,
         emitter: &Arc<Emitter>,
@@ -274,7 +436,7 @@ impl AgentAcpBackend {
             ActivationLeaseOptions {
                 stage_id:         StageId::new(node.id.clone(), stage_scope.visit),
                 session_id:       session_id.to_string(),
-                thread_id:        None,
+                thread_id:        thread_id.map(str::to_string),
                 provider:         Some(AgentBackend::Acp.to_string()),
                 model:            config_name.map(str::to_string),
                 reasoning_effort: None,
@@ -335,9 +497,22 @@ impl CodergenBackend for AgentAcpBackend {
             ));
         }
         let stage_scope = StageScope::for_handler(request.context, &request.node.id);
+        let thread_id = request.thread_id;
+        let reuse_target = if request.context.fidelity() == Fidelity::Full {
+            Some(resolve_reuse_target(
+                request.context,
+                &stage_scope,
+                request.node,
+                thread_id,
+            ))
+        } else {
+            None
+        };
         self.run_turn(
             request.node,
             request.prompt.to_string(),
+            thread_id,
+            reuse_target,
             request.emitter,
             &stage_scope,
             request.sandbox,
@@ -390,6 +565,43 @@ fn resolve_acp_process_spec(node: &Node) -> Result<AcpProcessSpec, Error> {
     .map_err(acp_process_error_to_workflow)
 }
 
+fn resolve_reuse_target(
+    context: &Context,
+    stage_scope: &StageScope,
+    node: &Node,
+    thread_id: Option<&str>,
+) -> AcpSessionReuseTarget {
+    let run_id = context.run_id();
+    let implicit_key = AcpSessionReuseKey::Implicit {
+        run_id:             run_id.clone(),
+        parallel_group_id:  stage_scope.parallel_group_id.clone(),
+        parallel_branch_id: stage_scope.parallel_branch_id.clone(),
+    };
+
+    if let Some(thread_id) = thread_id {
+        return AcpSessionReuseTarget {
+            primary_key:  AcpSessionReuseKey::Thread {
+                run_id,
+                thread_id: thread_id.to_string(),
+            },
+            fallback_key: node.thread_id().is_none().then_some(implicit_key),
+        };
+    }
+
+    AcpSessionReuseTarget {
+        primary_key:  implicit_key,
+        fallback_key: None,
+    }
+}
+
+fn acp_reuse_mismatch_error() -> Error {
+    Error::Validation(
+        "backend=\"acp\" full-fidelity session reuse requires matching ACP process configuration \
+         and working directory"
+            .to_string(),
+    )
+}
+
 fn acp_error_to_workflow(error: AcpError) -> Error {
     match error {
         AcpError::Cancelled => Error::Cancelled,
@@ -414,6 +626,7 @@ fn acp_error_to_workflow(error: AcpError) -> Error {
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
+    use std::path::Path;
     use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::{Arc, Mutex};
 
@@ -426,10 +639,67 @@ mod tests {
     use tokio_util::sync::CancellationToken;
 
     use super::{AgentAcpBackend, acp_error_to_workflow};
-    use crate::context::Context;
+    use crate::context::{Context, keys};
+    use crate::error::Error;
     use crate::event::Emitter;
     use crate::handler::agent::{CodergenBackend, CodergenResult, CodergenRunRequest};
     use crate::steering_hub::SteeringHub;
+
+    fn acp_node(id: &str, command: String) -> Node {
+        let mut node = Node::new(id);
+        node.attrs
+            .insert("backend".to_string(), AttrValue::String("acp".to_string()));
+        node.attrs
+            .insert("acp.command".to_string(), AttrValue::String(command));
+        node
+    }
+
+    fn fake_command(script_path: &Path) -> String {
+        format!("python3 {}", shell_quote(&script_path.to_string_lossy()))
+    }
+
+    fn full_context(run_id: &str) -> Context {
+        let context = Context::new();
+        context.set(keys::INTERNAL_FIDELITY, serde_json::json!("full"));
+        context.set(keys::INTERNAL_RUN_ID, serde_json::json!(run_id));
+        context
+    }
+
+    async fn run_backend_text(
+        backend: &AgentAcpBackend,
+        node: &Node,
+        prompt: &str,
+        context: &Context,
+        thread_id: Option<&str>,
+        emitter: &Arc<Emitter>,
+        sandbox: &Arc<dyn Sandbox>,
+    ) -> Result<String, Error> {
+        let result = backend
+            .run(CodergenRunRequest {
+                node,
+                prompt,
+                context,
+                thread_id,
+                emitter,
+                sandbox,
+                tool_hooks: None,
+                cancel_token: CancellationToken::new(),
+                agent_tool_runtime: fabro_agent::AgentToolRuntime::default(),
+            })
+            .await?;
+        let CodergenResult::Text { text, .. } = result else {
+            panic!("expected text result");
+        };
+        Ok(text)
+    }
+
+    async fn recorded_pid_count(path: &Path) -> usize {
+        tokio::fs::read_to_string(path)
+            .await
+            .unwrap_or_default()
+            .lines()
+            .count()
+    }
 
     #[tokio::test]
     async fn acp_backend_run_sends_prompt_and_returns_text() {
@@ -483,6 +753,200 @@ mod tests {
         };
         assert_eq!(text, "hello from acp");
         assert_eq!(files_touched, vec!["hello.txt"]);
+    }
+
+    #[tokio::test]
+    async fn acp_backend_full_fidelity_reuses_implicit_session_without_thread_id() {
+        let tempdir = tempfile::tempdir().unwrap();
+        init_git(tempdir.path());
+        let script_path = tempdir.path().join("fake_acp_agent.py");
+        let pid_path = tempdir.path().join("agent-pids.txt");
+        tokio::fs::write(&script_path, fake_acp_agent_script())
+            .await
+            .unwrap();
+
+        let node_a = acp_node("plan", fake_command(&script_path));
+        let node_b = acp_node("code", fake_command(&script_path));
+        let backend = AgentAcpBackend::new().with_env(HashMap::from([
+            ("ACP_MODE".to_string(), "echo_prompt_count".to_string()),
+            (
+                "ACP_PID_RECORD_APPEND".to_string(),
+                pid_path.to_string_lossy().into_owned(),
+            ),
+        ]));
+        let sandbox: Arc<dyn Sandbox> = Arc::new(LocalSandbox::new(tempdir.path().to_path_buf()));
+        let emitter = Arc::new(Emitter::default());
+        let events = Arc::new(Mutex::new(Vec::new()));
+        emitter.on_event({
+            let events = Arc::clone(&events);
+            move |event| events.lock().unwrap().push(event.clone())
+        });
+        let context = full_context("run-full-implicit");
+
+        let first = run_backend_text(
+            &backend, &node_a, "first", &context, None, &emitter, &sandbox,
+        )
+        .await
+        .unwrap();
+        let second = run_backend_text(
+            &backend,
+            &node_b,
+            "second",
+            &context,
+            Some("plan"),
+            &emitter,
+            &sandbox,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(first, "1:first");
+        assert_eq!(second, "2:second");
+        assert_eq!(recorded_pid_count(&pid_path).await, 1);
+
+        let reused_flags: Vec<bool> = events
+            .lock()
+            .unwrap()
+            .iter()
+            .filter_map(|event| match &event.body {
+                EventBody::AgentAcpStarted(props) => Some(props.reused),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(reused_flags, vec![false, true]);
+    }
+
+    #[tokio::test]
+    async fn acp_backend_full_fidelity_thread_id_targets_distinct_sessions() {
+        let tempdir = tempfile::tempdir().unwrap();
+        init_git(tempdir.path());
+        let script_path = tempdir.path().join("fake_acp_agent.py");
+        let pid_path = tempdir.path().join("agent-pids.txt");
+        tokio::fs::write(&script_path, fake_acp_agent_script())
+            .await
+            .unwrap();
+
+        let node = acp_node("work", fake_command(&script_path));
+        let backend = AgentAcpBackend::new().with_env(HashMap::from([
+            ("ACP_MODE".to_string(), "echo_prompt_count".to_string()),
+            (
+                "ACP_PID_RECORD_APPEND".to_string(),
+                pid_path.to_string_lossy().into_owned(),
+            ),
+        ]));
+        let sandbox: Arc<dyn Sandbox> = Arc::new(LocalSandbox::new(tempdir.path().to_path_buf()));
+        let emitter = Arc::new(Emitter::default());
+        let context = full_context("run-full-threads");
+
+        let alpha_first = run_backend_text(
+            &backend,
+            &node,
+            "alpha-one",
+            &context,
+            Some("alpha"),
+            &emitter,
+            &sandbox,
+        )
+        .await
+        .unwrap();
+        let beta_first = run_backend_text(
+            &backend,
+            &node,
+            "beta-one",
+            &context,
+            Some("beta"),
+            &emitter,
+            &sandbox,
+        )
+        .await
+        .unwrap();
+        let alpha_second = run_backend_text(
+            &backend,
+            &node,
+            "alpha-two",
+            &context,
+            Some("alpha"),
+            &emitter,
+            &sandbox,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(alpha_first, "1:alpha-one");
+        assert_eq!(beta_first, "1:beta-one");
+        assert_eq!(alpha_second, "2:alpha-two");
+        assert_eq!(recorded_pid_count(&pid_path).await, 2);
+    }
+
+    #[tokio::test]
+    async fn acp_backend_full_fidelity_mismatch_discards_cached_session() {
+        let tempdir = tempfile::tempdir().unwrap();
+        init_git(tempdir.path());
+        let script_path = tempdir.path().join("fake_acp_agent.py");
+        let pid_path = tempdir.path().join("agent-pids.txt");
+        tokio::fs::write(&script_path, fake_acp_agent_script())
+            .await
+            .unwrap();
+
+        let command = fake_command(&script_path);
+        let matching_node = acp_node("work", command.clone());
+        let mismatched_node = acp_node("work", format!("{command} --different"));
+        let backend = AgentAcpBackend::new().with_env(HashMap::from([
+            ("ACP_MODE".to_string(), "echo_prompt_count".to_string()),
+            (
+                "ACP_PID_RECORD_APPEND".to_string(),
+                pid_path.to_string_lossy().into_owned(),
+            ),
+        ]));
+        let sandbox: Arc<dyn Sandbox> = Arc::new(LocalSandbox::new(tempdir.path().to_path_buf()));
+        let emitter = Arc::new(Emitter::default());
+        let context = full_context("run-full-mismatch");
+
+        let first = run_backend_text(
+            &backend,
+            &matching_node,
+            "first",
+            &context,
+            Some("shared"),
+            &emitter,
+            &sandbox,
+        )
+        .await
+        .unwrap();
+        let mismatch = run_backend_text(
+            &backend,
+            &mismatched_node,
+            "second",
+            &context,
+            Some("shared"),
+            &emitter,
+            &sandbox,
+        )
+        .await;
+        let third = run_backend_text(
+            &backend,
+            &matching_node,
+            "third",
+            &context,
+            Some("shared"),
+            &emitter,
+            &sandbox,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(first, "1:first");
+        let Err(error) = mismatch else {
+            panic!("expected full-fidelity process mismatch to fail");
+        };
+        assert!(
+            error
+                .to_string()
+                .contains("requires matching ACP process configuration"),
+            "unexpected error: {error}"
+        );
+        assert_eq!(third, "1:third");
+        assert_eq!(recorded_pid_count(&pid_path).await, 2);
     }
 
     #[tokio::test]

--- a/lib/crates/fabro-workflow/src/operations/fork.rs
+++ b/lib/crates/fabro-workflow/src/operations/fork.rs
@@ -336,6 +336,7 @@ mod tests {
                 visit:       1,
                 command:     "python fake_agent.py".to_string(),
                 config_name: Some("fake".to_string()),
+                reused:      false,
             })
         ));
         assert!(replay_event_for_fork_projection(


### PR DESCRIPTION
## Summary

- Adds a reusable ACP session handle that keeps the initialized ACP process/session alive across prompts.
- Enables `backend="acp"` agent nodes with resolved `fidelity="full"` to reuse sessions by explicit `thread_id`, or by an implicit run/parallel-branch scoped key when no explicit thread is set.
- Discards reusable ACP sessions on timeout, cancellation, protocol/process errors, and process-config mismatches.
- Adds `agent.acp.started.properties.reused` for observability.
- Adds validation for statically-detectable full-fidelity ACP nodes sharing an explicit/default `thread_id` with mismatched ACP process configuration.

Closes #514.

## Testing

- `cargo check -p fabro-acp`
- `cargo check -p fabro-workflow`
- `cargo check -p fabro-validate`
- `cargo check -p fabro-server`
- `cargo test -p fabro-validate backend_valid`
- `cargo test -p fabro-workflow acp_backend_full_fidelity`
- `cargo test -p fabro-acp`
- `cargo test -p fabro-workflow handler::llm::acp::tests`
- `cargo +nightly-2026-04-14 fmt --check --all`
- `cargo +nightly-2026-04-14 clippy -p fabro-acp -p fabro-workflow -p fabro-validate -p fabro-server --all-targets -- -D warnings`