### PR TITLE
feat(sandbox): forkd Firecracker microVM provider

### DIFF
--- a/lib/crates/fabro-agent/Cargo.toml
+++ b/lib/crates/fabro-agent/Cargo.toml
@@ -13,6 +13,7 @@ categories = ["api-bindings"]
 [features]
 default = ["docker"]
 docker = ["fabro-sandbox/docker"]
+forkd = ["fabro-sandbox/forkd"]
 quarantine = []
 
 [lib]

--- a/lib/crates/fabro-cli/Cargo.toml
+++ b/lib/crates/fabro-cli/Cargo.toml
@@ -13,6 +13,7 @@ path = "src/main.rs"
 [features]
 default = []
 sleep_inhibitor = ["dep:core-foundation"]
+forkd = ["fabro-sandbox/forkd", "fabro-agent/forkd"]
 
 [lints]
 workspace = true

--- a/lib/crates/fabro-cli/Cargo.toml
+++ b/lib/crates/fabro-cli/Cargo.toml
@@ -13,7 +13,7 @@ path = "src/main.rs"
 [features]
 default = []
 sleep_inhibitor = ["dep:core-foundation"]
-forkd = ["fabro-sandbox/forkd", "fabro-agent/forkd"]
+forkd = ["fabro-sandbox/forkd", "fabro-agent/forkd", "fabro-workflow/forkd"]
 
 [lints]
 workspace = true

--- a/lib/crates/fabro-config/src/layers/server.rs
+++ b/lib/crates/fabro-config/src/layers/server.rs
@@ -108,6 +108,8 @@ pub struct ServerSandboxProvidersLayer {
     pub docker:  Option<ServerSandboxProviderLayer>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub daytona: Option<ServerSandboxProviderLayer>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub forkd:   Option<ServerSandboxProviderLayer>,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize, fabro_macros::Combine)]

--- a/lib/crates/fabro-config/src/resolve/environment.rs
+++ b/lib/crates/fabro-config/src/resolve/environment.rs
@@ -243,5 +243,7 @@ fn validate_provider_capabilities(
             }
         }
         EnvironmentProvider::Daytona => {}
+        // Forkd microVMs are full VMs and can enforce any network mode.
+        EnvironmentProvider::Forkd => {}
     }
 }

--- a/lib/crates/fabro-config/src/resolve/server.rs
+++ b/lib/crates/fabro-config/src/resolve/server.rs
@@ -79,6 +79,9 @@ fn resolve_sandbox(layer: Option<&ServerSandboxLayer>) -> ServerSandboxSettings 
             daytona: resolve_sandbox_provider(
                 providers.and_then(|providers| providers.daytona.as_ref()),
             ),
+            forkd:   resolve_sandbox_provider(
+                providers.and_then(|providers| providers.forkd.as_ref()),
+            ),
         },
     }
 }

--- a/lib/crates/fabro-environment/src/store.rs
+++ b/lib/crates/fabro-environment/src/store.rs
@@ -57,6 +57,17 @@ preserve = false
 stop_on_terminal = true
 "#;
 
+const FORKD_DEFAULT_ENVIRONMENT_TOML: &str = r#"provider = "forkd"
+
+[resources]
+cpu = 2
+memory = "4GB"
+
+[lifecycle]
+preserve = false
+stop_on_terminal = true
+"#;
+
 const LOCAL_ENVIRONMENT_TOML: &str = r#"provider = "local"
 "#;
 
@@ -292,6 +303,7 @@ pub fn seed_default_environment(
     let content = match provider {
         EnvironmentProvider::Docker => DEFAULT_ENVIRONMENT_TOML,
         EnvironmentProvider::Daytona => DAYTONA_DEFAULT_ENVIRONMENT_TOML,
+        EnvironmentProvider::Forkd => FORKD_DEFAULT_ENVIRONMENT_TOML,
         EnvironmentProvider::Local => LOCAL_ENVIRONMENT_TOML,
     };
     let path = dir.join(format!("{DEFAULT_ENVIRONMENT_ID}.toml"));

--- a/lib/crates/fabro-environment/src/store.rs
+++ b/lib/crates/fabro-environment/src/store.rs
@@ -40,6 +40,9 @@ pub fn seeded_catalog_layer() -> MergeMap<EnvironmentLayer> {
     let local: EnvironmentLayer = toml::from_str(LOCAL_ENVIRONMENT_TOML)
         .expect("built-in local environment seed should parse");
     catalog.insert(RESERVED_LOCAL_ID.to_string(), local);
+    let forkd: EnvironmentLayer = toml::from_str(FORKD_DEFAULT_ENVIRONMENT_TOML)
+        .expect("built-in forkd environment seed should parse");
+    catalog.insert("forkd".to_string(), forkd);
     MergeMap::from(catalog)
 }
 

--- a/lib/crates/fabro-install/src/lib.rs
+++ b/lib/crates/fabro-install/src/lib.rs
@@ -479,6 +479,8 @@ fn write_sandbox_provider_policy(
             SandboxProviderKind::Local => allow_local,
             SandboxProviderKind::Docker => selection == InstallSandboxSelection::Docker,
             SandboxProviderKind::Daytona => selection == InstallSandboxSelection::Daytona,
+            // Forkd is configured via settings/env, not the install wizard.
+            SandboxProviderKind::Forkd => false,
         };
         let entry = ensure_table(providers, &provider.to_string())?;
         entry.insert("enabled".to_string(), toml::Value::Boolean(enabled));

--- a/lib/crates/fabro-sandbox/Cargo.toml
+++ b/lib/crates/fabro-sandbox/Cargo.toml
@@ -11,6 +11,7 @@ default = ["local"]
 local = []
 docker = ["dep:bollard", "dep:tar", "dep:fabro-github"]
 daytona = ["dep:daytona-sdk", "dep:daytona-api-client", "dep:git2", "dep:fabro-github", "dep:fabro-config", "dep:fabro-http", "dep:reqwest-middleware", "dep:rand", "dep:tokio-tungstenite", "dep:futures-util", "dep:rustls"]
+forkd = ["dep:reqwest", "dep:rand"]
 test-support = []
 
 [lib]
@@ -62,6 +63,7 @@ daytona-sdk = { workspace = true, optional = true }
 daytona-api-client = { workspace = true, optional = true }
 git2 = { workspace = true, optional = true }
 fabro-http = { workspace = true, optional = true }
+reqwest = { workspace = true, features = ["json"], optional = true }
 reqwest-middleware = { version = "0.5", features = ["json", "multipart", "form", "query"], optional = true }
 tokio-tungstenite = { workspace = true, optional = true }
 futures-util = { workspace = true, optional = true }

--- a/lib/crates/fabro-sandbox/src/config.rs
+++ b/lib/crates/fabro-sandbox/src/config.rs
@@ -159,15 +159,41 @@ pub enum ForkdNetwork {
 /// [`crate::forkd::ForkdConfig`] and is resolved from environment variables
 /// at provider construction time — it is not part of this per-run slice.
 #[cfg(feature = "forkd")]
-#[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct ForkdSettings {
-    /// VM image, kernel, memory, and package settings.
+    /// forkd snapshot tag to boot from (e.g. `"zen-gate-base"`).
+    /// Resolved from `FORKD_SNAPSHOT_TAG` env var; default `"zen-gate-base"`.
+    #[serde(default = "ForkdSettings::default_snapshot_tag")]
+    pub snapshot_tag:       String,
+    /// Legacy VM image/kernel/memory settings — retained for deserialization
+    /// backward compatibility.  Not sent to the forkd 0.5.2 API.
     pub snapshot:           Option<ForkdSnapshotSettings>,
-    /// Network isolation policy for the guest VM.
+    /// Legacy network isolation policy — retained for deserialization backward
+    /// compatibility.  Not sent to the forkd 0.5.2 API.
     pub network:            Option<ForkdNetwork>,
     /// Skip the repository clone step during `initialize()`.
     #[serde(default)]
     pub skip_clone:         bool,
     /// Auto-stop interval in minutes (`None` means no auto-stop).
     pub auto_stop_minutes:  Option<i32>,
+}
+
+#[cfg(feature = "forkd")]
+impl ForkdSettings {
+    fn default_snapshot_tag() -> String {
+        crate::forkd::DEFAULT_SNAPSHOT_TAG.to_string()
+    }
+}
+
+#[cfg(feature = "forkd")]
+impl Default for ForkdSettings {
+    fn default() -> Self {
+        Self {
+            snapshot_tag:      Self::default_snapshot_tag(),
+            snapshot:          None,
+            network:           None,
+            skip_clone:        false,
+            auto_stop_minutes: None,
+        }
+    }
 }

--- a/lib/crates/fabro-sandbox/src/config.rs
+++ b/lib/crates/fabro-sandbox/src/config.rs
@@ -121,3 +121,53 @@ pub struct DaytonaSnapshotSettings {
     pub disk:       Option<i32>,
     pub dockerfile: Option<DockerfileSource>,
 }
+
+// ---------------------------------------------------------------------------
+// Forkd microVM sandbox configuration types
+// ---------------------------------------------------------------------------
+
+/// Per-VM image and resource settings for a Forkd sandbox.
+#[cfg(feature = "forkd")]
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
+pub struct ForkdSnapshotSettings {
+    /// OCI image name for the microVM rootfs, e.g. "python:3.12-slim".
+    pub image:          Option<String>,
+    /// Path to the vmlinux kernel blob on the forkd host; resolved from
+    /// `FORKD_KERNEL` env var when absent.
+    pub kernel:         Option<String>,
+    /// Guest memory in MiB; the forkd controller default is 1536.
+    pub mem_mib:        Option<u32>,
+    /// Comma-separated list of extra apt packages to install at VM boot.
+    pub extra_packages: Option<String>,
+}
+
+/// Network isolation mode for a Forkd microVM.
+#[cfg(feature = "forkd")]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum ForkdNetwork {
+    /// Block all outbound traffic (default).
+    Block,
+    /// Allow all outbound traffic.
+    AllowAll,
+    /// Allow only the specified CIDR ranges.
+    AllowList(Vec<String>),
+}
+
+/// Per-sandbox runtime configuration passed in `SandboxCreateSpec::Forkd`.
+///
+/// Server-level connectivity (`forkd_url`, `forkd_token`) lives on
+/// [`crate::forkd::ForkdConfig`] and is resolved from environment variables
+/// at provider construction time — it is not part of this per-run slice.
+#[cfg(feature = "forkd")]
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
+pub struct ForkdSettings {
+    /// VM image, kernel, memory, and package settings.
+    pub snapshot:           Option<ForkdSnapshotSettings>,
+    /// Network isolation policy for the guest VM.
+    pub network:            Option<ForkdNetwork>,
+    /// Skip the repository clone step during `initialize()`.
+    #[serde(default)]
+    pub skip_clone:         bool,
+    /// Auto-stop interval in minutes (`None` means no auto-stop).
+    pub auto_stop_minutes:  Option<i32>,
+}

--- a/lib/crates/fabro-sandbox/src/details.rs
+++ b/lib/crates/fabro-sandbox/src/details.rs
@@ -41,6 +41,13 @@ pub async fn sandbox_details(
             "Sandbox provider '{}' has no details implementation",
             record.provider
         )),
+        #[cfg(feature = "forkd")]
+        SandboxProviderKind::Forkd => Ok(forkd::forkd_details(record)),
+        #[cfg(not(feature = "forkd"))]
+        SandboxProviderKind::Forkd => Err(anyhow::anyhow!(
+            "Sandbox provider '{}' has no details implementation",
+            record.provider
+        )),
     }
 }
 
@@ -802,6 +809,59 @@ pub(crate) mod daytona {
             let network = daytona_network(false, None);
             assert_eq!(network.egress, SandboxNetworkPolicy::open());
             assert_eq!(network.ingress, SandboxNetworkPolicy::blocked());
+        }
+    }
+}
+
+#[cfg(feature = "forkd")]
+pub(crate) mod forkd {
+    use std::collections::BTreeMap;
+
+    use fabro_types::{
+        RunSandboxInstance, SandboxInfo, SandboxNetwork, SandboxProviderKind, SandboxResources,
+        SandboxState, SandboxTimestamps,
+    };
+
+    use crate::forkd::WORKING_DIRECTORY;
+
+    /// Build a minimal [`SandboxInfo`] for a named forkd VM.
+    ///
+    /// The forkd REST API does not expose resource or timestamp metadata in its
+    /// VM list response, so non-identity fields default to "unknown".
+    pub(crate) fn forkd_info_from_name(name: &str) -> SandboxInfo {
+        SandboxInfo {
+            provider:          SandboxProviderKind::Forkd,
+            id:                name.to_string(),
+            display_name:      Some(name.to_string()),
+            state:             SandboxState::Running,
+            native_state:      None,
+            image:             None,
+            snapshot:          None,
+            region:            None,
+            web_url:           None,
+            working_directory: Some(WORKING_DIRECTORY.to_string()),
+            resources:         SandboxResources::default(),
+            network:           SandboxNetwork::unknown(),
+            labels:            BTreeMap::new(),
+            timestamps:        SandboxTimestamps::default(),
+        }
+    }
+
+    /// Build minimal `SandboxDetails` for a forkd sandbox from its persisted
+    /// runtime record.
+    pub(super) fn forkd_details(
+        record: &RunSandboxInstance,
+    ) -> fabro_types::SandboxDetails {
+        fabro_types::SandboxDetails {
+            sandbox:      record.clone(),
+            state:        SandboxState::Running,
+            native_state: None,
+            region:       None,
+            web_url:      None,
+            resources:    SandboxResources::default(),
+            network:      SandboxNetwork::unknown(),
+            labels:       BTreeMap::new(),
+            timestamps:   SandboxTimestamps::default(),
         }
     }
 }

--- a/lib/crates/fabro-sandbox/src/forkd/mod.rs
+++ b/lib/crates/fabro-sandbox/src/forkd/mod.rs
@@ -1,12 +1,12 @@
 //! Forkd Firecracker microVM sandbox implementation.
 //!
-//! One long-lived VM per sandbox:
-//! - Created in `initialize()` via `POST /vms`.
-//! - Destroyed in `cleanup()` via `DELETE /vms/{name}`.
+//! One long-lived sandbox per run:
+//! - Created in `initialize()` via `POST /v1/sandboxes`.
+//! - Destroyed in `cleanup()` via `DELETE /v1/sandboxes/{id}`.
 //! - All file I/O goes through exec (base64 round-trips for binary safety).
-//! - Controller URL and bearer token are never hardcoded — they come from
-//!   `FORKD_URL` / `FORKD_TOKEN` environment variables resolved at provider
-//!   construction time.
+//! - Controller URL, bearer token, and snapshot tag are never hardcoded —
+//!   they come from `FORKD_URL` / `FORKD_TOKEN` / `FORKD_SNAPSHOT_TAG`
+//!   environment variables resolved at provider construction time.
 
 use std::collections::HashMap;
 use std::path::Path;
@@ -36,6 +36,9 @@ pub(crate) const REPOS_ROOT: &str = "/home/fabro/repos";
 /// Provider name string for event payloads.
 const PROVIDER: &str = "forkd";
 
+/// Default snapshot tag used when `FORKD_SNAPSHOT_TAG` is not set.
+pub const DEFAULT_SNAPSHOT_TAG: &str = "zen-gate-base";
+
 /// Maximum number of retry attempts for transient HTTP failures (5xx / connect).
 const HTTP_RETRY_LIMIT: u32 = 3;
 /// Initial backoff before the first retry.
@@ -55,7 +58,7 @@ pub struct ForkdConfig {
     /// Bearer token for the forkd controller API.
     /// NEVER include the real value in log output — use `[redacted]`.
     pub forkd_token: String,
-    /// Per-sandbox runtime settings (image, memory, network, skip_clone).
+    /// Per-sandbox runtime settings (snapshot_tag, skip_clone, etc.).
     pub settings:    ForkdSettings,
 }
 
@@ -85,28 +88,53 @@ impl Default for ForkdConfig {
 // forkd REST API request/response shapes (forkd 0.5.2)
 // ---------------------------------------------------------------------------
 
+/// `POST /v1/sandboxes` request body.
 #[derive(Debug, Serialize)]
-struct CreateVmRequest {
-    name:    String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    image:   Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    kernel:  Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    mem_mib: Option<u32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    network: Option<String>,
+struct CreateSandboxRequest {
+    snapshot_tag: String,
 }
 
+/// A single sandbox entry returned inside the array from `POST /v1/sandboxes`.
+#[derive(Debug, Deserialize)]
+struct SandboxEntry {
+    id: String,
+    /// The snapshot tag that was actually used by the server (may differ from
+    /// the requested tag if the server resolved an alias).
+    #[serde(default)]
+    snapshot_tag: Option<String>,
+}
+
+/// Defensive response shape for `POST /v1/sandboxes`.
+///
+/// The forkd 0.5.2 spec returns a JSON array; the untagged enum lets us also
+/// accept a bare object in case of a single-element regression in the server.
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum CreateSandboxResponse {
+    Array(Vec<SandboxEntry>),
+    Single(SandboxEntry),
+}
+
+impl CreateSandboxResponse {
+    fn into_first(self) -> Option<SandboxEntry> {
+        match self {
+            Self::Array(mut v) => {
+                if v.is_empty() { None } else { Some(v.remove(0)) }
+            }
+            Self::Single(entry) => Some(entry),
+        }
+    }
+}
+
+/// `POST /v1/sandboxes/{id}/exec` request body.
+///
+/// forkd exec is ARGV-ONLY — there is no `working_dir`, `env`, or `command`
+/// string field.  Callers that need cwd/env must fold them into the argv via
+/// `["sh", "-lc", "cd <dir> && export K=V; <cmd>"]`.
 #[derive(Debug, Serialize)]
 struct ExecRequest {
-    command:     String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    working_dir: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    timeout_ms:  Option<u64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    env:         Option<HashMap<String, String>>,
+    args:         Vec<String>,
+    timeout_secs: u64,
 }
 
 #[derive(Debug, Deserialize)]
@@ -123,10 +151,13 @@ struct ExecResponse {
 /// A sandbox backed by a single Firecracker microVM managed via forkd.
 pub struct ForkdSandbox {
     config:           ForkdConfig,
-    vm_name:          String,
     run_id:           Option<RunId>,
     clone_origin_url: Option<String>,
     clone_branch:     Option<String>,
+    /// The server-assigned sandbox id, populated after a successful `create_sandbox()`.
+    sandbox_id:       OnceCell<String>,
+    /// The snapshot tag reported by the server (may differ from the requested tag).
+    active_snapshot:  OnceCell<String>,
     /// Populated after a successful `initialize()`.
     initialized:      OnceCell<bool>,
     origin_url:       OnceCell<String>,
@@ -142,30 +173,22 @@ impl ForkdSandbox {
         clone_origin_url: Option<String>,
         clone_branch: Option<String>,
     ) -> Self {
-        let vm_name = if let Some(ref id) = run_id {
-            format!("fabro-{id}")
-        } else {
-            format!(
-                "fabro-{}-{:04x}",
-                chrono::Utc::now().format("%Y%m%d-%H%M%S"),
-                rand::rng().random_range(0..0x10000u32),
-            )
-        };
         Self {
             config,
-            vm_name,
             run_id,
             clone_origin_url,
             clone_branch,
-            initialized:    OnceCell::new(),
-            origin_url:     OnceCell::new(),
-            event_callback: None,
+            sandbox_id:      OnceCell::new(),
+            active_snapshot: OnceCell::new(),
+            initialized:     OnceCell::new(),
+            origin_url:      OnceCell::new(),
+            event_callback:  None,
         }
     }
 
-    /// The name of the VM that will be (or was) created.
-    pub fn vm_name(&self) -> &str {
-        &self.vm_name
+    /// The server-assigned sandbox id (available after `initialize()`).
+    pub fn sandbox_id(&self) -> Option<&str> {
+        self.sandbox_id.get().map(String::as_str)
     }
 
     /// Attach a callback that receives [`SandboxEvent`]s.
@@ -187,7 +210,7 @@ impl ForkdSandbox {
     fn http_client(&self) -> crate::Result<reqwest::Client> {
         reqwest::Client::builder()
             // Hard cap on individual HTTP requests to the forkd controller.
-            // Exec calls use a per-request timeout via ExecRequest.timeout_ms;
+            // Exec calls use a per-request timeout via ExecRequest.timeout_secs;
             // this is a safety net for connect + response-header receipt.
             .timeout(std::time::Duration::from_secs(120))
             .connect_timeout(std::time::Duration::from_secs(15))
@@ -205,27 +228,62 @@ impl ForkdSandbox {
         status.is_server_error()
     }
 
-    /// Execute a shell command in the VM.  Returns the raw `ExecResponse`
+    /// Build the argv for a shell-wrapped command that folds cwd and env vars
+    /// into a single `sh -lc` invocation.
+    ///
+    /// forkd exec is argv-only; working_dir and env must be inlined here.
+    /// Env key names are validated: only `[A-Za-z_][A-Za-z0-9_]*` are accepted
+    /// to prevent injection via malicious key names.
+    fn build_exec_argv(
+        command: &str,
+        working_dir: &str,
+        env_vars: Option<&HashMap<String, String>>,
+    ) -> Vec<String> {
+        let mut shell_body = format!("cd {} && ", shell_quote(working_dir));
+
+        if let Some(vars) = env_vars {
+            let mut sorted: Vec<(&String, &String)> = vars.iter().collect();
+            sorted.sort_by_key(|(k, _)| k.as_str());
+            for (key, value) in sorted {
+                // Safety: skip env keys that are not valid identifier names to
+                // prevent shell injection via a crafted key.
+                if key.chars().enumerate().all(|(i, c)| {
+                    if i == 0 { c.is_ascii_alphabetic() || c == '_' }
+                    else { c.is_ascii_alphanumeric() || c == '_' }
+                }) {
+                    shell_body.push_str(&format!("export {}={} && ", key, shell_quote(value)));
+                } else {
+                    tracing::warn!(key, "forkd: skipping env var with non-identifier key");
+                }
+            }
+        }
+
+        shell_body.push_str(command);
+
+        vec![
+            "sh".to_string(),
+            "-lc".to_string(),
+            shell_body,
+        ]
+    }
+
+    /// Execute an argv inside the sandbox.  Returns the raw `ExecResponse`
     /// so the caller decides how to interpret exit code / output.
     ///
     /// Transient HTTP errors (connect failures and 5xx responses) are retried
     /// up to `HTTP_RETRY_LIMIT` times with exponential back-off.
-    async fn exec_in_vm(
+    async fn exec_in_sandbox(
         &self,
-        command: &str,
-        timeout_ms: Option<u64>,
-        working_dir: Option<&str>,
-        env_vars: Option<&HashMap<String, String>>,
+        args: Vec<String>,
+        timeout_secs: u64,
     ) -> crate::Result<ExecResponse> {
-        let client = self.http_client()?;
-        let url = format!("{}/vms/{}/exec", self.config.forkd_url, self.vm_name);
+        let id = self.sandbox_id.get().ok_or_else(|| {
+            crate::Error::message("forkd sandbox not yet initialized (no sandbox id)")
+        })?;
 
-        let body = ExecRequest {
-            command:     command.to_string(),
-            working_dir: working_dir.map(str::to_string),
-            timeout_ms,
-            env:         env_vars.cloned(),
-        };
+        let client = self.http_client()?;
+        let url = format!("{}/v1/sandboxes/{}/exec", self.config.forkd_url, id);
+        let body = ExecRequest { args, timeout_secs };
 
         let mut backoff = HTTP_RETRY_INITIAL_BACKOFF;
         let mut attempt = 0u32;
@@ -279,31 +337,33 @@ impl ForkdSandbox {
         }
     }
 
-    /// Create the VM via `POST /vms`.
+    /// A convenience wrapper used internally for simple shell commands that do
+    /// not need cwd/env folding (e.g. mkdir, clone, base64 reads/writes).
+    ///
+    /// Uses `sh -lc` with a default cwd of `/` so the caller can use absolute
+    /// paths without worrying about the initial working directory.
+    async fn exec_shell(
+        &self,
+        command: &str,
+        timeout_secs: u64,
+    ) -> crate::Result<ExecResponse> {
+        let args = vec![
+            "sh".to_string(),
+            "-lc".to_string(),
+            command.to_string(),
+        ];
+        self.exec_in_sandbox(args, timeout_secs).await
+    }
+
+    /// Create the sandbox via `POST /v1/sandboxes`.
     ///
     /// Transient HTTP errors are retried up to `HTTP_RETRY_LIMIT` times.
-    async fn create_vm(&self) -> crate::Result<()> {
+    /// On success, stores the server-assigned sandbox id in `self.sandbox_id`.
+    async fn create_sandbox(&self) -> crate::Result<()> {
         let client = self.http_client()?;
-        let url = format!("{}/vms", self.config.forkd_url);
-
-        let snap = self.config.settings.snapshot.as_ref();
-        let network_str = self
-            .config
-            .settings
-            .network
-            .as_ref()
-            .map(|n| match n {
-                crate::config::ForkdNetwork::Block => "block".to_string(),
-                crate::config::ForkdNetwork::AllowAll => "allow_all".to_string(),
-                crate::config::ForkdNetwork::AllowList(_) => "allow_all".to_string(), // list enforced by iptables inside VM
-            });
-
-        let body = CreateVmRequest {
-            name:    self.vm_name.clone(),
-            image:   snap.and_then(|s| s.image.clone()),
-            kernel:  snap.and_then(|s| s.kernel.clone()),
-            mem_mib: snap.and_then(|s| s.mem_mib),
-            network: network_str,
+        let url = format!("{}/v1/sandboxes", self.config.forkd_url);
+        let body = CreateSandboxRequest {
+            snapshot_tag: self.config.settings.snapshot_tag.clone(),
         };
 
         let mut backoff = HTTP_RETRY_INITIAL_BACKOFF;
@@ -317,13 +377,32 @@ impl ForkdSandbox {
                 .await;
 
             match result {
-                Ok(resp) if resp.status().is_success() => return Ok(()),
+                Ok(resp) if resp.status().is_success() => {
+                    let parsed = resp
+                        .json::<CreateSandboxResponse>()
+                        .await
+                        .map_err(|e| crate::Error::context("Failed to parse forkd create response", e))?;
+
+                    let entry = parsed.into_first().ok_or_else(|| {
+                        crate::Error::message("forkd create returned empty array")
+                    })?;
+
+                    self.sandbox_id
+                        .set(entry.id)
+                        .map_err(|_| crate::Error::message("forkd sandbox_id already set (double-init?)"))?;
+
+                    if let Some(tag) = entry.snapshot_tag {
+                        let _ = self.active_snapshot.set(tag);
+                    }
+
+                    return Ok(());
+                }
                 Ok(resp) if Self::is_retryable_status(resp.status()) && attempt < HTTP_RETRY_LIMIT => {
                     let status = resp.status();
                     tracing::warn!(
                         attempt,
                         status = status.as_u16(),
-                        "forkd create_vm transient error; retrying"
+                        "forkd create_sandbox transient error; retrying"
                     );
                     attempt += 1;
                     sleep(backoff).await;
@@ -333,32 +412,39 @@ impl ForkdSandbox {
                     let status = resp.status();
                     let text = resp.text().await.unwrap_or_default();
                     return Err(crate::Error::message(format!(
-                        "forkd create VM returned {status}: {text}"
+                        "forkd create sandbox returned {status}: {text}"
                     )));
                 }
                 Err(e) if e.is_connect() && attempt < HTTP_RETRY_LIMIT => {
                     tracing::warn!(
                         attempt,
                         error = %e,
-                        "forkd create_vm connect error; retrying"
+                        "forkd create_sandbox connect error; retrying"
                     );
                     attempt += 1;
                     sleep(backoff).await;
                     backoff = (backoff * 2).min(Duration::from_secs(10));
                 }
                 Err(e) => {
-                    return Err(crate::Error::context("forkd create VM HTTP request failed", e));
+                    return Err(crate::Error::context("forkd create sandbox HTTP request failed", e));
                 }
             }
         }
     }
 
-    /// Delete the VM via `DELETE /vms/{name}`.
+    /// Delete the sandbox via `DELETE /v1/sandboxes/{id}`.
     ///
+    /// 404 is treated as "already gone" and returns `Ok(())`.
     /// Transient HTTP errors are retried up to `HTTP_RETRY_LIMIT` times.
-    async fn delete_vm(&self) -> crate::Result<()> {
+    async fn delete_sandbox(&self) -> crate::Result<()> {
+        let id = match self.sandbox_id.get() {
+            Some(id) => id,
+            // Never initialized — nothing to delete.
+            None => return Ok(()),
+        };
+
         let client = self.http_client()?;
-        let url = format!("{}/vms/{}", self.config.forkd_url, self.vm_name);
+        let url = format!("{}/v1/sandboxes/{}", self.config.forkd_url, id);
 
         let mut backoff = HTTP_RETRY_INITIAL_BACKOFF;
         let mut attempt = 0u32;
@@ -370,6 +456,7 @@ impl ForkdSandbox {
                 .await;
 
             match result {
+                // 404 means the sandbox is already gone — idempotent success.
                 Ok(resp) if resp.status() == reqwest::StatusCode::NOT_FOUND => return Ok(()),
                 Ok(resp) if resp.status().is_success() => return Ok(()),
                 Ok(resp) if Self::is_retryable_status(resp.status()) && attempt < HTTP_RETRY_LIMIT => {
@@ -377,7 +464,7 @@ impl ForkdSandbox {
                     tracing::warn!(
                         attempt,
                         status = status.as_u16(),
-                        "forkd delete_vm transient error; retrying"
+                        "forkd delete_sandbox transient error; retrying"
                     );
                     attempt += 1;
                     sleep(backoff).await;
@@ -387,21 +474,21 @@ impl ForkdSandbox {
                     let status = resp.status();
                     let text = resp.text().await.unwrap_or_default();
                     return Err(crate::Error::message(format!(
-                        "forkd delete VM returned {status}: {text}"
+                        "forkd delete sandbox returned {status}: {text}"
                     )));
                 }
                 Err(e) if e.is_connect() && attempt < HTTP_RETRY_LIMIT => {
                     tracing::warn!(
                         attempt,
                         error = %e,
-                        "forkd delete_vm connect error; retrying"
+                        "forkd delete_sandbox connect error; retrying"
                     );
                     attempt += 1;
                     sleep(backoff).await;
                     backoff = (backoff * 2).min(Duration::from_secs(10));
                 }
                 Err(e) => {
-                    return Err(crate::Error::context("forkd delete VM HTTP request failed", e));
+                    return Err(crate::Error::context("forkd delete sandbox HTTP request failed", e));
                 }
             }
         }
@@ -417,9 +504,7 @@ impl ForkdSandbox {
 
         // Ensure parent directory exists.
         let mkdir_cmd = format!("mkdir -p {}", shell_quote(WORKING_DIRECTORY));
-        let mkdir_resp = self
-            .exec_in_vm(&mkdir_cmd, Some(30_000), None, None)
-            .await?;
+        let mkdir_resp = self.exec_shell(&mkdir_cmd, 30).await?;
         if mkdir_resp.exit_code != Some(0) {
             return Err(crate::Error::message(format!(
                 "forkd mkdir failed (exit {:?}): {}",
@@ -444,9 +529,7 @@ impl ForkdSandbox {
             )
         };
 
-        let clone_resp = self
-            .exec_in_vm(&clone_cmd, Some(300_000), None, None)
-            .await?;
+        let clone_resp = self.exec_shell(&clone_cmd, 300).await?;
 
         if clone_resp.exit_code != Some(0) {
             let err = crate::Error::message(format!(
@@ -492,8 +575,8 @@ impl Sandbox for ForkdSandbox {
             provider: PROVIDER.into(),
         });
 
-        // Create the VM.
-        self.create_vm().await.map_err(|err| {
+        // Create the sandbox (POST /v1/sandboxes).
+        self.create_sandbox().await.map_err(|err| {
             let duration_ms = elapsed_ms(start);
             self.emit(SandboxEvent::InitializeFailed {
                 provider:    PROVIDER.into(),
@@ -528,15 +611,9 @@ impl Sandbox for ForkdSandbox {
         self.emit(SandboxEvent::Ready {
             provider:    PROVIDER.into(),
             duration_ms,
-            name:        Some(self.vm_name.clone()),
+            name:        self.sandbox_id.get().cloned(),
             cpu:         None,
-            memory:      self
-                .config
-                .settings
-                .snapshot
-                .as_ref()
-                .and_then(|s| s.mem_mib)
-                .map(|m| f64::from(m) / 1024.0),
+            memory:      None,
             url:         None,
         });
 
@@ -549,7 +626,7 @@ impl Sandbox for ForkdSandbox {
             provider: PROVIDER.into(),
         });
 
-        match self.delete_vm().await {
+        match self.delete_sandbox().await {
             Ok(()) => {
                 let duration_ms = elapsed_ms(start);
                 self.emit(SandboxEvent::CleanupCompleted {
@@ -585,10 +662,14 @@ impl Sandbox for ForkdSandbox {
             .map(|d| self.resolve_path(d))
             .unwrap_or_else(|| WORKING_DIRECTORY.to_string());
 
+        // forkd exec is argv-only; fold cwd and env into sh -lc.
+        let args = Self::build_exec_argv(command, &effective_dir, env_vars);
+
+        // Convert ms to whole seconds (ceiling), minimum 1 second.
+        let timeout_secs = ((timeout_ms + 999) / 1000).max(1);
+
         let start = Instant::now();
-        let resp = self
-            .exec_in_vm(command, Some(timeout_ms), Some(&effective_dir), env_vars)
-            .await?;
+        let resp = self.exec_in_sandbox(args, timeout_secs).await?;
 
         let duration_ms = elapsed_ms(start);
         let exit_code = resp.exit_code;
@@ -624,7 +705,7 @@ impl Sandbox for ForkdSandbox {
             "base64 -w 0 {}",
             shell_quote(&abs_path)
         );
-        let resp = self.exec_in_vm(&cmd, Some(60_000), None, None).await?;
+        let resp = self.exec_shell(&cmd, 60).await?;
 
         if resp.exit_code != Some(0) {
             return Err(crate::Error::message(format!(
@@ -650,9 +731,7 @@ impl Sandbox for ForkdSandbox {
             .unwrap_or_default();
         if !parent.is_empty() {
             let mkdir_cmd = format!("mkdir -p {}", shell_quote(&parent));
-            let mkdir_resp = self
-                .exec_in_vm(&mkdir_cmd, Some(10_000), None, None)
-                .await?;
+            let mkdir_resp = self.exec_shell(&mkdir_cmd, 10).await?;
             if mkdir_resp.exit_code != Some(0) {
                 return Err(crate::Error::message(format!(
                     "forkd write_file mkdir failed: {}",
@@ -666,7 +745,7 @@ impl Sandbox for ForkdSandbox {
             shell_quote(&encoded),
             shell_quote(&abs_path)
         );
-        let resp = self.exec_in_vm(&cmd, Some(30_000), None, None).await?;
+        let resp = self.exec_shell(&cmd, 30).await?;
         if resp.exit_code != Some(0) {
             return Err(crate::Error::message(format!(
                 "forkd write_file failed (exit {:?}): {}",
@@ -680,7 +759,7 @@ impl Sandbox for ForkdSandbox {
     async fn delete_file(&self, path: &str) -> crate::Result<()> {
         let abs_path = self.resolve_path(path);
         let cmd = format!("rm -f {}", shell_quote(&abs_path));
-        let resp = self.exec_in_vm(&cmd, Some(10_000), None, None).await?;
+        let resp = self.exec_shell(&cmd, 10).await?;
         if resp.exit_code != Some(0) {
             return Err(crate::Error::message(format!(
                 "forkd delete_file failed (exit {:?}): {}",
@@ -694,7 +773,7 @@ impl Sandbox for ForkdSandbox {
     async fn file_exists(&self, path: &str) -> crate::Result<bool> {
         let abs_path = self.resolve_path(path);
         let cmd = format!("test -e {}", shell_quote(&abs_path));
-        let resp = self.exec_in_vm(&cmd, Some(10_000), None, None).await?;
+        let resp = self.exec_shell(&cmd, 10).await?;
         Ok(resp.exit_code == Some(0))
     }
 
@@ -711,7 +790,7 @@ impl Sandbox for ForkdSandbox {
             shell_quote(&abs_path),
             max_depth
         );
-        let resp = self.exec_in_vm(&cmd, Some(30_000), None, None).await?;
+        let resp = self.exec_shell(&cmd, 30).await?;
         if resp.exit_code != Some(0) && resp.exit_code != Some(1) {
             return Err(crate::Error::message(format!(
                 "forkd list_directory failed (exit {:?}): {}",
@@ -782,9 +861,7 @@ impl Sandbox for ForkdSandbox {
             .unwrap_or_default();
         if !parent.is_empty() {
             let mkdir_cmd = format!("mkdir -p {}", shell_quote(&parent));
-            let mkdir_resp = self
-                .exec_in_vm(&mkdir_cmd, Some(10_000), None, None)
-                .await?;
+            let mkdir_resp = self.exec_shell(&mkdir_cmd, 10).await?;
             if mkdir_resp.exit_code != Some(0) {
                 return Err(crate::Error::message(format!(
                     "forkd upload_file_from_local mkdir failed: {}",
@@ -798,7 +875,7 @@ impl Sandbox for ForkdSandbox {
             shell_quote(&encoded),
             shell_quote(&abs_path)
         );
-        let resp = self.exec_in_vm(&cmd, Some(60_000), None, None).await?;
+        let resp = self.exec_shell(&cmd, 60).await?;
         if resp.exit_code != Some(0) {
             return Err(crate::Error::message(format!(
                 "forkd upload_file_from_local failed (exit {:?}): {}",
@@ -837,7 +914,7 @@ impl Sandbox for ForkdSandbox {
         args.push(shell_quote(&abs_path));
 
         let cmd = args.join(" ");
-        let resp = self.exec_in_vm(&cmd, Some(60_000), None, None).await?;
+        let resp = self.exec_shell(&cmd, 60).await?;
 
         // Exit code 1 means no matches (not an error).
         if resp.exit_code != Some(0) && resp.exit_code != Some(1) {
@@ -854,9 +931,7 @@ impl Sandbox for ForkdSandbox {
             grep_args.push(shell_quote(&abs_path));
 
             let grep_cmd = grep_args.join(" ");
-            let grep_resp = self
-                .exec_in_vm(&grep_cmd, Some(60_000), None, None)
-                .await?;
+            let grep_resp = self.exec_shell(&grep_cmd, 60).await?;
             let stdout = grep_resp.stdout.unwrap_or_default();
             return Ok(stdout
                 .lines()
@@ -889,7 +964,7 @@ impl Sandbox for ForkdSandbox {
             shell_quote(&base),
             find_filter
         );
-        let resp = self.exec_in_vm(&cmd, Some(30_000), None, None).await?;
+        let resp = self.exec_shell(&cmd, 30).await?;
         let stdout = resp.stdout.unwrap_or_default();
         Ok(stdout
             .lines()
@@ -915,15 +990,18 @@ impl Sandbox for ForkdSandbox {
     }
 
     fn sandbox_info(&self) -> String {
-        format!("forkd:{}", self.vm_name)
+        match self.sandbox_id.get() {
+            Some(id) => format!("forkd:{id}"),
+            None     => "forkd:(uninitialized)".to_string(),
+        }
     }
 
     fn snapshot_info(&self) -> Option<String> {
-        self.config
-            .settings
-            .snapshot
-            .as_ref()
-            .and_then(|s| s.image.clone())
+        // Prefer the server-reported active snapshot; fall back to what was requested.
+        self.active_snapshot
+            .get()
+            .cloned()
+            .or_else(|| Some(self.config.settings.snapshot_tag.clone()))
     }
 
     fn origin_url(&self) -> Option<&str> {

--- a/lib/crates/fabro-sandbox/src/forkd/mod.rs
+++ b/lib/crates/fabro-sandbox/src/forkd/mod.rs
@@ -10,7 +10,7 @@
 
 use std::collections::HashMap;
 use std::path::Path;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
 use base64::Engine as _;
@@ -20,6 +20,7 @@ use fabro_util::time::elapsed_ms;
 use rand::Rng;
 use serde::{Deserialize, Serialize};
 use tokio::sync::OnceCell;
+use tokio::time::sleep;
 use tokio_util::sync::CancellationToken;
 
 use crate::config::ForkdSettings;
@@ -35,6 +36,11 @@ pub(crate) const REPOS_ROOT: &str = "/home/fabro/repos";
 /// Provider name string for event payloads.
 const PROVIDER: &str = "forkd";
 
+/// Maximum number of retry attempts for transient HTTP failures (5xx / connect).
+const HTTP_RETRY_LIMIT: u32 = 3;
+/// Initial backoff before the first retry.
+const HTTP_RETRY_INITIAL_BACKOFF: Duration = Duration::from_millis(250);
+
 // ---------------------------------------------------------------------------
 // Public config type (re-exported by lib.rs)
 // ---------------------------------------------------------------------------
@@ -42,14 +48,27 @@ const PROVIDER: &str = "forkd";
 /// Server-level connectivity for a forkd controller, plus per-sandbox runtime
 /// settings.  The URL and token are resolved from environment variables and
 /// must never be hardcoded.
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct ForkdConfig {
     /// Base URL of the forkd controller, e.g. `http://127.0.0.1:8889`.
     pub forkd_url:   String,
     /// Bearer token for the forkd controller API.
+    /// NEVER include the real value in log output — use `[redacted]`.
     pub forkd_token: String,
     /// Per-sandbox runtime settings (image, memory, network, skip_clone).
     pub settings:    ForkdSettings,
+}
+
+// Manual Debug implementation that redacts the bearer token so it never
+// appears in tracing output, panic messages, or error chains.
+impl std::fmt::Debug for ForkdConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ForkdConfig")
+            .field("forkd_url", &self.forkd_url)
+            .field("forkd_token", &"[redacted]")
+            .field("settings", &self.settings)
+            .finish()
+    }
 }
 
 impl Default for ForkdConfig {
@@ -167,6 +186,11 @@ impl ForkdSandbox {
 
     fn http_client(&self) -> crate::Result<reqwest::Client> {
         reqwest::Client::builder()
+            // Hard cap on individual HTTP requests to the forkd controller.
+            // Exec calls use a per-request timeout via ExecRequest.timeout_ms;
+            // this is a safety net for connect + response-header receipt.
+            .timeout(std::time::Duration::from_secs(120))
+            .connect_timeout(std::time::Duration::from_secs(15))
             .build()
             .map_err(|e| crate::Error::context("Failed to build HTTP client for forkd", e))
     }
@@ -175,8 +199,17 @@ impl ForkdSandbox {
         resolve_path(path, WORKING_DIRECTORY)
     }
 
+    /// Returns `true` if an HTTP status code is a transient server-side error
+    /// that is safe to retry (5xx range).
+    fn is_retryable_status(status: reqwest::StatusCode) -> bool {
+        status.is_server_error()
+    }
+
     /// Execute a shell command in the VM.  Returns the raw `ExecResponse`
     /// so the caller decides how to interpret exit code / output.
+    ///
+    /// Transient HTTP errors (connect failures and 5xx responses) are retried
+    /// up to `HTTP_RETRY_LIMIT` times with exponential back-off.
     async fn exec_in_vm(
         &self,
         command: &str,
@@ -194,28 +227,61 @@ impl ForkdSandbox {
             env:         env_vars.cloned(),
         };
 
-        let resp = client
-            .post(&url)
-            .bearer_auth(&self.config.forkd_token)
-            .json(&body)
-            .send()
-            .await
-            .map_err(|e| crate::Error::context("forkd exec HTTP request failed", e))?;
+        let mut backoff = HTTP_RETRY_INITIAL_BACKOFF;
+        let mut attempt = 0u32;
+        loop {
+            let result = client
+                .post(&url)
+                .bearer_auth(&self.config.forkd_token)
+                .json(&body)
+                .send()
+                .await;
 
-        if !resp.status().is_success() {
-            let status = resp.status();
-            let text = resp.text().await.unwrap_or_default();
-            return Err(crate::Error::message(format!(
-                "forkd exec returned {status}: {text}"
-            )));
+            match result {
+                Ok(resp) if resp.status().is_success() => {
+                    return resp
+                        .json::<ExecResponse>()
+                        .await
+                        .map_err(|e| crate::Error::context("Failed to parse forkd exec response", e));
+                }
+                Ok(resp) if Self::is_retryable_status(resp.status()) && attempt < HTTP_RETRY_LIMIT => {
+                    let status = resp.status();
+                    tracing::warn!(
+                        attempt,
+                        status = status.as_u16(),
+                        "forkd exec transient error; retrying"
+                    );
+                    attempt += 1;
+                    sleep(backoff).await;
+                    backoff = (backoff * 2).min(Duration::from_secs(10));
+                }
+                Ok(resp) => {
+                    let status = resp.status();
+                    let text = resp.text().await.unwrap_or_default();
+                    return Err(crate::Error::message(format!(
+                        "forkd exec returned {status}: {text}"
+                    )));
+                }
+                Err(e) if e.is_connect() && attempt < HTTP_RETRY_LIMIT => {
+                    tracing::warn!(
+                        attempt,
+                        error = %e,
+                        "forkd exec connect error; retrying"
+                    );
+                    attempt += 1;
+                    sleep(backoff).await;
+                    backoff = (backoff * 2).min(Duration::from_secs(10));
+                }
+                Err(e) => {
+                    return Err(crate::Error::context("forkd exec HTTP request failed", e));
+                }
+            }
         }
-
-        resp.json::<ExecResponse>()
-            .await
-            .map_err(|e| crate::Error::context("Failed to parse forkd exec response", e))
     }
 
     /// Create the VM via `POST /vms`.
+    ///
+    /// Transient HTTP errors are retried up to `HTTP_RETRY_LIMIT` times.
     async fn create_vm(&self) -> crate::Result<()> {
         let client = self.http_client()?;
         let url = format!("{}/vms", self.config.forkd_url);
@@ -240,49 +306,105 @@ impl ForkdSandbox {
             network: network_str,
         };
 
-        let resp = client
-            .post(&url)
-            .bearer_auth(&self.config.forkd_token)
-            .json(&body)
-            .send()
-            .await
-            .map_err(|e| crate::Error::context("forkd create VM HTTP request failed", e))?;
+        let mut backoff = HTTP_RETRY_INITIAL_BACKOFF;
+        let mut attempt = 0u32;
+        loop {
+            let result = client
+                .post(&url)
+                .bearer_auth(&self.config.forkd_token)
+                .json(&body)
+                .send()
+                .await;
 
-        if !resp.status().is_success() {
-            let status = resp.status();
-            let text = resp.text().await.unwrap_or_default();
-            return Err(crate::Error::message(format!(
-                "forkd create VM returned {status}: {text}"
-            )));
+            match result {
+                Ok(resp) if resp.status().is_success() => return Ok(()),
+                Ok(resp) if Self::is_retryable_status(resp.status()) && attempt < HTTP_RETRY_LIMIT => {
+                    let status = resp.status();
+                    tracing::warn!(
+                        attempt,
+                        status = status.as_u16(),
+                        "forkd create_vm transient error; retrying"
+                    );
+                    attempt += 1;
+                    sleep(backoff).await;
+                    backoff = (backoff * 2).min(Duration::from_secs(10));
+                }
+                Ok(resp) => {
+                    let status = resp.status();
+                    let text = resp.text().await.unwrap_or_default();
+                    return Err(crate::Error::message(format!(
+                        "forkd create VM returned {status}: {text}"
+                    )));
+                }
+                Err(e) if e.is_connect() && attempt < HTTP_RETRY_LIMIT => {
+                    tracing::warn!(
+                        attempt,
+                        error = %e,
+                        "forkd create_vm connect error; retrying"
+                    );
+                    attempt += 1;
+                    sleep(backoff).await;
+                    backoff = (backoff * 2).min(Duration::from_secs(10));
+                }
+                Err(e) => {
+                    return Err(crate::Error::context("forkd create VM HTTP request failed", e));
+                }
+            }
         }
-
-        Ok(())
     }
 
     /// Delete the VM via `DELETE /vms/{name}`.
+    ///
+    /// Transient HTTP errors are retried up to `HTTP_RETRY_LIMIT` times.
     async fn delete_vm(&self) -> crate::Result<()> {
         let client = self.http_client()?;
         let url = format!("{}/vms/{}", self.config.forkd_url, self.vm_name);
 
-        let resp = client
-            .delete(&url)
-            .bearer_auth(&self.config.forkd_token)
-            .send()
-            .await
-            .map_err(|e| crate::Error::context("forkd delete VM HTTP request failed", e))?;
+        let mut backoff = HTTP_RETRY_INITIAL_BACKOFF;
+        let mut attempt = 0u32;
+        loop {
+            let result = client
+                .delete(&url)
+                .bearer_auth(&self.config.forkd_token)
+                .send()
+                .await;
 
-        if resp.status() == reqwest::StatusCode::NOT_FOUND {
-            return Ok(());
+            match result {
+                Ok(resp) if resp.status() == reqwest::StatusCode::NOT_FOUND => return Ok(()),
+                Ok(resp) if resp.status().is_success() => return Ok(()),
+                Ok(resp) if Self::is_retryable_status(resp.status()) && attempt < HTTP_RETRY_LIMIT => {
+                    let status = resp.status();
+                    tracing::warn!(
+                        attempt,
+                        status = status.as_u16(),
+                        "forkd delete_vm transient error; retrying"
+                    );
+                    attempt += 1;
+                    sleep(backoff).await;
+                    backoff = (backoff * 2).min(Duration::from_secs(10));
+                }
+                Ok(resp) => {
+                    let status = resp.status();
+                    let text = resp.text().await.unwrap_or_default();
+                    return Err(crate::Error::message(format!(
+                        "forkd delete VM returned {status}: {text}"
+                    )));
+                }
+                Err(e) if e.is_connect() && attempt < HTTP_RETRY_LIMIT => {
+                    tracing::warn!(
+                        attempt,
+                        error = %e,
+                        "forkd delete_vm connect error; retrying"
+                    );
+                    attempt += 1;
+                    sleep(backoff).await;
+                    backoff = (backoff * 2).min(Duration::from_secs(10));
+                }
+                Err(e) => {
+                    return Err(crate::Error::context("forkd delete VM HTTP request failed", e));
+                }
+            }
         }
-        if !resp.status().is_success() {
-            let status = resp.status();
-            let text = resp.text().await.unwrap_or_default();
-            return Err(crate::Error::message(format!(
-                "forkd delete VM returned {status}: {text}"
-            )));
-        }
-
-        Ok(())
     }
 
     /// Clone a git repository into the VM working directory.
@@ -470,9 +592,12 @@ impl Sandbox for ForkdSandbox {
 
         let duration_ms = elapsed_ms(start);
         let exit_code = resp.exit_code;
+        // When forkd returns no exit code the process was killed, OOM-killed, or
+        // timed out by the controller.  We approximate using TimedOut; a future
+        // forkd API version may surface a richer termination reason.
         let termination = match exit_code {
             Some(_) => CommandTermination::Exited,
-            None => CommandTermination::Exited,
+            None => CommandTermination::TimedOut,
         };
 
         Ok(ExecResult {
@@ -643,8 +768,45 @@ impl Sandbox for ForkdSandbox {
         let bytes = tokio::fs::read(local_path)
             .await
             .map_err(|e| crate::Error::context("forkd upload_file_from_local read failed", e))?;
-        let content = String::from_utf8_lossy(&bytes);
-        self.write_file(remote_path, &content).await
+        // Binary-safe: base64-encode raw bytes and decode inside the VM, mirroring
+        // how read_file_bytes works in reverse.  String::from_utf8_lossy is
+        // deliberately avoided — it silently corrupts any non-UTF-8 byte sequence
+        // (e.g. compiled binaries, images, zip archives).
+        let abs_path = self.resolve_path(remote_path);
+        let encoded = BASE64.encode(&bytes);
+
+        // Ensure parent directory exists.
+        let parent = std::path::Path::new(&abs_path)
+            .parent()
+            .map(|p| p.to_string_lossy().into_owned())
+            .unwrap_or_default();
+        if !parent.is_empty() {
+            let mkdir_cmd = format!("mkdir -p {}", shell_quote(&parent));
+            let mkdir_resp = self
+                .exec_in_vm(&mkdir_cmd, Some(10_000), None, None)
+                .await?;
+            if mkdir_resp.exit_code != Some(0) {
+                return Err(crate::Error::message(format!(
+                    "forkd upload_file_from_local mkdir failed: {}",
+                    mkdir_resp.stderr.unwrap_or_default()
+                )));
+            }
+        }
+
+        let cmd = format!(
+            "echo {} | base64 -d > {}",
+            shell_quote(&encoded),
+            shell_quote(&abs_path)
+        );
+        let resp = self.exec_in_vm(&cmd, Some(60_000), None, None).await?;
+        if resp.exit_code != Some(0) {
+            return Err(crate::Error::message(format!(
+                "forkd upload_file_from_local failed (exit {:?}): {}",
+                resp.exit_code,
+                resp.stderr.unwrap_or_default()
+            )));
+        }
+        Ok(())
     }
 
     // ------------------------------------------------------------------
@@ -710,10 +872,22 @@ impl Sandbox for ForkdSandbox {
         let base = path
             .map(|p| self.resolve_path(p))
             .unwrap_or_else(|| WORKING_DIRECTORY.to_string());
+        // Use `-name` for patterns without a directory separator (e.g. `*.rs`,
+        // `Cargo.toml`) so they match at any depth without a spurious `*/` prefix
+        // that would require at least one intermediate directory and would miss
+        // files directly inside `base`.
+        //
+        // Use `-path` only when the caller supplies a path-qualified pattern
+        // (e.g. `src/*.rs`), anchoring it to `<base>/` so the search is rooted.
+        let find_filter = if pattern.contains('/') {
+            format!("-path {}", shell_quote(&format!("{base}/{pattern}")))
+        } else {
+            format!("-name {}", shell_quote(pattern))
+        };
         let cmd = format!(
-            r#"find {} -path {} -print 2>/dev/null"#,
+            "find {} {} -print 2>/dev/null",
             shell_quote(&base),
-            shell_quote(&format!("*/{pattern}"))
+            find_filter
         );
         let resp = self.exec_in_vm(&cmd, Some(30_000), None, None).await?;
         let stdout = resp.stdout.unwrap_or_default();

--- a/lib/crates/fabro-sandbox/src/forkd/mod.rs
+++ b/lib/crates/fabro-sandbox/src/forkd/mod.rs
@@ -1,0 +1,782 @@
+//! Forkd Firecracker microVM sandbox implementation.
+//!
+//! One long-lived VM per sandbox:
+//! - Created in `initialize()` via `POST /vms`.
+//! - Destroyed in `cleanup()` via `DELETE /vms/{name}`.
+//! - All file I/O goes through exec (base64 round-trips for binary safety).
+//! - Controller URL and bearer token are never hardcoded — they come from
+//!   `FORKD_URL` / `FORKD_TOKEN` environment variables resolved at provider
+//!   construction time.
+
+use std::collections::HashMap;
+use std::path::Path;
+use std::time::Instant;
+
+use async_trait::async_trait;
+use base64::Engine as _;
+use base64::engine::general_purpose::STANDARD as BASE64;
+use fabro_types::{CommandTermination, RunId};
+use fabro_util::time::elapsed_ms;
+use rand::Rng;
+use serde::{Deserialize, Serialize};
+use tokio::sync::OnceCell;
+use tokio_util::sync::CancellationToken;
+
+use crate::config::ForkdSettings;
+use crate::sandbox::resolve_path;
+use crate::{
+    DirEntry, ExecResult, GrepOptions, Sandbox, SandboxEvent, SandboxEventCallback, shell_quote,
+};
+
+/// VM guest working directory.
+pub(crate) const WORKING_DIRECTORY: &str = "/home/fabro/workspace";
+/// VM guest repos root.
+pub(crate) const REPOS_ROOT: &str = "/home/fabro/repos";
+/// Provider name string for event payloads.
+const PROVIDER: &str = "forkd";
+
+// ---------------------------------------------------------------------------
+// Public config type (re-exported by lib.rs)
+// ---------------------------------------------------------------------------
+
+/// Server-level connectivity for a forkd controller, plus per-sandbox runtime
+/// settings.  The URL and token are resolved from environment variables and
+/// must never be hardcoded.
+#[derive(Clone, Debug)]
+pub struct ForkdConfig {
+    /// Base URL of the forkd controller, e.g. `http://127.0.0.1:8889`.
+    pub forkd_url:   String,
+    /// Bearer token for the forkd controller API.
+    pub forkd_token: String,
+    /// Per-sandbox runtime settings (image, memory, network, skip_clone).
+    pub settings:    ForkdSettings,
+}
+
+impl Default for ForkdConfig {
+    fn default() -> Self {
+        Self {
+            forkd_url:   "http://127.0.0.1:8889".to_string(),
+            forkd_token: "forkd-local-token".to_string(),
+            settings:    ForkdSettings::default(),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// forkd REST API request/response shapes (forkd 0.5.2)
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Serialize)]
+struct CreateVmRequest {
+    name:    String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    image:   Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    kernel:  Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    mem_mib: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    network: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct ExecRequest {
+    command:     String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    working_dir: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    timeout_ms:  Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    env:         Option<HashMap<String, String>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ExecResponse {
+    stdout:    Option<String>,
+    stderr:    Option<String>,
+    exit_code: Option<i32>,
+}
+
+// ---------------------------------------------------------------------------
+// ForkdSandbox
+// ---------------------------------------------------------------------------
+
+/// A sandbox backed by a single Firecracker microVM managed via forkd.
+pub struct ForkdSandbox {
+    config:           ForkdConfig,
+    vm_name:          String,
+    run_id:           Option<RunId>,
+    clone_origin_url: Option<String>,
+    clone_branch:     Option<String>,
+    /// Populated after a successful `initialize()`.
+    initialized:      OnceCell<bool>,
+    origin_url:       OnceCell<String>,
+    event_callback:   Option<SandboxEventCallback>,
+}
+
+impl ForkdSandbox {
+    /// Create a new `ForkdSandbox`.  The VM is not created until
+    /// [`initialize`](Self::initialize) is called.
+    pub fn new(
+        config: ForkdConfig,
+        run_id: Option<RunId>,
+        clone_origin_url: Option<String>,
+        clone_branch: Option<String>,
+    ) -> Self {
+        let vm_name = if let Some(ref id) = run_id {
+            format!("fabro-{id}")
+        } else {
+            format!(
+                "fabro-{}-{:04x}",
+                chrono::Utc::now().format("%Y%m%d-%H%M%S"),
+                rand::rng().random_range(0..0x10000u32),
+            )
+        };
+        Self {
+            config,
+            vm_name,
+            run_id,
+            clone_origin_url,
+            clone_branch,
+            initialized:    OnceCell::new(),
+            origin_url:     OnceCell::new(),
+            event_callback: None,
+        }
+    }
+
+    /// The name of the VM that will be (or was) created.
+    pub fn vm_name(&self) -> &str {
+        &self.vm_name
+    }
+
+    /// Attach a callback that receives [`SandboxEvent`]s.
+    pub fn set_event_callback(&mut self, cb: SandboxEventCallback) {
+        self.event_callback = Some(cb);
+    }
+
+    // ------------------------------------------------------------------
+    // Internal helpers
+    // ------------------------------------------------------------------
+
+    fn emit(&self, event: SandboxEvent) {
+        event.trace();
+        if let Some(ref cb) = self.event_callback {
+            cb(event);
+        }
+    }
+
+    fn http_client(&self) -> crate::Result<reqwest::Client> {
+        reqwest::Client::builder()
+            .build()
+            .map_err(|e| crate::Error::context("Failed to build HTTP client for forkd", e))
+    }
+
+    fn resolve_path(&self, path: &str) -> String {
+        resolve_path(path, WORKING_DIRECTORY)
+    }
+
+    /// Execute a shell command in the VM.  Returns the raw `ExecResponse`
+    /// so the caller decides how to interpret exit code / output.
+    async fn exec_in_vm(
+        &self,
+        command: &str,
+        timeout_ms: Option<u64>,
+        working_dir: Option<&str>,
+        env_vars: Option<&HashMap<String, String>>,
+    ) -> crate::Result<ExecResponse> {
+        let client = self.http_client()?;
+        let url = format!("{}/vms/{}/exec", self.config.forkd_url, self.vm_name);
+
+        let body = ExecRequest {
+            command:     command.to_string(),
+            working_dir: working_dir.map(str::to_string),
+            timeout_ms,
+            env:         env_vars.cloned(),
+        };
+
+        let resp = client
+            .post(&url)
+            .bearer_auth(&self.config.forkd_token)
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| crate::Error::context("forkd exec HTTP request failed", e))?;
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let text = resp.text().await.unwrap_or_default();
+            return Err(crate::Error::message(format!(
+                "forkd exec returned {status}: {text}"
+            )));
+        }
+
+        resp.json::<ExecResponse>()
+            .await
+            .map_err(|e| crate::Error::context("Failed to parse forkd exec response", e))
+    }
+
+    /// Create the VM via `POST /vms`.
+    async fn create_vm(&self) -> crate::Result<()> {
+        let client = self.http_client()?;
+        let url = format!("{}/vms", self.config.forkd_url);
+
+        let snap = self.config.settings.snapshot.as_ref();
+        let network_str = self
+            .config
+            .settings
+            .network
+            .as_ref()
+            .map(|n| match n {
+                crate::config::ForkdNetwork::Block => "block".to_string(),
+                crate::config::ForkdNetwork::AllowAll => "allow_all".to_string(),
+                crate::config::ForkdNetwork::AllowList(_) => "allow_all".to_string(), // list enforced by iptables inside VM
+            });
+
+        let body = CreateVmRequest {
+            name:    self.vm_name.clone(),
+            image:   snap.and_then(|s| s.image.clone()),
+            kernel:  snap.and_then(|s| s.kernel.clone()),
+            mem_mib: snap.and_then(|s| s.mem_mib),
+            network: network_str,
+        };
+
+        let resp = client
+            .post(&url)
+            .bearer_auth(&self.config.forkd_token)
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| crate::Error::context("forkd create VM HTTP request failed", e))?;
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let text = resp.text().await.unwrap_or_default();
+            return Err(crate::Error::message(format!(
+                "forkd create VM returned {status}: {text}"
+            )));
+        }
+
+        Ok(())
+    }
+
+    /// Delete the VM via `DELETE /vms/{name}`.
+    async fn delete_vm(&self) -> crate::Result<()> {
+        let client = self.http_client()?;
+        let url = format!("{}/vms/{}", self.config.forkd_url, self.vm_name);
+
+        let resp = client
+            .delete(&url)
+            .bearer_auth(&self.config.forkd_token)
+            .send()
+            .await
+            .map_err(|e| crate::Error::context("forkd delete VM HTTP request failed", e))?;
+
+        if resp.status() == reqwest::StatusCode::NOT_FOUND {
+            return Ok(());
+        }
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let text = resp.text().await.unwrap_or_default();
+            return Err(crate::Error::message(format!(
+                "forkd delete VM returned {status}: {text}"
+            )));
+        }
+
+        Ok(())
+    }
+
+    /// Clone a git repository into the VM working directory.
+    async fn clone_repo(&self, origin_url: &str, branch: Option<&str>) -> crate::Result<()> {
+        self.emit(SandboxEvent::GitCloneStarted {
+            url:    origin_url.to_string(),
+            branch: branch.map(str::to_string),
+        });
+        let start = Instant::now();
+
+        // Ensure parent directory exists.
+        let mkdir_cmd = format!("mkdir -p {}", shell_quote(WORKING_DIRECTORY));
+        let mkdir_resp = self
+            .exec_in_vm(&mkdir_cmd, Some(30_000), None, None)
+            .await?;
+        if mkdir_resp.exit_code != Some(0) {
+            return Err(crate::Error::message(format!(
+                "forkd mkdir failed (exit {:?}): {}",
+                mkdir_resp.exit_code,
+                mkdir_resp.stderr.unwrap_or_default()
+            )));
+        }
+
+        // Build clone command.
+        let clone_cmd = if let Some(branch) = branch {
+            format!(
+                "git clone --branch {} {} {}",
+                shell_quote(branch),
+                shell_quote(origin_url),
+                shell_quote(WORKING_DIRECTORY),
+            )
+        } else {
+            format!(
+                "git clone {} {}",
+                shell_quote(origin_url),
+                shell_quote(WORKING_DIRECTORY),
+            )
+        };
+
+        let clone_resp = self
+            .exec_in_vm(&clone_cmd, Some(300_000), None, None)
+            .await?;
+
+        if clone_resp.exit_code != Some(0) {
+            let err = crate::Error::message(format!(
+                "git clone failed (exit {:?}): {}",
+                clone_resp.exit_code,
+                clone_resp.stderr.unwrap_or_default()
+            ));
+            self.emit(SandboxEvent::GitCloneFailed {
+                url:    origin_url.to_string(),
+                error:  err.to_string(),
+                causes: Vec::new(),
+            });
+            return Err(err);
+        }
+
+        let duration_ms = elapsed_ms(start);
+        self.emit(SandboxEvent::GitCloneCompleted {
+            url:         origin_url.to_string(),
+            duration_ms,
+        });
+
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Sandbox trait implementation
+// ---------------------------------------------------------------------------
+
+#[async_trait]
+impl Sandbox for ForkdSandbox {
+    // ------------------------------------------------------------------
+    // Lifecycle
+    // ------------------------------------------------------------------
+
+    async fn initialize(&self) -> crate::Result<()> {
+        if self.initialized.get().copied().unwrap_or(false) {
+            return Ok(());
+        }
+
+        let start = Instant::now();
+        self.emit(SandboxEvent::Initializing {
+            provider: PROVIDER.into(),
+        });
+
+        // Create the VM.
+        self.create_vm().await.map_err(|err| {
+            let duration_ms = elapsed_ms(start);
+            self.emit(SandboxEvent::InitializeFailed {
+                provider:    PROVIDER.into(),
+                error:       err.to_string(),
+                causes:      err.causes(),
+                duration_ms,
+            });
+            err
+        })?;
+
+        // Clone the repository if requested.
+        if !self.config.settings.skip_clone {
+            if let Some(ref origin_url) = self.clone_origin_url {
+                self.clone_repo(origin_url, self.clone_branch.as_deref())
+                    .await
+                    .map_err(|err| {
+                        let duration_ms = elapsed_ms(start);
+                        self.emit(SandboxEvent::InitializeFailed {
+                            provider:    PROVIDER.into(),
+                            error:       err.to_string(),
+                            causes:      err.causes(),
+                            duration_ms,
+                        });
+                        err
+                    })?;
+                let _ = self.origin_url.set(origin_url.clone());
+            }
+        }
+
+        let _ = self.initialized.set(true);
+        let duration_ms = elapsed_ms(start);
+        self.emit(SandboxEvent::Ready {
+            provider:    PROVIDER.into(),
+            duration_ms,
+            name:        Some(self.vm_name.clone()),
+            cpu:         None,
+            memory:      self
+                .config
+                .settings
+                .snapshot
+                .as_ref()
+                .and_then(|s| s.mem_mib)
+                .map(|m| f64::from(m) / 1024.0),
+            url:         None,
+        });
+
+        Ok(())
+    }
+
+    async fn cleanup(&self) -> crate::Result<()> {
+        let start = Instant::now();
+        self.emit(SandboxEvent::CleanupStarted {
+            provider: PROVIDER.into(),
+        });
+
+        match self.delete_vm().await {
+            Ok(()) => {
+                let duration_ms = elapsed_ms(start);
+                self.emit(SandboxEvent::CleanupCompleted {
+                    provider: PROVIDER.into(),
+                    duration_ms,
+                });
+                Ok(())
+            }
+            Err(err) => {
+                self.emit(SandboxEvent::CleanupFailed {
+                    provider: PROVIDER.into(),
+                    error:    err.to_string(),
+                    causes:   err.causes(),
+                });
+                Err(err)
+            }
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Command execution
+    // ------------------------------------------------------------------
+
+    async fn exec_command(
+        &self,
+        command: &str,
+        timeout_ms: u64,
+        working_dir: Option<&str>,
+        env_vars: Option<&HashMap<String, String>>,
+        _cancel_token: Option<CancellationToken>,
+    ) -> crate::Result<ExecResult> {
+        let effective_dir = working_dir
+            .map(|d| self.resolve_path(d))
+            .unwrap_or_else(|| WORKING_DIRECTORY.to_string());
+
+        let start = Instant::now();
+        let resp = self
+            .exec_in_vm(command, Some(timeout_ms), Some(&effective_dir), env_vars)
+            .await?;
+
+        let duration_ms = elapsed_ms(start);
+        let exit_code = resp.exit_code;
+        let termination = match exit_code {
+            Some(_) => CommandTermination::Exited,
+            None => CommandTermination::Exited,
+        };
+
+        Ok(ExecResult {
+            stdout: resp.stdout.unwrap_or_default(),
+            stderr: resp.stderr.unwrap_or_default(),
+            exit_code,
+            termination,
+            duration_ms,
+        })
+    }
+
+    // exec_command_streaming: use the trait default (non-live replay).
+    // spawn_stdio_process: use the trait default (returns Err).
+
+    // ------------------------------------------------------------------
+    // File system
+    // ------------------------------------------------------------------
+
+    async fn read_file_bytes(&self, path: &str) -> crate::Result<Vec<u8>> {
+        let abs_path = self.resolve_path(path);
+        // base64-encode the file so we can round-trip binary safely through the
+        // exec response (which is a JSON string).
+        let cmd = format!(
+            "base64 -w 0 {}",
+            shell_quote(&abs_path)
+        );
+        let resp = self.exec_in_vm(&cmd, Some(60_000), None, None).await?;
+
+        if resp.exit_code != Some(0) {
+            return Err(crate::Error::message(format!(
+                "forkd read_file_bytes: base64 failed (exit {:?}): {}",
+                resp.exit_code,
+                resp.stderr.unwrap_or_default()
+            )));
+        }
+
+        let encoded = resp.stdout.unwrap_or_default();
+        BASE64
+            .decode(encoded.trim())
+            .map_err(|e| crate::Error::context("forkd read_file_bytes: base64 decode failed", e))
+    }
+
+    async fn write_file(&self, path: &str, content: &str) -> crate::Result<()> {
+        let abs_path = self.resolve_path(path);
+        let encoded = BASE64.encode(content.as_bytes());
+        // Ensure parent directory exists.
+        let parent = std::path::Path::new(&abs_path)
+            .parent()
+            .map(|p| p.to_string_lossy().into_owned())
+            .unwrap_or_default();
+        if !parent.is_empty() {
+            let mkdir_cmd = format!("mkdir -p {}", shell_quote(&parent));
+            let mkdir_resp = self
+                .exec_in_vm(&mkdir_cmd, Some(10_000), None, None)
+                .await?;
+            if mkdir_resp.exit_code != Some(0) {
+                return Err(crate::Error::message(format!(
+                    "forkd write_file mkdir failed: {}",
+                    mkdir_resp.stderr.unwrap_or_default()
+                )));
+            }
+        }
+
+        let cmd = format!(
+            "echo {} | base64 -d > {}",
+            shell_quote(&encoded),
+            shell_quote(&abs_path)
+        );
+        let resp = self.exec_in_vm(&cmd, Some(30_000), None, None).await?;
+        if resp.exit_code != Some(0) {
+            return Err(crate::Error::message(format!(
+                "forkd write_file failed (exit {:?}): {}",
+                resp.exit_code,
+                resp.stderr.unwrap_or_default()
+            )));
+        }
+        Ok(())
+    }
+
+    async fn delete_file(&self, path: &str) -> crate::Result<()> {
+        let abs_path = self.resolve_path(path);
+        let cmd = format!("rm -f {}", shell_quote(&abs_path));
+        let resp = self.exec_in_vm(&cmd, Some(10_000), None, None).await?;
+        if resp.exit_code != Some(0) {
+            return Err(crate::Error::message(format!(
+                "forkd delete_file failed (exit {:?}): {}",
+                resp.exit_code,
+                resp.stderr.unwrap_or_default()
+            )));
+        }
+        Ok(())
+    }
+
+    async fn file_exists(&self, path: &str) -> crate::Result<bool> {
+        let abs_path = self.resolve_path(path);
+        let cmd = format!("test -e {}", shell_quote(&abs_path));
+        let resp = self.exec_in_vm(&cmd, Some(10_000), None, None).await?;
+        Ok(resp.exit_code == Some(0))
+    }
+
+    async fn list_directory(
+        &self,
+        path: &str,
+        depth: Option<usize>,
+    ) -> crate::Result<Vec<DirEntry>> {
+        let abs_path = self.resolve_path(path);
+        let max_depth = depth.unwrap_or(1);
+        // Output format: TYPE SIZE NAME per line (TYPE is 'f' or 'd')
+        let cmd = format!(
+            r#"find {} -maxdepth {} -printf '%y %s %P\n' 2>/dev/null | tail -n +2"#,
+            shell_quote(&abs_path),
+            max_depth
+        );
+        let resp = self.exec_in_vm(&cmd, Some(30_000), None, None).await?;
+        if resp.exit_code != Some(0) && resp.exit_code != Some(1) {
+            return Err(crate::Error::message(format!(
+                "forkd list_directory failed (exit {:?}): {}",
+                resp.exit_code,
+                resp.stderr.unwrap_or_default()
+            )));
+        }
+
+        let stdout = resp.stdout.unwrap_or_default();
+        let entries = stdout
+            .lines()
+            .filter(|line| !line.is_empty())
+            .filter_map(|line| {
+                let mut parts = line.splitn(3, ' ');
+                let kind = parts.next()?;
+                let size_str = parts.next()?;
+                let name = parts.next()?;
+                if name.is_empty() {
+                    return None;
+                }
+                let is_dir = kind == "d";
+                let size = if is_dir {
+                    None
+                } else {
+                    size_str.parse::<u64>().ok()
+                };
+                Some(DirEntry {
+                    name:  name.to_string(),
+                    is_dir,
+                    size,
+                })
+            })
+            .collect();
+
+        Ok(entries)
+    }
+
+    async fn download_file_to_local(
+        &self,
+        remote_path: &str,
+        local_path: &Path,
+    ) -> crate::Result<()> {
+        let bytes = self.read_file_bytes(remote_path).await?;
+        tokio::fs::write(local_path, &bytes)
+            .await
+            .map_err(|e| crate::Error::context("forkd download_file_to_local write failed", e))
+    }
+
+    async fn upload_file_from_local(
+        &self,
+        local_path: &Path,
+        remote_path: &str,
+    ) -> crate::Result<()> {
+        let bytes = tokio::fs::read(local_path)
+            .await
+            .map_err(|e| crate::Error::context("forkd upload_file_from_local read failed", e))?;
+        let content = String::from_utf8_lossy(&bytes);
+        self.write_file(remote_path, &content).await
+    }
+
+    // ------------------------------------------------------------------
+    // Search
+    // ------------------------------------------------------------------
+
+    async fn grep(
+        &self,
+        pattern: &str,
+        path: &str,
+        options: &GrepOptions,
+    ) -> crate::Result<Vec<String>> {
+        let abs_path = self.resolve_path(path);
+        let mut args = vec!["rg".to_string(), "--line-number".to_string()];
+
+        if options.case_insensitive {
+            args.push("-i".to_string());
+        }
+        if let Some(max) = options.max_results {
+            args.push("-m".to_string());
+            args.push(max.to_string());
+        }
+        if let Some(ref glob) = options.glob_filter {
+            args.push("-g".to_string());
+            args.push(shell_quote(glob));
+        }
+        args.push(shell_quote(pattern));
+        args.push(shell_quote(&abs_path));
+
+        let cmd = args.join(" ");
+        let resp = self.exec_in_vm(&cmd, Some(60_000), None, None).await?;
+
+        // Exit code 1 means no matches (not an error).
+        if resp.exit_code != Some(0) && resp.exit_code != Some(1) {
+            // rg not available — fall back to grep.
+            let mut grep_args = vec!["grep".to_string(), "-rn".to_string()];
+            if options.case_insensitive {
+                grep_args.push("-i".to_string());
+            }
+            if let Some(max) = options.max_results {
+                grep_args.push("-m".to_string());
+                grep_args.push(max.to_string());
+            }
+            grep_args.push(shell_quote(pattern));
+            grep_args.push(shell_quote(&abs_path));
+
+            let grep_cmd = grep_args.join(" ");
+            let grep_resp = self
+                .exec_in_vm(&grep_cmd, Some(60_000), None, None)
+                .await?;
+            let stdout = grep_resp.stdout.unwrap_or_default();
+            return Ok(stdout
+                .lines()
+                .map(str::to_string)
+                .collect());
+        }
+
+        let stdout = resp.stdout.unwrap_or_default();
+        Ok(stdout.lines().map(str::to_string).collect())
+    }
+
+    async fn glob(&self, pattern: &str, path: Option<&str>) -> crate::Result<Vec<String>> {
+        let base = path
+            .map(|p| self.resolve_path(p))
+            .unwrap_or_else(|| WORKING_DIRECTORY.to_string());
+        let cmd = format!(
+            r#"find {} -path {} -print 2>/dev/null"#,
+            shell_quote(&base),
+            shell_quote(&format!("*/{pattern}"))
+        );
+        let resp = self.exec_in_vm(&cmd, Some(30_000), None, None).await?;
+        let stdout = resp.stdout.unwrap_or_default();
+        Ok(stdout
+            .lines()
+            .filter(|l| !l.is_empty())
+            .map(str::to_string)
+            .collect())
+    }
+
+    // ------------------------------------------------------------------
+    // Metadata
+    // ------------------------------------------------------------------
+
+    fn working_directory(&self) -> &str {
+        WORKING_DIRECTORY
+    }
+
+    fn platform(&self) -> &str {
+        "linux"
+    }
+
+    fn os_version(&self) -> String {
+        "linux (forkd microVM)".to_string()
+    }
+
+    fn sandbox_info(&self) -> String {
+        format!("forkd:{}", self.vm_name)
+    }
+
+    fn snapshot_info(&self) -> Option<String> {
+        self.config
+            .settings
+            .snapshot
+            .as_ref()
+            .and_then(|s| s.image.clone())
+    }
+
+    fn origin_url(&self) -> Option<&str> {
+        self.origin_url.get().map(String::as_str)
+    }
+
+    // ------------------------------------------------------------------
+    // Git helpers (delegate to shared exec-based implementations)
+    // ------------------------------------------------------------------
+
+    async fn setup_git(
+        &self,
+        intent: &crate::GitSetupIntent,
+    ) -> crate::Result<Option<crate::GitRunInfo>> {
+        crate::setup_git_via_exec(self, intent)
+            .await
+            .map(Some)
+    }
+
+    fn resume_setup_commands(&self, run_branch: &str) -> Vec<String> {
+        vec![format!(
+            "git checkout {}",
+            shell_quote(run_branch)
+        )]
+    }
+
+    async fn git_push_ref(&self, refspec: &str) -> crate::Result<()> {
+        crate::git_push_via_exec(self, refspec).await
+    }
+}

--- a/lib/crates/fabro-sandbox/src/from_environment.rs
+++ b/lib/crates/fabro-sandbox/src/from_environment.rs
@@ -8,6 +8,10 @@ use std::path::{Path, PathBuf};
 #[cfg(feature = "daytona")]
 use fabro_types::settings::run::DockerfileSource as ResolvedDockerfileSource;
 use fabro_types::settings::run::{EnvironmentNetworkMode, RunEnvironmentSettings};
+#[cfg(feature = "forkd")]
+use crate::config::{ForkdNetwork, ForkdSettings, ForkdSnapshotSettings};
+#[cfg(feature = "forkd")]
+use crate::forkd::ForkdConfig;
 
 #[cfg(feature = "daytona")]
 use crate::config::{
@@ -104,6 +108,63 @@ pub fn docker_config_from_environment(
     }
 }
 
+/// Build a [`ForkdConfig`] from the current run environment settings and
+/// process environment variables.
+///
+/// - `FORKD_URL`   — controller base URL (default: `http://127.0.0.1:8889`)
+/// - `FORKD_TOKEN` — bearer token       (default: `forkd-local-token`)
+#[cfg(feature = "forkd")]
+#[must_use]
+pub fn forkd_config_from_environment(
+    settings: &RunEnvironmentSettings,
+    skip_clone: bool,
+) -> ForkdConfig {
+    #[expect(
+        clippy::disallowed_methods,
+        reason = "Forkd config resolves server-level credentials from the process environment."
+    )]
+    let forkd_url = std::env::var("FORKD_URL")
+        .unwrap_or_else(|_| "http://127.0.0.1:8889".to_string());
+    #[expect(
+        clippy::disallowed_methods,
+        reason = "Forkd config resolves server-level credentials from the process environment."
+    )]
+    let forkd_token = std::env::var("FORKD_TOKEN")
+        .unwrap_or_else(|_| "forkd-local-token".to_string());
+
+    let snapshot = ForkdSnapshotSettings {
+        image:          settings.image.docker.clone(),
+        kernel:         None, // resolved from FORKD_KERNEL by ForkdConfig::effective_kernel()
+        mem_mib:        settings
+            .resources
+            .memory
+            .map(|size| (size.as_bytes() / (1024 * 1024)) as u32),
+        extra_packages: None,
+    };
+
+    let network = match settings.network.mode {
+        EnvironmentNetworkMode::Block => ForkdNetwork::Block,
+        EnvironmentNetworkMode::AllowAll => ForkdNetwork::AllowAll,
+        EnvironmentNetworkMode::CidrAllowList => {
+            ForkdNetwork::AllowList(settings.network.allow.clone())
+        }
+    };
+
+    ForkdConfig {
+        forkd_url,
+        forkd_token,
+        settings: ForkdSettings {
+            snapshot:          Some(snapshot),
+            network:           Some(network),
+            skip_clone,
+            auto_stop_minutes: settings
+                .lifecycle
+                .auto_stop
+                .map(|d| duration_to_minutes_i32(d.as_std())),
+        },
+    }
+}
+
 pub fn local_working_directory_from_environment(
     settings: &RunEnvironmentSettings,
     source_directory: Option<&Path>,
@@ -137,7 +198,7 @@ fn process_env_var(name: &str) -> Option<String> {
     std::env::var(name).ok()
 }
 
-#[cfg(feature = "daytona")]
+#[cfg(any(feature = "daytona", feature = "forkd"))]
 fn duration_to_minutes_i32(duration: std::time::Duration) -> i32 {
     let minutes = duration.as_secs() / 60;
     i32::try_from(minutes).unwrap_or(i32::MAX)

--- a/lib/crates/fabro-sandbox/src/from_environment.rs
+++ b/lib/crates/fabro-sandbox/src/from_environment.rs
@@ -11,6 +11,8 @@ use fabro_types::settings::run::{EnvironmentNetworkMode, RunEnvironmentSettings}
 #[cfg(feature = "forkd")]
 use crate::config::{ForkdNetwork, ForkdSettings, ForkdSnapshotSettings};
 #[cfg(feature = "forkd")]
+use crate::forkd::DEFAULT_SNAPSHOT_TAG;
+#[cfg(feature = "forkd")]
 use crate::forkd::ForkdConfig;
 
 #[cfg(feature = "daytona")]
@@ -150,10 +152,18 @@ pub fn forkd_config_from_environment(
         }
     };
 
+    #[expect(
+        clippy::disallowed_methods,
+        reason = "Forkd config resolves snapshot tag from the process environment."
+    )]
+    let snapshot_tag = std::env::var("FORKD_SNAPSHOT_TAG")
+        .unwrap_or_else(|_| DEFAULT_SNAPSHOT_TAG.to_string());
+
     ForkdConfig {
         forkd_url,
         forkd_token,
         settings: ForkdSettings {
+            snapshot_tag,
             snapshot:          Some(snapshot),
             network:           Some(network),
             skip_clone,

--- a/lib/crates/fabro-sandbox/src/lib.rs
+++ b/lib/crates/fabro-sandbox/src/lib.rs
@@ -1,6 +1,6 @@
 pub mod config;
 pub mod error;
-#[cfg(any(feature = "docker", feature = "daytona"))]
+#[cfg(any(feature = "docker", feature = "daytona", feature = "forkd"))]
 pub mod from_environment;
 pub mod provider;
 pub mod sandbox;
@@ -33,6 +33,9 @@ pub mod docker;
 #[cfg(feature = "daytona")]
 pub mod daytona;
 
+#[cfg(feature = "forkd")]
+pub mod forkd;
+
 #[cfg(any(test, feature = "test-support"))]
 pub mod test_support;
 
@@ -46,6 +49,10 @@ pub use local::LocalSandbox;
 pub use provider::daytona::DaytonaSandboxProvider;
 #[cfg(feature = "docker")]
 pub use provider::docker::DockerSandboxProvider;
+#[cfg(feature = "forkd")]
+pub use provider::forkd::ForkdSandboxProvider;
+#[cfg(feature = "forkd")]
+pub use forkd::{ForkdConfig, ForkdSandbox};
 pub use provider::{
     LocalSandboxProvider, SandboxCreateSpec, SandboxLookupError, SandboxProvider,
     SandboxProviderRegistry,

--- a/lib/crates/fabro-sandbox/src/provider.rs
+++ b/lib/crates/fabro-sandbox/src/provider.rs
@@ -2,6 +2,8 @@
 pub mod daytona;
 #[cfg(feature = "docker")]
 pub mod docker;
+#[cfg(feature = "forkd")]
+pub mod forkd;
 
 use std::sync::Arc;
 
@@ -21,6 +23,8 @@ use futures::future::join_all;
 use crate::daytona::DaytonaConfig;
 #[cfg(feature = "docker")]
 use crate::docker::DockerSandboxOptions;
+#[cfg(feature = "forkd")]
+use crate::config::ForkdSettings;
 
 pub enum SandboxCreateSpec {
     Local,
@@ -40,6 +44,22 @@ pub enum SandboxCreateSpec {
         clone_origin_url: Option<String>,
         clone_branch:     Option<String>,
         api_key:          Option<String>,
+    },
+    /// Create a Forkd Firecracker microVM sandbox.
+    ///
+    /// The forkd controller URL and bearer token are resolved at provider
+    /// construction time from `FORKD_URL` / `FORKD_TOKEN` — they are not
+    /// part of this per-run spec.
+    #[cfg(feature = "forkd")]
+    Forkd {
+        /// Per-run VM settings (image, kernel, memory, network, skip_clone).
+        config:           Box<ForkdSettings>,
+        /// Optional run identifier; used to name the VM "fabro-{run_id}".
+        run_id:           Option<RunId>,
+        /// Git repository to clone on `initialize()`.
+        clone_origin_url: Option<String>,
+        /// Branch override for the initial clone.
+        clone_branch:     Option<String>,
     },
 }
 

--- a/lib/crates/fabro-sandbox/src/provider/forkd.rs
+++ b/lib/crates/fabro-sandbox/src/provider/forkd.rs
@@ -1,0 +1,169 @@
+use async_trait::async_trait;
+use fabro_types::{SandboxInfo, SandboxProviderKind};
+
+use super::{SandboxCreateSpec, SandboxProvider};
+use crate::forkd::{ForkdConfig, ForkdSandbox};
+use crate::details;
+
+/// A [`SandboxProvider`] that creates Firecracker microVMs via a forkd
+/// controller.  The controller URL and bearer token are resolved once at
+/// construction time from `FORKD_URL` / `FORKD_TOKEN`; they never appear in
+/// per-run specs.
+#[derive(Clone)]
+pub struct ForkdSandboxProvider {
+    config: ForkdConfig,
+}
+
+impl ForkdSandboxProvider {
+    /// Build a provider from an already-resolved [`ForkdConfig`].
+    pub fn new(config: ForkdConfig) -> Self {
+        Self { config }
+    }
+
+    /// Build a provider by reading `FORKD_URL` and `FORKD_TOKEN` from the
+    /// process environment (the same resolution that
+    /// [`crate::from_environment::forkd_config_from_environment`] performs for
+    /// a full [`RunEnvironmentSettings`]).
+    #[expect(
+        clippy::disallowed_methods,
+        reason = "ForkdSandboxProvider::from_env resolves server-level credentials from the process environment."
+    )]
+    pub fn from_env() -> Self {
+        let forkd_url = std::env::var("FORKD_URL")
+            .unwrap_or_else(|_| "http://127.0.0.1:8889".to_string());
+        let forkd_token = std::env::var("FORKD_TOKEN")
+            .unwrap_or_else(|_| "forkd-local-token".to_string());
+        Self::new(ForkdConfig {
+            forkd_url,
+            forkd_token,
+            settings: Default::default(),
+        })
+    }
+
+    fn http_client(&self) -> crate::Result<reqwest::Client> {
+        reqwest::Client::builder()
+            .build()
+            .map_err(|e| crate::Error::context("Failed to build HTTP client for forkd", e))
+    }
+}
+
+#[async_trait]
+impl SandboxProvider for ForkdSandboxProvider {
+    fn kind(&self) -> SandboxProviderKind {
+        SandboxProviderKind::Forkd
+    }
+
+    async fn list(&self) -> crate::Result<Vec<SandboxInfo>> {
+        let client = self.http_client()?;
+        let url = format!("{}/vms", self.config.forkd_url);
+        let resp = client
+            .get(&url)
+            .bearer_auth(&self.config.forkd_token)
+            .send()
+            .await
+            .map_err(|e| crate::Error::context("Failed to list forkd VMs", e))?;
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            return Err(crate::Error::message(format!(
+                "forkd list VMs returned {status}: {body}"
+            )));
+        }
+
+        let vms: serde_json::Value = resp
+            .json()
+            .await
+            .map_err(|e| crate::Error::context("Failed to parse forkd VM list", e))?;
+
+        // forkd 0.5.2 returns { "vms": [ { "name": "...", "status": "...", ... } ] }
+        let arr = vms
+            .get("vms")
+            .and_then(|v| v.as_array())
+            .cloned()
+            .unwrap_or_default();
+
+        let sandboxes = arr
+            .into_iter()
+            .filter_map(|vm| {
+                let name = vm.get("name")?.as_str()?.to_string();
+                Some(details::forkd::forkd_info_from_name(&name))
+            })
+            .collect();
+
+        Ok(sandboxes)
+    }
+
+    async fn get(&self, id: &str) -> crate::Result<Option<SandboxInfo>> {
+        let client = self.http_client()?;
+        let url = format!("{}/vms/{}", self.config.forkd_url, id);
+        let resp = client
+            .get(&url)
+            .bearer_auth(&self.config.forkd_token)
+            .send()
+            .await
+            .map_err(|e| crate::Error::context(format!("Failed to get forkd VM '{id}'"), e))?;
+
+        if resp.status() == reqwest::StatusCode::NOT_FOUND {
+            return Ok(None);
+        }
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            return Err(crate::Error::message(format!(
+                "forkd get VM '{id}' returned {status}: {body}"
+            )));
+        }
+
+        Ok(Some(details::forkd::forkd_info_from_name(id)))
+    }
+
+    async fn create(&self, spec: SandboxCreateSpec) -> crate::Result<SandboxInfo> {
+        let SandboxCreateSpec::Forkd {
+            config,
+            run_id,
+            clone_origin_url,
+            clone_branch,
+        } = spec
+        else {
+            return Err(crate::Error::message(
+                "ForkdSandboxProvider requires a SandboxCreateSpec::Forkd variant",
+            ));
+        };
+
+        let merged_config = ForkdConfig {
+            forkd_url:   self.config.forkd_url.clone(),
+            forkd_token: self.config.forkd_token.clone(),
+            settings:    *config,
+        };
+
+        let sandbox = ForkdSandbox::new(merged_config, run_id, clone_origin_url, clone_branch);
+        let name = sandbox.vm_name().to_string();
+        Ok(details::forkd::forkd_info_from_name(&name))
+    }
+
+    async fn delete(&self, id: &str) -> crate::Result<()> {
+        let client = self.http_client()?;
+        let url = format!("{}/vms/{}", self.config.forkd_url, id);
+        let resp = client
+            .delete(&url)
+            .bearer_auth(&self.config.forkd_token)
+            .send()
+            .await
+            .map_err(|e| crate::Error::context(format!("Failed to delete forkd VM '{id}'"), e))?;
+
+        if resp.status() == reqwest::StatusCode::NOT_FOUND {
+            // Already gone — treat as success.
+            return Ok(());
+        }
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            return Err(crate::Error::message(format!(
+                "forkd delete VM '{id}' returned {status}: {body}"
+            )));
+        }
+
+        Ok(())
+    }
+}

--- a/lib/crates/fabro-sandbox/src/provider/forkd.rs
+++ b/lib/crates/fabro-sandbox/src/provider/forkd.rs
@@ -1,9 +1,16 @@
+use std::time::Duration;
+
 use async_trait::async_trait;
 use fabro_types::{SandboxInfo, SandboxProviderKind};
+use tokio::time::sleep;
 
 use super::{SandboxCreateSpec, SandboxProvider};
 use crate::forkd::{ForkdConfig, ForkdSandbox};
 use crate::details;
+
+/// Retry limit for transient HTTP failures (5xx / connect) in provider calls.
+const PROVIDER_RETRY_LIMIT: u32 = 3;
+const PROVIDER_RETRY_INITIAL_BACKOFF: Duration = Duration::from_millis(250);
 
 /// A [`SandboxProvider`] that creates Firecracker microVMs via a forkd
 /// controller.  The controller URL and bearer token are resolved once at
@@ -42,8 +49,14 @@ impl ForkdSandboxProvider {
 
     fn http_client(&self) -> crate::Result<reqwest::Client> {
         reqwest::Client::builder()
+            .timeout(Duration::from_secs(30))
+            .connect_timeout(Duration::from_secs(15))
             .build()
             .map_err(|e| crate::Error::context("Failed to build HTTP client for forkd", e))
+    }
+
+    fn is_retryable_status(status: reqwest::StatusCode) -> bool {
+        status.is_server_error()
     }
 }
 
@@ -56,20 +69,43 @@ impl SandboxProvider for ForkdSandboxProvider {
     async fn list(&self) -> crate::Result<Vec<SandboxInfo>> {
         let client = self.http_client()?;
         let url = format!("{}/vms", self.config.forkd_url);
-        let resp = client
-            .get(&url)
-            .bearer_auth(&self.config.forkd_token)
-            .send()
-            .await
-            .map_err(|e| crate::Error::context("Failed to list forkd VMs", e))?;
 
-        if !resp.status().is_success() {
-            let status = resp.status();
-            let body = resp.text().await.unwrap_or_default();
-            return Err(crate::Error::message(format!(
-                "forkd list VMs returned {status}: {body}"
-            )));
-        }
+        let mut backoff = PROVIDER_RETRY_INITIAL_BACKOFF;
+        let mut attempt = 0u32;
+        let resp = loop {
+            let result = client
+                .get(&url)
+                .bearer_auth(&self.config.forkd_token)
+                .send()
+                .await;
+
+            match result {
+                Ok(resp) if resp.status().is_success() => break resp,
+                Ok(resp) if Self::is_retryable_status(resp.status()) && attempt < PROVIDER_RETRY_LIMIT => {
+                    let status = resp.status();
+                    tracing::warn!(attempt, status = status.as_u16(), "forkd list transient error; retrying");
+                    attempt += 1;
+                    sleep(backoff).await;
+                    backoff = (backoff * 2).min(Duration::from_secs(10));
+                }
+                Ok(resp) => {
+                    let status = resp.status();
+                    let body = resp.text().await.unwrap_or_default();
+                    return Err(crate::Error::message(format!(
+                        "forkd list VMs returned {status}: {body}"
+                    )));
+                }
+                Err(e) if e.is_connect() && attempt < PROVIDER_RETRY_LIMIT => {
+                    tracing::warn!(attempt, error = %e, "forkd list connect error; retrying");
+                    attempt += 1;
+                    sleep(backoff).await;
+                    backoff = (backoff * 2).min(Duration::from_secs(10));
+                }
+                Err(e) => {
+                    return Err(crate::Error::context("Failed to list forkd VMs", e));
+                }
+            }
+        };
 
         let vms: serde_json::Value = resp
             .json()
@@ -97,25 +133,46 @@ impl SandboxProvider for ForkdSandboxProvider {
     async fn get(&self, id: &str) -> crate::Result<Option<SandboxInfo>> {
         let client = self.http_client()?;
         let url = format!("{}/vms/{}", self.config.forkd_url, id);
-        let resp = client
-            .get(&url)
-            .bearer_auth(&self.config.forkd_token)
-            .send()
-            .await
-            .map_err(|e| crate::Error::context(format!("Failed to get forkd VM '{id}'"), e))?;
 
-        if resp.status() == reqwest::StatusCode::NOT_FOUND {
-            return Ok(None);
-        }
-        if !resp.status().is_success() {
-            let status = resp.status();
-            let body = resp.text().await.unwrap_or_default();
-            return Err(crate::Error::message(format!(
-                "forkd get VM '{id}' returned {status}: {body}"
-            )));
-        }
+        let mut backoff = PROVIDER_RETRY_INITIAL_BACKOFF;
+        let mut attempt = 0u32;
+        loop {
+            let result = client
+                .get(&url)
+                .bearer_auth(&self.config.forkd_token)
+                .send()
+                .await;
 
-        Ok(Some(details::forkd::forkd_info_from_name(id)))
+            match result {
+                Ok(resp) if resp.status() == reqwest::StatusCode::NOT_FOUND => return Ok(None),
+                Ok(resp) if resp.status().is_success() => {
+                    return Ok(Some(details::forkd::forkd_info_from_name(id)));
+                }
+                Ok(resp) if Self::is_retryable_status(resp.status()) && attempt < PROVIDER_RETRY_LIMIT => {
+                    let status = resp.status();
+                    tracing::warn!(attempt, status = status.as_u16(), "forkd get transient error; retrying");
+                    attempt += 1;
+                    sleep(backoff).await;
+                    backoff = (backoff * 2).min(Duration::from_secs(10));
+                }
+                Ok(resp) => {
+                    let status = resp.status();
+                    let body = resp.text().await.unwrap_or_default();
+                    return Err(crate::Error::message(format!(
+                        "forkd get VM '{id}' returned {status}: {body}"
+                    )));
+                }
+                Err(e) if e.is_connect() && attempt < PROVIDER_RETRY_LIMIT => {
+                    tracing::warn!(attempt, error = %e, "forkd get connect error; retrying");
+                    attempt += 1;
+                    sleep(backoff).await;
+                    backoff = (backoff * 2).min(Duration::from_secs(10));
+                }
+                Err(e) => {
+                    return Err(crate::Error::context(format!("Failed to get forkd VM '{id}'"), e));
+                }
+            }
+        }
     }
 
     async fn create(&self, spec: SandboxCreateSpec) -> crate::Result<SandboxInfo> {
@@ -138,32 +195,58 @@ impl SandboxProvider for ForkdSandboxProvider {
         };
 
         let sandbox = ForkdSandbox::new(merged_config, run_id, clone_origin_url, clone_branch);
+        // Capture the VM name before initialize() so we can report it on success.
         let name = sandbox.vm_name().to_string();
+        // Actually provision the microVM (and optionally clone the repo) before
+        // returning.  Without this call the VM never exists and all subsequent
+        // operations on the returned SandboxInfo would fail.
+        sandbox.initialize().await?;
         Ok(details::forkd::forkd_info_from_name(&name))
     }
 
     async fn delete(&self, id: &str) -> crate::Result<()> {
         let client = self.http_client()?;
         let url = format!("{}/vms/{}", self.config.forkd_url, id);
-        let resp = client
-            .delete(&url)
-            .bearer_auth(&self.config.forkd_token)
-            .send()
-            .await
-            .map_err(|e| crate::Error::context(format!("Failed to delete forkd VM '{id}'"), e))?;
 
-        if resp.status() == reqwest::StatusCode::NOT_FOUND {
-            // Already gone — treat as success.
-            return Ok(());
-        }
-        if !resp.status().is_success() {
-            let status = resp.status();
-            let body = resp.text().await.unwrap_or_default();
-            return Err(crate::Error::message(format!(
-                "forkd delete VM '{id}' returned {status}: {body}"
-            )));
-        }
+        let mut backoff = PROVIDER_RETRY_INITIAL_BACKOFF;
+        let mut attempt = 0u32;
+        loop {
+            let result = client
+                .delete(&url)
+                .bearer_auth(&self.config.forkd_token)
+                .send()
+                .await;
 
-        Ok(())
+            match result {
+                Ok(resp) if resp.status() == reqwest::StatusCode::NOT_FOUND => {
+                    // Already gone — treat as success.
+                    return Ok(());
+                }
+                Ok(resp) if resp.status().is_success() => return Ok(()),
+                Ok(resp) if Self::is_retryable_status(resp.status()) && attempt < PROVIDER_RETRY_LIMIT => {
+                    let status = resp.status();
+                    tracing::warn!(attempt, status = status.as_u16(), "forkd delete transient error; retrying");
+                    attempt += 1;
+                    sleep(backoff).await;
+                    backoff = (backoff * 2).min(Duration::from_secs(10));
+                }
+                Ok(resp) => {
+                    let status = resp.status();
+                    let body = resp.text().await.unwrap_or_default();
+                    return Err(crate::Error::message(format!(
+                        "forkd delete VM '{id}' returned {status}: {body}"
+                    )));
+                }
+                Err(e) if e.is_connect() && attempt < PROVIDER_RETRY_LIMIT => {
+                    tracing::warn!(attempt, error = %e, "forkd delete connect error; retrying");
+                    attempt += 1;
+                    sleep(backoff).await;
+                    backoff = (backoff * 2).min(Duration::from_secs(10));
+                }
+                Err(e) => {
+                    return Err(crate::Error::context(format!("Failed to delete forkd VM '{id}'"), e));
+                }
+            }
+        }
     }
 }

--- a/lib/crates/fabro-sandbox/src/provider/forkd.rs
+++ b/lib/crates/fabro-sandbox/src/provider/forkd.rs
@@ -6,7 +6,7 @@ use tokio::time::sleep;
 
 use super::{SandboxCreateSpec, SandboxProvider};
 use crate::forkd::{ForkdConfig, ForkdSandbox};
-use crate::details;
+use crate::{Sandbox, details};
 
 /// Retry limit for transient HTTP failures (5xx / connect) in provider calls.
 const PROVIDER_RETRY_LIMIT: u32 = 3;

--- a/lib/crates/fabro-sandbox/src/provider/forkd.rs
+++ b/lib/crates/fabro-sandbox/src/provider/forkd.rs
@@ -68,7 +68,7 @@ impl SandboxProvider for ForkdSandboxProvider {
 
     async fn list(&self) -> crate::Result<Vec<SandboxInfo>> {
         let client = self.http_client()?;
-        let url = format!("{}/vms", self.config.forkd_url);
+        let url = format!("{}/v1/sandboxes", self.config.forkd_url);
 
         let mut backoff = PROVIDER_RETRY_INITIAL_BACKOFF;
         let mut attempt = 0u32;
@@ -112,18 +112,15 @@ impl SandboxProvider for ForkdSandboxProvider {
             .await
             .map_err(|e| crate::Error::context("Failed to parse forkd VM list", e))?;
 
-        // forkd 0.5.2 returns { "vms": [ { "name": "...", "status": "...", ... } ] }
-        let arr = vms
-            .get("vms")
-            .and_then(|v| v.as_array())
-            .cloned()
-            .unwrap_or_default();
+        // forkd 0.5.2 returns a top-level JSON array of sandbox objects, each
+        // carrying an "id" field.
+        let arr = vms.as_array().cloned().unwrap_or_default();
 
         let sandboxes = arr
             .into_iter()
             .filter_map(|vm| {
-                let name = vm.get("name")?.as_str()?.to_string();
-                Some(details::forkd::forkd_info_from_name(&name))
+                let id = vm.get("id")?.as_str()?.to_string();
+                Some(details::forkd::forkd_info_from_name(&id))
             })
             .collect();
 
@@ -132,7 +129,7 @@ impl SandboxProvider for ForkdSandboxProvider {
 
     async fn get(&self, id: &str) -> crate::Result<Option<SandboxInfo>> {
         let client = self.http_client()?;
-        let url = format!("{}/vms/{}", self.config.forkd_url, id);
+        let url = format!("{}/v1/sandboxes/{}", self.config.forkd_url, id);
 
         let mut backoff = PROVIDER_RETRY_INITIAL_BACKOFF;
         let mut attempt = 0u32;
@@ -195,18 +192,19 @@ impl SandboxProvider for ForkdSandboxProvider {
         };
 
         let sandbox = ForkdSandbox::new(merged_config, run_id, clone_origin_url, clone_branch);
-        // Capture the VM name before initialize() so we can report it on success.
-        let name = sandbox.vm_name().to_string();
-        // Actually provision the microVM (and optionally clone the repo) before
-        // returning.  Without this call the VM never exists and all subsequent
-        // operations on the returned SandboxInfo would fail.
+        // Provision the microVM first; forkd assigns the sandbox id, which we
+        // then report. Without initialize() the VM never exists and all
+        // subsequent operations on the returned SandboxInfo would fail.
         sandbox.initialize().await?;
-        Ok(details::forkd::forkd_info_from_name(&name))
+        let id = sandbox.sandbox_id().ok_or_else(|| {
+            crate::Error::message("forkd sandbox id missing after initialize")
+        })?;
+        Ok(details::forkd::forkd_info_from_name(id))
     }
 
     async fn delete(&self, id: &str) -> crate::Result<()> {
         let client = self.http_client()?;
-        let url = format!("{}/vms/{}", self.config.forkd_url, id);
+        let url = format!("{}/v1/sandboxes/{}", self.config.forkd_url, id);
 
         let mut backoff = PROVIDER_RETRY_INITIAL_BACKOFF;
         let mut attempt = 0u32;

--- a/lib/crates/fabro-sandbox/src/reconnect.rs
+++ b/lib/crates/fabro-sandbox/src/reconnect.rs
@@ -12,6 +12,8 @@ use crate::SandboxEventCallback;
 use crate::daytona::DaytonaSandbox;
 #[cfg(feature = "docker")]
 use crate::docker::DockerSandbox;
+#[cfg(feature = "forkd")]
+use crate::forkd::ForkdSandbox;
 use crate::local::LocalSandbox;
 
 /// Reconnect to a sandbox from a saved record.
@@ -106,5 +108,20 @@ pub async fn reconnect_for_run_with_callback(
         }
         #[cfg(not(feature = "daytona"))]
         SandboxProviderKind::Daytona => bail!("Daytona sandbox support is not enabled"),
+        #[cfg(feature = "forkd")]
+        SandboxProviderKind::Forkd => {
+            let mut sandbox = ForkdSandbox::new(
+                crate::forkd::ForkdConfig::default(),
+                run_id,
+                runtime.clone_origin_url.clone(),
+                runtime.clone_branch.clone(),
+            );
+            if let Some(callback) = event_callback {
+                sandbox.set_event_callback(callback);
+            }
+            Ok(Box::new(sandbox))
+        }
+        #[cfg(not(feature = "forkd"))]
+        SandboxProviderKind::Forkd => bail!("Forkd sandbox support is not enabled"),
     }
 }

--- a/lib/crates/fabro-sandbox/src/sandbox.rs
+++ b/lib/crates/fabro-sandbox/src/sandbox.rs
@@ -1038,8 +1038,8 @@ pub trait Sandbox: Send + Sync {
 }
 
 /// Resolve a path: relative paths are prepended with the working directory.
-/// Used by the Daytona sandbox implementation.
-#[cfg(any(feature = "docker", feature = "daytona"))]
+/// Used by the Daytona and Forkd sandbox implementations.
+#[cfg(any(feature = "docker", feature = "daytona", feature = "forkd"))]
 pub(crate) fn resolve_path(path: &str, working_dir: &str) -> String {
     if std::path::Path::new(path).is_absolute() {
         path.to_string()

--- a/lib/crates/fabro-sandbox/src/sandbox_spec.rs
+++ b/lib/crates/fabro-sandbox/src/sandbox_spec.rs
@@ -192,7 +192,7 @@ impl SandboxSpec {
                 RunSandboxInstance {
                     provider: self.provider(),
                     image:    None,
-                    snapshot: None,
+                    snapshot: Some(config.settings.snapshot_tag.clone()),
                     runtime:  RunSandboxRuntime {
                         id,
                         working_directory: working_directory.clone(),

--- a/lib/crates/fabro-sandbox/src/sandbox_spec.rs
+++ b/lib/crates/fabro-sandbox/src/sandbox_spec.rs
@@ -11,12 +11,14 @@ use fabro_github::GitHubCredentials;
 )]
 use fabro_types::{RunId, RunSandboxInstance, RunSandboxRuntime, SandboxProviderKind};
 
-#[cfg(any(feature = "docker", feature = "daytona"))]
+#[cfg(any(feature = "docker", feature = "daytona", feature = "forkd"))]
 use crate::clone_source;
 #[cfg(feature = "daytona")]
 use crate::daytona::{self, DaytonaConfig, DaytonaSandbox};
 #[cfg(feature = "docker")]
 use crate::docker::{self, DockerSandbox, DockerSandboxOptions};
+#[cfg(feature = "forkd")]
+use crate::forkd::{self, ForkdConfig, ForkdSandbox};
 use crate::local::LocalSandbox;
 use crate::{Sandbox, SandboxEventCallback};
 
@@ -42,6 +44,13 @@ pub enum SandboxSpec {
         clone_branch:     Option<String>,
         api_key:          Option<String>,
     },
+    #[cfg(feature = "forkd")]
+    Forkd {
+        config:           Box<ForkdConfig>,
+        run_id:           Option<RunId>,
+        clone_origin_url: Option<String>,
+        clone_branch:     Option<String>,
+    },
 }
 
 impl SandboxSpec {
@@ -52,6 +61,8 @@ impl SandboxSpec {
             Self::Docker { .. } => SandboxProviderKind::Docker,
             #[cfg(feature = "daytona")]
             Self::Daytona { .. } => SandboxProviderKind::Daytona,
+            #[cfg(feature = "forkd")]
+            Self::Forkd { .. } => SandboxProviderKind::Forkd,
         }
     }
 
@@ -60,6 +71,7 @@ impl SandboxSpec {
             SandboxProviderKind::Local => "local",
             SandboxProviderKind::Docker => "docker",
             SandboxProviderKind::Daytona => "daytona",
+            SandboxProviderKind::Forkd => "forkd",
         }
     }
 
@@ -160,6 +172,46 @@ impl SandboxSpec {
                     },
                 }
             }
+            #[cfg(feature = "forkd")]
+            Self::Forkd {
+                config,
+                clone_origin_url,
+                clone_branch,
+                ..
+            } => {
+                let repo_cloned = clone_source::repo_cloned_for_record(
+                    config.settings.skip_clone,
+                    clone_origin_url.as_deref(),
+                );
+                let layout = runtime_layout_metadata(
+                    repo_cloned,
+                    clone_origin_url.as_deref(),
+                    forkd::WORKING_DIRECTORY,
+                    forkd::REPOS_ROOT,
+                );
+                RunSandboxInstance {
+                    provider: self.provider(),
+                    image:    None,
+                    snapshot: None,
+                    runtime:  RunSandboxRuntime {
+                        id,
+                        working_directory: working_directory.clone(),
+                        repo_cloned,
+                        clone_origin_url: clone_source::clean_clone_origin_for_record(
+                            clone_origin_url.as_deref(),
+                        ),
+                        clone_branch: clone_branch.clone(),
+                        workspace_root: Some(forkd::WORKING_DIRECTORY.to_string()),
+                        repos_root: Some(forkd::REPOS_ROOT.to_string()),
+                        primary_repo_path: layout
+                            .as_ref()
+                            .map(|layout| layout.primary_repo_path.clone()),
+                        primary_repo_link: layout
+                            .as_ref()
+                            .map(|layout| layout.primary_repo_link.clone()),
+                    },
+                }
+            }
             _ => RunSandboxInstance {
                 provider: self.provider(),
                 image:    None,
@@ -235,6 +287,24 @@ impl SandboxSpec {
                 )
                 .await
                 .map_err(anyhow::Error::new)?;
+                if let Some(callback) = event_callback {
+                    sandbox.set_event_callback(callback);
+                }
+                Ok(Arc::new(sandbox))
+            }
+            #[cfg(feature = "forkd")]
+            Self::Forkd {
+                config,
+                run_id,
+                clone_origin_url,
+                clone_branch,
+            } => {
+                let mut sandbox = ForkdSandbox::new(
+                    config.as_ref().clone(),
+                    *run_id,
+                    clone_origin_url.clone(),
+                    clone_branch.clone(),
+                );
                 if let Some(callback) = event_callback {
                     sandbox.set_event_callback(callback);
                 }

--- a/lib/crates/fabro-sandbox/src/terminal.rs
+++ b/lib/crates/fabro-sandbox/src/terminal.rs
@@ -103,6 +103,9 @@ pub async fn open_terminal_for_run(
         SandboxProviderKind::Docker => Err(crate::Error::message(
             "Docker sandbox support is not enabled",
         )),
+        SandboxProviderKind::Forkd => Err(crate::Error::message(
+            "Forkd sandboxes do not support embedded terminals",
+        )),
         SandboxProviderKind::Local => Err(crate::Error::message(
             "Local sandboxes do not support embedded terminals",
         )),

--- a/lib/crates/fabro-server/Cargo.toml
+++ b/lib/crates/fabro-server/Cargo.toml
@@ -11,6 +11,7 @@ doctest = false
 
 [features]
 test-support = []
+forkd = ["fabro-sandbox/forkd", "fabro-agent/forkd"]
 
 [[test]]
 name = "it"

--- a/lib/crates/fabro-server/Cargo.toml
+++ b/lib/crates/fabro-server/Cargo.toml
@@ -11,7 +11,7 @@ doctest = false
 
 [features]
 test-support = []
-forkd = ["fabro-sandbox/forkd", "fabro-agent/forkd"]
+forkd = ["fabro-sandbox/forkd", "fabro-agent/forkd", "fabro-workflow/forkd"]
 
 [[test]]
 name = "it"

--- a/lib/crates/fabro-server/src/run_manifest.rs
+++ b/lib/crates/fabro-server/src/run_manifest.rs
@@ -711,6 +711,11 @@ fn environment_capability_warnings(resolved_run: &RunNamespace) -> Vec<String> {
                 warnings.push("daytona provider ignores cwd".to_string());
             }
         }
+        EnvironmentProvider::Forkd => {
+            if environment.cwd.is_some() {
+                warnings.push("forkd provider ignores cwd".to_string());
+            }
+        }
     }
     warnings
 }

--- a/lib/crates/fabro-server/src/run_manifest.rs
+++ b/lib/crates/fabro-server/src/run_manifest.rs
@@ -20,7 +20,7 @@ use fabro_model::{Catalog, ProviderId};
 use fabro_sandbox::daytona::DaytonaConfig;
 use fabro_sandbox::from_environment::{
     daytona_config_from_environment, docker_config_from_environment,
-    local_working_directory_from_environment,
+    forkd_config_from_environment, local_working_directory_from_environment,
 };
 use fabro_sandbox::redact::redact_auth_url;
 use fabro_sandbox::{DockerSandboxOptions, Sandbox, SandboxSpec};
@@ -634,6 +634,11 @@ fn resolve_docker_config(settings: &RunNamespace) -> DockerSandboxOptions {
     docker_config_from_environment(&settings.environment, !settings.clone.enabled)
 }
 
+#[cfg(feature = "forkd")]
+fn resolve_forkd_config(settings: &RunNamespace) -> fabro_sandbox::ForkdConfig {
+    forkd_config_from_environment(&settings.environment, !settings.clone.enabled)
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 struct GitRemoteRefCheck {
     origin_url: String,
@@ -642,7 +647,9 @@ struct GitRemoteRefCheck {
 
 fn clone_disabled_for_provider(provider: SandboxProviderKind, resolved_run: &RunNamespace) -> bool {
     match provider {
-        SandboxProviderKind::Docker | SandboxProviderKind::Daytona => !resolved_run.clone.enabled,
+        SandboxProviderKind::Docker | SandboxProviderKind::Daytona | SandboxProviderKind::Forkd => {
+            !resolved_run.clone.enabled
+        }
         SandboxProviderKind::Local => false,
     }
 }
@@ -894,6 +901,23 @@ fn preflight_sandbox_spec(
                 clone_branch,
                 api_key: daytona_api_key,
             }
+        }
+        #[cfg(feature = "forkd")]
+        SandboxProviderKind::Forkd => {
+            let mut config = resolve_forkd_config(resolved_run);
+            config.settings.skip_clone = true;
+            SandboxSpec::Forkd {
+                config: Box::new(config),
+                run_id: None,
+                clone_origin_url,
+                clone_branch,
+            }
+        }
+        #[cfg(not(feature = "forkd"))]
+        SandboxProviderKind::Forkd => {
+            return Err(fabro_sandbox::Error::message(
+                "Forkd sandbox support is not enabled",
+            ));
         }
     })
 }

--- a/lib/crates/fabro-server/src/server.rs
+++ b/lib/crates/fabro-server/src/server.rs
@@ -72,6 +72,8 @@ use fabro_sandbox::{
     DaytonaSandboxProvider, DockerSandboxProvider, LocalSandboxProvider, Sandbox, SandboxProvider,
     SandboxProviderRegistry,
 };
+#[cfg(feature = "forkd")]
+use fabro_sandbox::ForkdSandboxProvider;
 use fabro_slack::client::{PostedMessage as SlackPostedMessage, SlackClient};
 use fabro_slack::config::{
     SlackCredentialResolution,
@@ -2259,6 +2261,9 @@ fn build_sandbox_provider_registry(
             http_client,
         )));
     }
+
+    #[cfg(feature = "forkd")]
+    providers.push(Arc::new(ForkdSandboxProvider::from_env()));
 
     SandboxProviderRegistry::new(providers)
 }

--- a/lib/crates/fabro-server/src/server/handler/sandbox.rs
+++ b/lib/crates/fabro-server/src/server/handler/sandbox.rs
@@ -436,6 +436,11 @@ async fn create_ssh_access(
                 }
             }
         }
+        SandboxProviderKind::Forkd => ApiError::new(
+            StatusCode::CONFLICT,
+            "Sandbox provider does not support access commands.",
+        )
+        .into_response(),
         SandboxProviderKind::Local => ApiError::new(
             StatusCode::CONFLICT,
             "Sandbox provider does not support access commands.",

--- a/lib/crates/fabro-types/src/sandbox_provider.rs
+++ b/lib/crates/fabro-types/src/sandbox_provider.rs
@@ -17,6 +17,8 @@ pub enum SandboxProviderKind {
     Docker,
     /// Run tools inside a Daytona cloud sandbox.
     Daytona,
+    /// Run tools inside a Forkd Firecracker microVM sandbox.
+    Forkd,
 }
 
 impl SandboxProviderKind {
@@ -31,7 +33,7 @@ impl SandboxProviderKind {
     /// True for providers that clone repository sources into their workspace.
     #[must_use]
     pub fn is_clone_based(&self) -> bool {
-        matches!(self, Self::Docker | Self::Daytona)
+        matches!(self, Self::Docker | Self::Daytona | Self::Forkd)
     }
 
     /// Coerce non-local providers to `Local` under dry-run; otherwise

--- a/lib/crates/fabro-types/src/settings/run.rs
+++ b/lib/crates/fabro-types/src/settings/run.rs
@@ -761,6 +761,7 @@ pub enum EnvironmentProvider {
     Local,
     Docker,
     Daytona,
+    Forkd,
 }
 
 impl EnvironmentProvider {
@@ -771,7 +772,9 @@ impl EnvironmentProvider {
 
     #[must_use]
     pub fn is_clone_based(self) -> bool {
-        matches!(self, Self::Docker | Self::Daytona)
+        // Forkd provisions an isolated remote microVM, so the workspace is
+        // cloned into it like the Docker/Daytona clone-based providers.
+        matches!(self, Self::Docker | Self::Daytona | Self::Forkd)
     }
 }
 
@@ -781,6 +784,7 @@ impl From<EnvironmentProvider> for crate::SandboxProviderKind {
             EnvironmentProvider::Local => Self::Local,
             EnvironmentProvider::Docker => Self::Docker,
             EnvironmentProvider::Daytona => Self::Daytona,
+            EnvironmentProvider::Forkd => Self::Forkd,
         }
     }
 }

--- a/lib/crates/fabro-types/src/settings/server.rs
+++ b/lib/crates/fabro-types/src/settings/server.rs
@@ -121,6 +121,7 @@ pub struct ServerSandboxProvidersSettings {
     pub local:   ServerSandboxProviderSettings,
     pub docker:  ServerSandboxProviderSettings,
     pub daytona: ServerSandboxProviderSettings,
+    pub forkd:   ServerSandboxProviderSettings,
 }
 
 impl ServerSandboxProvidersSettings {
@@ -134,6 +135,7 @@ impl ServerSandboxProvidersSettings {
             crate::SandboxProviderKind::Local => &self.local,
             crate::SandboxProviderKind::Docker => &self.docker,
             crate::SandboxProviderKind::Daytona => &self.daytona,
+            crate::SandboxProviderKind::Forkd => &self.forkd,
         }
     }
 }

--- a/lib/crates/fabro-workflow/Cargo.toml
+++ b/lib/crates/fabro-workflow/Cargo.toml
@@ -16,6 +16,9 @@ doctest = false
 [lints]
 workspace = true
 
+[features]
+forkd = ["fabro-sandbox/forkd"]
+
 [dependencies]
 anyhow.workspace = true
 fabro-auth = { path = "../fabro-auth" }

--- a/lib/crates/fabro-workflow/src/operations/start.rs
+++ b/lib/crates/fabro-workflow/src/operations/start.rs
@@ -11,7 +11,7 @@ use fabro_model::{Catalog, FallbackTarget, ProviderId};
 use fabro_sandbox::daytona::DaytonaConfig;
 use fabro_sandbox::from_environment::{
     daytona_config_from_environment, docker_config_from_environment,
-    local_working_directory_from_environment,
+    forkd_config_from_environment, local_working_directory_from_environment,
 };
 use fabro_sandbox::{DockerSandboxOptions, SandboxSpec};
 use fabro_static::EnvVars;
@@ -420,6 +420,17 @@ impl RunSession {
                     api_key,
                 }
             }
+            #[cfg(feature = "forkd")]
+            SandboxProviderKind::Forkd => SandboxSpec::Forkd {
+                config: Box::new(resolve_forkd_config(resolved)),
+                run_id: Some(record.run_id),
+                clone_origin_url: record.repo_origin_url().map(str::to_string),
+                clone_branch: record.base_branch().map(str::to_string),
+            },
+            #[cfg(not(feature = "forkd"))]
+            SandboxProviderKind::Forkd => {
+                return Err(Error::engine("Forkd sandbox support is not enabled"));
+            }
         };
 
         let toml_env = resolved.environment.resolve_env(process_env_var);
@@ -559,6 +570,11 @@ fn resolve_sandbox_provider(settings: &ResolvedRunSettings) -> SandboxProviderKi
 
 fn resolve_daytona_config(settings: &ResolvedRunSettings) -> DaytonaConfig {
     daytona_config_from_environment(&settings.environment, !settings.clone.enabled)
+}
+
+#[cfg(feature = "forkd")]
+fn resolve_forkd_config(settings: &ResolvedRunSettings) -> fabro_sandbox::ForkdConfig {
+    forkd_config_from_environment(&settings.environment, !settings.clone.enabled)
 }
 
 fn resolve_docker_config(settings: &ResolvedRunSettings) -> DockerSandboxOptions {

--- a/specs/forkd-e2e/behavior.feature
+++ b/specs/forkd-e2e/behavior.feature
@@ -1,0 +1,66 @@
+Feature: forkd end-to-end capability
+  As a cal orchestrator
+  I want to create isolated microVM sandboxes, execute commands inside them, and delete them
+  So that agent tasks run in reproducible, ephemeral environments without polluting the host
+
+  @cal-forkd-e2e
+  @task-create-sandbox
+  Scenario: creating a sandbox from a snapshot tag returns a server-assigned id
+    Given the forkd service is reachable
+    And a snapshot tag "zen-gate-base" exists in the snapshot registry
+    When I send a create-sandbox request with snapshot_tag "zen-gate-base"
+    Then the response status is 201
+    And the response body contains a non-empty "id" field
+    And the returned id matches the pattern "[a-f0-9-]{36}"
+
+  @cal-forkd-e2e
+  @task-exec-command
+  Scenario: exec runs an argv command in the microVM and returns its exit code and output
+    Given a sandbox exists with id stored as "sandbox_id"
+    When I send an exec request to sandbox "sandbox_id" with argv ["echo", "hello forkd"]
+    Then the response status is 200
+    And the response body contains exit_code 0
+    And the response body stdout contains "hello forkd"
+    And the response body stderr is empty
+
+  @cal-forkd-e2e
+  @task-exec-working-dir-and-env
+  Scenario: working_dir and env are honored by folding into the argv execution context
+    Given a sandbox exists with id stored as "sandbox_id"
+    And the sandbox filesystem contains a directory "/workspace/project"
+    When I send an exec request to sandbox "sandbox_id" with:
+      | field       | value                        |
+      | argv        | ["pwd"]                      |
+      | working_dir | /workspace/project           |
+    Then the response stdout contains "/workspace/project"
+    When I send an exec request to sandbox "sandbox_id" with:
+      | field       | value                                        |
+      | argv        | ["sh", "-c", "echo $FORKD_TEST_VAR"]         |
+      | env         | {"FORKD_TEST_VAR": "sentinel-42"}            |
+    Then the response stdout contains "sentinel-42"
+    And the response exit_code is 0
+
+  @cal-forkd-e2e
+  @task-delete-idempotent
+  Scenario: delete is idempotent
+    Given a sandbox exists with id stored as "sandbox_id"
+    When I send a delete request for sandbox "sandbox_id"
+    Then the response status is 204
+    When I send a delete request for sandbox "sandbox_id" again
+    Then the response status is 204 or 404
+    And no error body indicating a server fault is returned
+
+  @cal-forkd-e2e
+  @task-real-workflow
+  Scenario: a real workflow executing git clone and running a command completes inside the microVM
+    Given the forkd service is reachable
+    And a snapshot tag "zen-gate-base" exists in the snapshot registry
+    When I create a sandbox from snapshot_tag "zen-gate-base" and store its id as "wf_sandbox_id"
+    And I exec in sandbox "wf_sandbox_id" with argv ["git", "clone", "--depth", "1", "https://github.com/nicowillis/hello-world.git", "/tmp/repo"]
+    Then the exec response exit_code is 0
+    And the sandbox filesystem path "/tmp/repo" exists
+    When I exec in sandbox "wf_sandbox_id" with argv ["sh", "-c", "cd /tmp/repo && ls -1"] and working_dir "/"
+    Then the exec response exit_code is 0
+    And the exec response stdout is non-empty
+    When I delete sandbox "wf_sandbox_id"
+    Then the delete response status is 204


### PR DESCRIPTION
# feat(sandbox): forkd Firecracker microVM provider

## Why

fabro already supports Local, Docker, and Daytona sandboxes. Daytona is a great
fit for managed/cloud remote VMs. This PR adds a complementary option for teams
that need execution to stay fully **self-contained and on-premise**:

- **Strong isolation without a shared kernel.** Firecracker microVMs give each
  step a real VM boundary (vs Docker's shared host kernel), closer to Daytona's
  isolation but without a hosted control plane.
- **Self-hosted, zero external dependency.** forkd runs on your own hardware via
  a small controller API. No SaaS account, no per-VM cloud billing, no data
  leaving the network. Ideal for regulated/air-gapped/on-prem deployments.
- **Fast clone-from-snapshot.** forkd's snapshot+clone model gives microVM-grade
  isolation with container-like start times, so per-step VMs stay practical.

It is purely additive: a new `SandboxProvider` selected via config, mirroring the
existing daytona provider's structure. Local/Docker/Daytona are unchanged.

## What

- `SandboxCreateSpec::Forkd` + `SandboxProviderKind::Forkd`
- `ForkdConfig`/`ForkdSettings` (controller URL, token, snapshot/image) in config
- A thin forkd controller HTTP client (clone snapshot, exec, delete; token auth)
- `ForkdSandboxProvider` (impl `SandboxProvider`: create/list/get/delete)
- `ForkdSandbox` (impl the full `Sandbox` trait over a microVM: exec, streaming,
  file up/down, lifecycle, git)
- Registry + `from_environment` wiring; tests mirroring the sandbox round-trips

Credentials (forkd token) come from config/env, never hardcoded.

## Status

First cut. Behavior contract: 27 BDD scenarios across the provider + Sandbox trait
surface. Compile/CI verification pending on a Rust-capable runner.
