### PR TITLE
Add a durable main event stream

### DIFF
--- a/docs/superpowers/specs/2026-06-21-main-event-stream-design.md
+++ b/docs/superpowers/specs/2026-06-21-main-event-stream-design.md
@@ -1,0 +1,194 @@
+# Fabro Main Event Stream Design
+
+## Context
+
+Fabro currently has durable workflow run event streams. Each run stores canonical
+`RunEvent` records under a run-scoped SlateDB prefix:
+
+```text
+runs/<run_id>/events/<seq-ts>
+```
+
+Those per-run events drive run projections, run event APIs, attach/SSE, CLI
+progress, and live server broadcasts. They are also deleted when the run is
+deleted.
+
+The server also has an in-memory `global_event_tx`, but that is only a live
+broadcast of per-run events for active server consumers. It is not durable and
+is not the "main event stream" needed for future automation triggers.
+
+This design creates the first chunk of the main event stream: a durable,
+server-wide event log for coarse internal Fabro lifecycle events. It does not
+include GitHub webhook ingestion, automation trigger matching, public APIs, or
+listener cursor persistence.
+
+## Goals
+
+- Add a durable main event stream in the existing SlateDB database.
+- Store main events under a global prefix that survives run deletion.
+- Mirror selected coarse run lifecycle events into the main stream.
+- Give main events their own identity, sequence, and timestamp.
+- Preserve enough compact event details for future automation matching and audit
+  even after a run is deleted.
+- Keep storage generic and place lifecycle mirroring policy in `fabro-server`.
+
+## Non-Goals
+
+- Do not ingest GitHub webhook deliveries in this chunk.
+- Do not add event-triggered automations or matcher syntax.
+- Do not add public API, SSE, or CLI surfaces for the main stream.
+- Do not persist listener cursors or retry state.
+- Do not mirror stage, agent, tool, transcript, sandbox, or detailed run events.
+- Do not duplicate large run payloads such as full graphs, settings, patches,
+  transcripts, or tool output.
+
+## Main Event Model
+
+Add a new shared type module in `fabro-types` named `main_event`.
+
+`MainEventEnvelope` contains:
+
+- `seq`: monotonically increasing main-stream sequence number.
+- `event`: the `MainEvent`.
+
+`MainEvent` contains:
+
+- `id`: new UUIDv7-style event id for the main stream record.
+- `ts`: append timestamp for the main stream record.
+- `event`: the main event name through a typed `MainEventBody`.
+- `properties`: typed body data through serde's tagged enum shape.
+
+Each mirrored run lifecycle event gets a distinct main event name:
+
+- `fabro.run.created`
+- `fabro.run.started`
+- `fabro.run.running`
+- `fabro.run.completed`
+- `fabro.run.failed`
+- `fabro.run.cancelled`
+- `fabro.run.paused`
+- `fabro.run.unpaused`
+
+`run.cancel.requested` is intentionally not mirrored in v1. Terminal
+cancellation is represented today by `run.failed` with cancellation semantics,
+so the main stream emits `fabro.run.cancelled` for that terminal condition.
+
+All mirrored events include source metadata:
+
+- `run_id`
+- `source_event_id`
+- `source_event_ts`
+- `source_event_name`
+- `actor`, when present
+
+Lifecycle bodies include compact standalone summaries:
+
+- Created: title, workflow slug, automation ref, git context, parent id, and
+  provenance subject or actor information.
+- Started/running: run id, source metadata, and lightweight start metadata when
+  present.
+- Completed: success reason/status, final commit SHA, compact billing summary,
+  automation ref when available, and source metadata.
+- Failed: failure reason/category/message summary, final commit SHA, compact
+  billing summary, automation ref when available, and source metadata.
+- Cancelled: same source shape as failed, but named as a cancellation event and
+  containing cancellation reason/message summary.
+- Paused/unpaused: run id and source metadata.
+
+The main event stream must stand on its own after run deletion, but it should
+not become a second full run event log.
+
+## Storage
+
+Add a main event store to `fabro-store::Database` using the same SlateDB
+database as runs. Events are stored under:
+
+```text
+events/main/<seq-ts>
+```
+
+The store supports internal operations:
+
+- append a `MainEventBody` and return a `MainEventEnvelope`.
+- list events from `since_seq` with a bounded limit.
+- recover the next sequence number on open by scanning the prefix.
+- subscribe to live appended main events for future internal consumers.
+
+Run deletion remains scoped to `runs/<run_id>/...`, so it does not remove main
+events.
+
+`fabro-store` should not decide which run events are worth mirroring. It only
+stores and replays main events.
+
+## Server Mirroring
+
+`fabro-server` owns the mirroring policy.
+
+The first implementation point is the existing active-run forwarding path that
+subscribes to each active run's event stream and forwards events into
+`global_event_tx`. When a run event arrives:
+
+1. Reconcile the server's live run state as it does today.
+2. Attempt to map the `RunEvent` to a `MainEventBody`.
+3. Append the main event if the run event is one of the selected lifecycle
+   events.
+4. Ignore all non-v1 run events.
+5. Continue broadcasting the run event through the existing in-memory bus.
+
+This keeps product policy in the server and leaves `fabro-store` as the durable
+storage layer.
+
+## Error Handling
+
+This chunk follows the current practical behavior of run event persistence:
+
+- Server/API lifecycle append paths already fail when their run event append
+  fails.
+- Workflow runtime event logging can be warning-only through the async run event
+  logger.
+
+Main event mirroring from the active-run forwarding path logs a warning on append
+failure and does not stop or fail the running workflow. This is acceptable for
+the first chunk because there is no automation listener yet. A later automation
+trigger chunk can introduce stricter fail-closed wrappers for critical server
+transitions if trigger correctness requires them.
+
+## Testing
+
+Add focused coverage at three layers.
+
+`fabro-types`:
+
+- `MainEvent` serde round trips for each v1 event name.
+- Event name mapping is explicit and stable.
+- Unknown event names deserialize into an `Unknown` body that preserves the
+  original name and raw properties, matching the compatibility style of
+  `RunEvent`.
+
+`fabro-store`:
+
+- Append and list main events under `events/main/<seq-ts>`.
+- Sequence numbers are stable and recover after reopening the database.
+- `delete_run` does not delete main events.
+- Bounded list-from behavior returns ordered events from `since_seq`.
+
+`fabro-server`:
+
+- Active run lifecycle events mirror into the main event store.
+- Non-v1 events such as stage or agent events are ignored.
+- Terminal cancelled `run.failed` maps to `fabro.run.cancelled`.
+- Normal `run.failed` maps to `fabro.run.failed`.
+- Mirroring failures are logged and do not stop forwarding the original run
+  event.
+
+## Deferred Follow-Up Work
+
+- GitHub webhook producer: convert verified webhook deliveries into durable main
+  events with raw provider payloads and idempotency metadata.
+- Automation event triggers: add deterministic matcher syntax and an internal
+  replay-plus-tail listener over the main event store.
+- Listener cursors: persist per-listener processing state and retry behavior.
+- Public read/stream APIs: expose main events to operators or external
+  consumers only after the internal model has settled.
+- Stronger failure semantics: add server wrappers for critical lifecycle paths
+  if automation correctness requires fail-closed mirroring.

--- a/lib/apps/fabro-server/src/server.rs
+++ b/lib/apps/fabro-server/src/server.rs
@@ -173,6 +173,7 @@ use crate::{
 
 mod automation_scheduler;
 mod handler;
+mod main_event_mirror;
 mod pull_request_supervisor;
 mod resource_sampler;
 mod session_runtime;
@@ -3317,16 +3318,71 @@ async fn forward_run_events_to_global(
     loop {
         match run_events.recv().await {
             Ok(event) => {
-                let mut runs = state.runs.lock().expect("runs lock poisoned");
-                if let Some(managed_run) = runs.get_mut(&run_id) {
-                    reconcile_live_interview_state_for_event(managed_run, &event.event);
+                {
+                    let mut runs = state.runs.lock().expect("runs lock poisoned");
+                    if let Some(managed_run) = runs.get_mut(&run_id) {
+                        reconcile_live_interview_state_for_event(managed_run, &event.event);
+                    }
                 }
+
+                if let Err(err) =
+                    append_main_event_for_run_event(state.as_ref(), &event.event).await
+                {
+                    tracing::warn!(
+                        run_id = %event.event.run_id,
+                        source_event_id = %event.event.id,
+                        source_event_name = event.event.event_name(),
+                        error = %err,
+                        "Failed to mirror live run event to main event stream"
+                    );
+                }
+
                 let _ = state.global_event_tx.send(event);
             }
-            Err(RecvError::Lagged(_)) => {}
+            Err(RecvError::Lagged(skipped)) => {
+                tracing::warn!(
+                    run_id = %run_id,
+                    skipped,
+                    "Run event forwarder lagged; skipped live run events cannot be mirrored to the main stream"
+                );
+            }
             Err(RecvError::Closed) => break,
         }
     }
+}
+
+pub(super) async fn append_main_event_for_run_event(
+    state: &AppState,
+    event: &RunEvent,
+) -> anyhow::Result<()> {
+    if let Some(body) = main_event_mirror::main_event_body_from_run_event(event) {
+        let main_events = state
+            .stores
+            .runs
+            .main_events()
+            .await
+            .context("open main event store for mirroring")?;
+        main_events
+            .append(body)
+            .await
+            .context("append mirrored main event")?;
+    }
+    Ok(())
+}
+
+pub(super) async fn mirror_persisted_run_created_to_main(
+    state: &AppState,
+    run_id: RunId,
+) -> anyhow::Result<()> {
+    let run_store = state.stores.runs.open_run(&run_id).await?;
+    let events = run_store.list_events_from_with_limit(1, 1).await?;
+    let Some(created) = events
+        .into_iter()
+        .find(|event| matches!(event.event.body, EventBody::RunCreated(_)))
+    else {
+        anyhow::bail!("run {run_id} has no run.created event to mirror");
+    };
+    append_main_event_for_run_event(state, &created.event).await
 }
 
 fn managed_run(

--- a/lib/apps/fabro-server/src/server/handler/runs.rs
+++ b/lib/apps/fabro-server/src/server/handler/runs.rs
@@ -42,8 +42,9 @@ use tracing::info;
 use super::super::{
     AppState, DeleteRunOutcome, ListResponse, RunExecutionMode, VariableError, answer_from_request,
     api_question_from_pending_interview, clamp_page_limit, clamp_page_offset, default_page_limit,
-    delete_run_internal, load_pending_interview, managed_run, parse_run_id_path,
-    parse_stage_id_path, reject_if_archived, submit_pending_interview_answer, workflow_event,
+    delete_run_internal, load_pending_interview, managed_run, mirror_persisted_run_created_to_main,
+    parse_run_id_path, parse_stage_id_path, reject_if_archived, submit_pending_interview_answer,
+    workflow_event,
 };
 use crate::error::ApiError;
 use crate::principal_middleware::{
@@ -820,6 +821,18 @@ pub(crate) async fn create_run_from_manifest(
             .into_response();
         }
     };
+    if let Err(err) = mirror_persisted_run_created_to_main(state.as_ref(), created.run_id).await {
+        tracing::error!(
+            run_id = %created.run_id,
+            error = %err,
+            "Failed to mirror persisted run creation to main event stream"
+        );
+        return ApiError::new(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "Failed to record run creation.",
+        )
+        .into_response();
+    }
     let created_at = created.run_id.created_at();
     let summary = match state
         .stores

--- a/lib/apps/fabro-server/src/server/main_event_mirror.rs
+++ b/lib/apps/fabro-server/src/server/main_event_mirror.rs
@@ -1,0 +1,215 @@
+use fabro_types::{
+    EventBody, FailureReason, MainEventBody, MainEventCancelledProps, MainEventCompletedProps,
+    MainEventCreatedProps, MainEventFailedProps, MainEventLifecycleProps, MainEventSource,
+    MainEventStartedProps, RunEvent,
+};
+
+pub(crate) fn main_event_body_from_run_event(event: &RunEvent) -> Option<MainEventBody> {
+    let source = source_from_run_event(event);
+    match &event.body {
+        EventBody::RunCreated(props) => Some(MainEventBody::RunCreated(MainEventCreatedProps {
+            source,
+            title: props.title.clone(),
+            workflow_slug: props.workflow_slug.clone(),
+            automation: props.automation.clone(),
+            git: props.git.clone(),
+            parent_id: props.parent_id,
+            provenance_subject: Some(props.provenance.subject.clone()),
+        })),
+        EventBody::RunStarted(props) => Some(MainEventBody::RunStarted(MainEventStartedProps {
+            source,
+            name: props.name.clone(),
+            base_branch: props.base_branch.clone(),
+            base_sha: props.base_sha.clone(),
+            run_branch: props.run_branch.clone(),
+            worktree_dir: props.worktree_dir.clone(),
+            goal: props.goal.clone(),
+        })),
+        EventBody::RunRunning(_) => Some(MainEventBody::RunRunning(MainEventLifecycleProps {
+            source,
+        })),
+        EventBody::RunCompleted(props) => {
+            Some(MainEventBody::RunCompleted(MainEventCompletedProps {
+                source,
+                status: props.status.clone(),
+                reason: props.reason,
+                total_usd_micros: props.total_usd_micros,
+                final_git_commit_sha: props.final_git_commit_sha.clone(),
+                automation: None,
+                billing: props.billing.clone(),
+            }))
+        }
+        EventBody::RunFailed(props) if props.failure.reason == FailureReason::Cancelled => {
+            Some(MainEventBody::RunCancelled(MainEventCancelledProps {
+                source,
+                reason: props.failure.reason,
+                category: props.failure.detail.category,
+                message: props.failure.detail.message.clone(),
+                final_git_commit_sha: props.final_git_commit_sha.clone(),
+                automation: None,
+                billing: props.billing.clone(),
+            }))
+        }
+        EventBody::RunFailed(props) => Some(MainEventBody::RunFailed(MainEventFailedProps {
+            source,
+            reason: props.failure.reason,
+            category: props.failure.detail.category,
+            message: props.failure.detail.message.clone(),
+            final_git_commit_sha: props.final_git_commit_sha.clone(),
+            automation: None,
+            billing: props.billing.clone(),
+        })),
+        EventBody::RunPaused(_) => {
+            Some(MainEventBody::RunPaused(MainEventLifecycleProps { source }))
+        }
+        EventBody::RunUnpaused(_) => Some(MainEventBody::RunUnpaused(MainEventLifecycleProps {
+            source,
+        })),
+        _ => None,
+    }
+}
+
+fn source_from_run_event(event: &RunEvent) -> MainEventSource {
+    MainEventSource {
+        run_id:            event.run_id,
+        source_event_id:   event.id.clone(),
+        source_event_ts:   event.ts,
+        source_event_name: event.event_name().to_string(),
+        actor:             event.actor.clone(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::{TimeZone, Utc};
+    use fabro_types::run_event::RunFailedProps;
+    use fabro_types::{
+        EventBody, FailureCategory, FailureDetail, FailureReason, Graph, MainEventBody, RunEvent,
+        RunFailure, RunTiming, WorkflowSettings, fixtures, test_support,
+    };
+    use serde_json::json;
+
+    use super::main_event_body_from_run_event;
+
+    fn run_event(event_name: &str, properties: &serde_json::Value) -> RunEvent {
+        RunEvent::from_value(json!({
+            "id": format!("evt-{event_name}"),
+            "ts": "2026-06-21T12:00:00Z",
+            "run_id": fixtures::RUN_1,
+            "event": event_name,
+            "properties": properties.clone()
+        }))
+        .unwrap()
+    }
+
+    #[test]
+    fn maps_created_with_compact_identity_fields() {
+        let event = run_event(
+            "run.created",
+            &json!({
+                "title": "Triage bug",
+                "settings": WorkflowSettings::default(),
+                "graph": Graph::new("test"),
+                "run_dir": "/tmp/test",
+                "workflow_slug": "triage",
+                "provenance": test_support::test_run_provenance(),
+                "parent_id": fixtures::RUN_2,
+            }),
+        );
+
+        let mapped = main_event_body_from_run_event(&event).unwrap();
+        match mapped {
+            MainEventBody::RunCreated(props) => {
+                assert_eq!(props.source.run_id, fixtures::RUN_1);
+                assert_eq!(props.source.source_event_name, "run.created");
+                assert_eq!(props.title.as_deref(), Some("Triage bug"));
+                assert_eq!(props.workflow_slug.as_deref(), Some("triage"));
+                assert_eq!(props.parent_id, Some(fixtures::RUN_2));
+                assert!(props.provenance_subject.is_some());
+            }
+            other => panic!("expected created, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn maps_failed_and_cancelled_separately() {
+        let failed = RunEvent {
+            id:                 "evt-failed".to_string(),
+            ts:                 Utc.with_ymd_and_hms(2026, 6, 21, 12, 0, 0).unwrap(),
+            run_id:             fixtures::RUN_1,
+            node_id:            None,
+            node_label:         None,
+            stage_id:           None,
+            parallel_group_id:  None,
+            parallel_branch_id: None,
+            session_id:         None,
+            parent_session_id:  None,
+            tool_call_id:       None,
+            actor:              None,
+            body:               EventBody::RunFailed(RunFailedProps {
+                failure:              RunFailure {
+                    reason: FailureReason::WorkflowError,
+                    detail: FailureDetail {
+                        message:          "boom".to_string(),
+                        category:         FailureCategory::Deterministic,
+                        causes:           Vec::new(),
+                        system_actor:     None,
+                        signature:        None,
+                        exec_output_tail: None,
+                    },
+                },
+                timing:               RunTiming::default(),
+                final_git_commit_sha: Some("abc123".to_string()),
+                final_patch:          None,
+                diff_summary:         None,
+                billing:              None,
+            }),
+        };
+        assert!(matches!(
+            main_event_body_from_run_event(&failed),
+            Some(MainEventBody::RunFailed(_))
+        ));
+
+        let mut cancelled = failed.clone();
+        cancelled.id = "evt-cancelled".to_string();
+        cancelled.body = EventBody::RunFailed(RunFailedProps {
+            failure:              RunFailure {
+                reason: FailureReason::Cancelled,
+                detail: FailureDetail {
+                    message:          "cancelled".to_string(),
+                    category:         FailureCategory::Canceled,
+                    causes:           Vec::new(),
+                    system_actor:     None,
+                    signature:        None,
+                    exec_output_tail: None,
+                },
+            },
+            timing:               RunTiming::default(),
+            final_git_commit_sha: None,
+            final_patch:          None,
+            diff_summary:         None,
+            billing:              None,
+        });
+        assert!(matches!(
+            main_event_body_from_run_event(&cancelled),
+            Some(MainEventBody::RunCancelled(_))
+        ));
+    }
+
+    #[test]
+    fn ignores_non_v1_events_and_cancel_requested() {
+        let stage = run_event(
+            "stage.started",
+            &json!({
+                "index": 0,
+                "handler_type": "command",
+                "attempt": 1,
+                "max_attempts": 1
+            }),
+        );
+        assert!(main_event_body_from_run_event(&stage).is_none());
+
+        let cancel_requested = run_event("run.cancel.requested", &json!({ "action": "cancel" }));
+        assert!(main_event_body_from_run_event(&cancel_requested).is_none());
+    }
+}

--- a/lib/apps/fabro-server/src/server/tests.rs
+++ b/lib/apps/fabro-server/src/server/tests.rs
@@ -27,8 +27,8 @@ use fabro_types::settings::ServerAuthMethod;
 use fabro_types::settings::run::EnvironmentProvider;
 use fabro_types::{
     AgentBackend, AttrValue, AuthMethod, BlobHash, CommandTermination, FailureCategory,
-    FailureDetail, Graph, InterviewQuestionRecord, Node, Outcome, ParallelBranchId, QuestionType,
-    RunId, RunSpec, SandboxProviderKind, StageContextWindowBreakdownItem,
+    FailureDetail, Graph, InterviewQuestionRecord, MainEventBody, Node, Outcome, ParallelBranchId,
+    QuestionType, RunId, RunSpec, SandboxProviderKind, StageContextWindowBreakdownItem,
     StageContextWindowCategory, StageContextWindowCountMethod, StageContextWindowProjection,
     StageContextWindowStaleness, StageContextWindowWarning, StageModelUsage, StageTiming,
     SuccessReason, SystemActorKind, WorkflowSettings, fixtures, test_support,
@@ -229,6 +229,211 @@ fn run_json_pending_control(run: &serde_json::Value) -> &serde_json::Value {
 
 fn run_json_archived(run: &serde_json::Value) -> bool {
     run["lifecycle"]["archived"].as_bool().unwrap_or(false)
+}
+
+async fn wait_for_main_events(
+    main_events: StdArc<fabro_store::MainEventStore>,
+    expected_len: usize,
+) -> Vec<fabro_types::MainEventEnvelope> {
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+    loop {
+        let listed = main_events.list_from_with_limit(1, 100).await.unwrap();
+        if listed.len() == expected_len {
+            return listed;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "timed out waiting for {expected_len} main events, saw {}",
+            listed.len()
+        );
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+    }
+}
+
+fn run_event_value(
+    run_id: RunId,
+    event_name: &str,
+    properties: &serde_json::Value,
+) -> serde_json::Value {
+    json!({
+        "id": format!("evt-{event_name}"),
+        "ts": "2026-06-21T12:00:00Z",
+        "run_id": run_id,
+        "event": event_name,
+        "properties": properties.clone()
+    })
+}
+
+async fn append_run_event(
+    run_store: &fabro_store::RunDatabase,
+    run_id: RunId,
+    event_name: &str,
+    properties: &serde_json::Value,
+) {
+    let payload =
+        fabro_store::EventPayload::new(run_event_value(run_id, event_name, properties), &run_id)
+            .unwrap();
+    run_store.append_event(&payload).await.unwrap();
+}
+
+#[tokio::test]
+async fn persisted_run_created_mirrors_to_main_stream_without_forwarder() {
+    let state = test_app_state();
+    let run_id = fixtures::RUN_1;
+    let run_store = state.stores.runs.create_run(&run_id).await.unwrap();
+
+    append_run_event(
+        &run_store,
+        run_id,
+        "run.created",
+        &json!({
+            "title": "Triage bug",
+            "settings": WorkflowSettings::default(),
+            "graph": Graph::new("test"),
+            "run_dir": "/tmp/test",
+            "workflow_slug": "triage",
+            "provenance": test_support::test_run_provenance()
+        }),
+    )
+    .await;
+
+    mirror_persisted_run_created_to_main(state.as_ref(), run_id)
+        .await
+        .unwrap();
+
+    let main_events = state.stores.runs.main_events().await.unwrap();
+    let listed = wait_for_main_events(StdArc::clone(&main_events), 1).await;
+
+    match &listed[0].event.body {
+        MainEventBody::RunCreated(props) => {
+            assert_eq!(props.source.run_id, run_id);
+            assert_eq!(props.title.as_deref(), Some("Triage bug"));
+            assert_eq!(props.workflow_slug.as_deref(), Some("triage"));
+        }
+        other => panic!("expected created, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn forward_run_events_mirrors_live_lifecycle_events_to_main_stream() {
+    let state = test_app_state();
+    let run_id = fixtures::RUN_1;
+    let run_store = state.stores.runs.create_run(&run_id).await.unwrap();
+    append_run_event(
+        &run_store,
+        run_id,
+        "run.created",
+        &json!({
+            "settings": WorkflowSettings::default(),
+            "graph": Graph::new("test"),
+            "run_dir": "/tmp/test",
+            "provenance": test_support::test_run_provenance()
+        }),
+    )
+    .await;
+    let forwarder = tokio::spawn(forward_run_events_to_global(
+        StdArc::clone(&state),
+        run_id,
+        run_store.subscribe(),
+    ));
+
+    append_run_event(
+        &run_store,
+        run_id,
+        "run.started",
+        &json!({
+            "name": "triage",
+            "base_branch": "main",
+            "run_branch": "fabro/run-1",
+            "goal": "Triage bug"
+        }),
+    )
+    .await;
+    append_run_event(
+        &run_store,
+        run_id,
+        "run.runnable",
+        &json!({ "source": "start_requested" }),
+    )
+    .await;
+    append_run_event(&run_store, run_id, "run.starting", &json!({})).await;
+    append_run_event(&run_store, run_id, "run.running", &json!({})).await;
+
+    let main_events = state.stores.runs.main_events().await.unwrap();
+    let listed = wait_for_main_events(StdArc::clone(&main_events), 2).await;
+
+    assert!(matches!(listed[0].event.body, MainEventBody::RunStarted(_)));
+    assert!(matches!(listed[1].event.body, MainEventBody::RunRunning(_)));
+
+    drop(run_store);
+    forwarder.abort();
+}
+
+#[tokio::test]
+async fn forward_run_events_ignores_non_v1_and_maps_cancelled() {
+    let state = test_app_state();
+    let run_id = fixtures::RUN_1;
+    let run_store = state.stores.runs.create_run(&run_id).await.unwrap();
+    append_run_event(
+        &run_store,
+        run_id,
+        "run.created",
+        &json!({
+            "settings": WorkflowSettings::default(),
+            "graph": Graph::new("test"),
+            "run_dir": "/tmp/test",
+            "provenance": test_support::test_run_provenance()
+        }),
+    )
+    .await;
+    let forwarder = tokio::spawn(forward_run_events_to_global(
+        StdArc::clone(&state),
+        run_id,
+        run_store.subscribe(),
+    ));
+
+    append_run_event(
+        &run_store,
+        run_id,
+        "stage.started",
+        &json!({
+            "index": 0,
+            "handler_type": "command",
+            "attempt": 1,
+            "max_attempts": 1
+        }),
+    )
+    .await;
+    append_run_event(
+        &run_store,
+        run_id,
+        "run.failed",
+        &json!({
+            "failure": {
+                "reason": "cancelled",
+                "detail": {
+                    "message": "cancelled",
+                    "category": "canceled"
+                }
+            },
+            "timing": {"wall_time_ms": 1, "inference_time_ms": 0, "tool_time_ms": 0, "active_time_ms": 0}
+        }),
+    )
+    .await;
+
+    let main_events = state.stores.runs.main_events().await.unwrap();
+    let listed = wait_for_main_events(StdArc::clone(&main_events), 1).await;
+
+    assert_eq!(
+        listed
+            .iter()
+            .map(|event| event.event.event_name())
+            .collect::<Vec<_>>(),
+        vec!["fabro.run.cancelled"]
+    );
+
+    drop(run_store);
+    forwarder.abort();
 }
 
 async fn mock_daytona_auth_probe(server: &MockServer) -> httpmock::Mock<'_> {

--- a/lib/components/fabro-store/src/keys.rs
+++ b/lib/components/fabro-store/src/keys.rs
@@ -91,6 +91,16 @@ pub(crate) fn run_events_range(run_id: &RunId, start_seq: u32) -> Range<SlateKey
     run_event_seq_prefix(run_id, start_seq)..end
 }
 
+pub(crate) fn main_events_prefix() -> SlateKey {
+    SlateKey::new("events").with("main").into_prefix()
+}
+
+pub(crate) fn main_event_key(seq: u32, epoch_ms: i64) -> SlateKey {
+    SlateKey::new("events")
+        .with("main")
+        .with(format!("{seq:06}-{epoch_ms}"))
+}
+
 pub(crate) fn sessions_by_id_prefix() -> SlateKey {
     SlateKey::new("sessions").with("by-id").into_prefix()
 }
@@ -111,6 +121,16 @@ pub(crate) fn parse_event_seq(key: &str) -> Option<u32> {
     segments.next()?.split_once('-')?.0.parse().ok()
 }
 
+pub(crate) fn parse_main_event_seq(key: &str) -> Option<u32> {
+    let mut segments = SlateKey::segments(key);
+    if segments.next()? != "events" {
+        return None;
+    }
+    if segments.next()? != "main" {
+        return None;
+    }
+    segments.next()?.split_once('-')?.0.parse().ok()
+}
 #[cfg(test)]
 mod tests {
     use fabro_types::RunId;
@@ -140,6 +160,13 @@ mod tests {
             "events",
             "000007-123"
         ]);
+    }
+
+    #[test]
+    fn main_event_key_segments() {
+        let key = main_event_key(7, 123);
+        let segments: Vec<&str> = SlateKey::segments(key.as_str()).collect();
+        assert_eq!(segments, ["events", "main", "000007-123"]);
     }
 
     #[test]
@@ -174,6 +201,23 @@ mod tests {
         assert_eq!(
             parse_event_seq(run_event_key(&run_id, 7, 123).as_str()),
             Some(7)
+        );
+    }
+
+    #[test]
+    fn parse_main_event_seq_roundtrip() {
+        assert_eq!(
+            parse_main_event_seq(main_event_key(7, 123).as_str()),
+            Some(7)
+        );
+        assert_eq!(
+            parse_main_event_seq(
+                SlateKey::new("events")
+                    .with("other")
+                    .with("000007-123")
+                    .as_str()
+            ),
+            None
         );
     }
 

--- a/lib/components/fabro-store/src/lib.rs
+++ b/lib/components/fabro-store/src/lib.rs
@@ -36,8 +36,8 @@ pub use run_summary_store::{
 };
 pub use serializable_projection::SerializableProjection;
 pub use slate::{
-    AuthCode, AuthCodeStore, CachedRunProjection, ConsumeOutcome, Database, RefreshToken,
-    RefreshTokenStore, RunCatalogIndex, RunDatabase, Runs, UnreadableRun,
+    AuthCode, AuthCodeStore, CachedRunProjection, ConsumeOutcome, Database, MainEventStore,
+    RefreshToken, RefreshTokenStore, RunCatalogIndex, RunDatabase, Runs, UnreadableRun,
 };
 pub use types::EventPayload;
 

--- a/lib/components/fabro-store/src/slate/main_event_store.rs
+++ b/lib/components/fabro-store/src/slate/main_event_store.rs
@@ -1,0 +1,124 @@
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU32, Ordering};
+
+use bytes::Bytes;
+use chrono::Utc;
+use fabro_types::{MainEvent, MainEventBody, MainEventEnvelope};
+use slatedb::{Db, DbRead};
+use tokio::sync::{Mutex, broadcast};
+use uuid::Uuid;
+
+use crate::{Error, Result, keys};
+
+const DEFAULT_MAIN_EVENT_TAIL_LIMIT: usize = 1024;
+
+#[derive(Clone)]
+pub struct MainEventStore {
+    inner: Arc<MainEventStoreInner>,
+}
+
+impl std::fmt::Debug for MainEventStore {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MainEventStore").finish_non_exhaustive()
+    }
+}
+
+struct MainEventStoreInner {
+    db:          Db,
+    event_seq:   AtomicU32,
+    append_lock: Mutex<()>,
+    event_tx:    broadcast::Sender<MainEventEnvelope>,
+}
+
+impl MainEventStore {
+    pub(crate) async fn open(db: Db) -> Result<Self> {
+        let event_seq = recover_next_seq(&db).await?;
+        let (event_tx, _) = broadcast::channel(DEFAULT_MAIN_EVENT_TAIL_LIMIT.max(16));
+        Ok(Self {
+            inner: Arc::new(MainEventStoreInner {
+                db,
+                event_seq: AtomicU32::new(event_seq),
+                append_lock: Mutex::new(()),
+                event_tx,
+            }),
+        })
+    }
+
+    pub async fn append(&self, body: MainEventBody) -> Result<MainEventEnvelope> {
+        let _guard = self.inner.append_lock.lock().await;
+        let seq = self.inner.event_seq.fetch_add(1, Ordering::SeqCst);
+        let now = Utc::now();
+        let event = MainEvent {
+            id: Uuid::now_v7().to_string(),
+            ts: now,
+            body,
+        };
+        self.inner
+            .db
+            .put(
+                keys::main_event_key(seq, now.timestamp_millis()),
+                serde_json::to_vec(&event)?,
+            )
+            .await?;
+        let envelope = MainEventEnvelope { seq, event };
+        let _ = self.inner.event_tx.send(envelope.clone());
+        Ok(envelope)
+    }
+
+    pub fn subscribe(&self) -> broadcast::Receiver<MainEventEnvelope> {
+        self.inner.event_tx.subscribe()
+    }
+
+    pub async fn list_from_with_limit(
+        &self,
+        start_seq: u32,
+        limit: usize,
+    ) -> Result<Vec<MainEventEnvelope>> {
+        let mut events = list_events_from(&self.inner.db, start_seq).await?;
+        events.truncate(limit.saturating_add(1));
+        Ok(events)
+    }
+}
+
+async fn recover_next_seq<R>(db: &R) -> Result<u32>
+where
+    R: DbRead + Sync,
+{
+    let mut iter = db.scan_prefix(keys::main_events_prefix()).await?;
+    let mut max_seq = 0;
+    while let Some(entry) = iter.next().await? {
+        let key = key_to_string(&entry.key)?;
+        if let Some(seq) = keys::parse_main_event_seq(&key) {
+            max_seq = max_seq.max(seq);
+        }
+    }
+    Ok(max_seq.saturating_add(1).max(1))
+}
+
+async fn list_events_from<R>(db: &R, start_seq: u32) -> Result<Vec<MainEventEnvelope>>
+where
+    R: DbRead + Sync,
+{
+    let mut iter = db.scan_prefix(keys::main_events_prefix()).await?;
+    let mut events = Vec::new();
+    while let Some(entry) = iter.next().await? {
+        let key = key_to_string(&entry.key)?;
+        let Some(seq) = keys::parse_main_event_seq(&key) else {
+            continue;
+        };
+        if seq < start_seq {
+            continue;
+        }
+        events.push(MainEventEnvelope {
+            seq,
+            event: serde_json::from_slice(&entry.value)?,
+        });
+    }
+    events.sort_by_key(|event| event.seq);
+    Ok(events)
+}
+
+fn key_to_string(key: &Bytes) -> Result<String> {
+    String::from_utf8(key.to_vec())
+        .map_err(|err| Error::Other(format!("stored key is not valid UTF-8: {err}")))
+}

--- a/lib/components/fabro-store/src/slate/mod.rs
+++ b/lib/components/fabro-store/src/slate/mod.rs
@@ -1,5 +1,6 @@
 mod auth_codes;
 mod auth_tokens;
+mod main_event_store;
 mod projection_cache;
 mod run_catalog_index;
 mod run_store;
@@ -13,6 +14,7 @@ pub use auth_codes::{AuthCode, AuthCodeStore};
 pub use auth_tokens::{ConsumeOutcome, RefreshToken, RefreshTokenStore};
 use chrono::{DateTime, Utc};
 use fabro_types::{Run, RunId, SessionId};
+pub use main_event_store::MainEventStore;
 use object_store::ObjectStore;
 pub use projection_cache::CachedRunProjection;
 use projection_cache::RunProjectionCache;
@@ -47,6 +49,7 @@ pub struct Database {
     active_runs: Arc<Mutex<HashMap<RunId, Arc<RunDatabaseInner>>>>,
     blobs: Arc<OnceCell<Arc<BlobStore>>>,
     catalog_index: Arc<OnceCell<Arc<RunCatalogIndex>>>,
+    main_events: Arc<OnceCell<Arc<MainEventStore>>>,
     auth_codes: Arc<OnceCell<Arc<AuthCodeStore>>>,
     refresh_tokens: Arc<OnceCell<Arc<RefreshTokenStore>>>,
     projection_cache: Arc<RunProjectionCache>,
@@ -80,6 +83,7 @@ impl Database {
             active_runs: Arc::new(Mutex::new(HashMap::new())),
             blobs: Arc::new(OnceCell::new()),
             catalog_index: Arc::new(OnceCell::new()),
+            main_events: Arc::new(OnceCell::new()),
             auth_codes: Arc::new(OnceCell::new()),
             refresh_tokens: Arc::new(OnceCell::new()),
             projection_cache: Arc::new(RunProjectionCache::default()),
@@ -453,6 +457,15 @@ impl Database {
         Ok(Arc::clone(store))
     }
 
+    pub async fn main_events(&self) -> Result<Arc<MainEventStore>> {
+        let db = self.open_db().await?;
+        let store = self
+            .main_events
+            .get_or_try_init(|| async { Ok::<_, Error>(Arc::new(MainEventStore::open(db).await?)) })
+            .await?;
+        Ok(Arc::clone(store))
+    }
+
     pub async fn refresh_tokens(&self) -> Result<Arc<RefreshTokenStore>> {
         let store = self
             .refresh_tokens
@@ -514,8 +527,9 @@ fn active_run_from(
 mod tests {
     use chrono::{DateTime, Utc};
     use fabro_types::{
-        AttrValue, FailureReason, Graph, RunControlAction, RunSpec, RunStatus, StageId,
-        SuccessReason, WorkflowSettings, test_support,
+        AttrValue, FailureReason, Graph, MainEventBody, MainEventLifecycleProps, MainEventSource,
+        MainEventStartedProps, RunControlAction, RunSpec, RunStatus, StageId, SuccessReason,
+        WorkflowSettings, test_support,
     };
     use futures::TryStreamExt;
     use object_store::memory::InMemory;
@@ -653,6 +667,30 @@ mod tests {
         ))
         .await
         .unwrap();
+    }
+
+    fn main_event_body(run_id: RunId, source_event_name: &str) -> MainEventBody {
+        let source = MainEventSource {
+            run_id,
+            source_event_id: format!("evt-{source_event_name}"),
+            source_event_ts: dt("2026-06-21T12:00:00Z"),
+            source_event_name: source_event_name.to_string(),
+            actor: None,
+        };
+        match source_event_name {
+            "run.started" => MainEventBody::RunStarted(MainEventStartedProps {
+                source,
+                name: "test".to_string(),
+                base_branch: None,
+                base_sha: None,
+                run_branch: None,
+                worktree_dir: None,
+                goal: None,
+            }),
+            "run.running" => MainEventBody::RunRunning(MainEventLifecycleProps { source }),
+            "run.paused" => MainEventBody::RunPaused(MainEventLifecycleProps { source }),
+            other => panic!("unsupported test main event source {other}"),
+        }
     }
 
     async fn append_created_with_parent(
@@ -824,6 +862,95 @@ mod tests {
         assert_eq!(remaining.len(), 1);
         assert_eq!(remaining[0].id, test_run_id("run-2"));
         assert!(!list_paths(object_store, "runs/").await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn main_events_append_list_and_subscribe_in_order() {
+        let (_object_store, store) = make_store();
+        let main_events = store.main_events().await.unwrap();
+        let run_id = test_run_id("run-1");
+        let mut rx = main_events.subscribe();
+
+        let first = main_events
+            .append(main_event_body(run_id, "run.started"))
+            .await
+            .unwrap();
+        let second = main_events
+            .append(main_event_body(run_id, "run.running"))
+            .await
+            .unwrap();
+
+        assert_eq!(first.seq, 1);
+        assert_eq!(second.seq, 2);
+        assert_eq!(first.event.event_name(), "fabro.run.started");
+
+        assert_eq!(rx.recv().await.unwrap().seq, 1);
+        assert_eq!(rx.recv().await.unwrap().seq, 2);
+
+        let listed = main_events.list_from_with_limit(1, 10).await.unwrap();
+        assert_eq!(
+            listed.iter().map(|event| event.seq).collect::<Vec<_>>(),
+            vec![1, 2]
+        );
+    }
+
+    #[tokio::test]
+    async fn main_events_list_returns_limit_plus_one_from_start_seq() {
+        let (_object_store, store) = make_store();
+        let main_events = store.main_events().await.unwrap();
+        let run_id = test_run_id("run-1");
+
+        for source in ["run.started", "run.running", "run.paused"] {
+            main_events
+                .append(main_event_body(run_id, source))
+                .await
+                .unwrap();
+        }
+
+        let listed = main_events.list_from_with_limit(2, 1).await.unwrap();
+        assert_eq!(
+            listed.iter().map(|event| event.seq).collect::<Vec<_>>(),
+            vec![2, 3]
+        );
+    }
+
+    #[tokio::test]
+    async fn main_events_recover_next_sequence_after_reopen() {
+        let (object_store, store) = make_store();
+        let run_id = test_run_id("run-1");
+        let main_events = store.main_events().await.unwrap();
+        main_events
+            .append(main_event_body(run_id, "run.started"))
+            .await
+            .unwrap();
+
+        let reopened = Database::new(object_store, "runs", Duration::from_millis(1), None);
+        let reopened_main_events = reopened.main_events().await.unwrap();
+        let appended = reopened_main_events
+            .append(main_event_body(run_id, "run.running"))
+            .await
+            .unwrap();
+
+        assert_eq!(appended.seq, 2);
+    }
+
+    #[tokio::test]
+    async fn delete_run_keeps_main_events() {
+        let (_object_store, store) = make_store();
+        let run = store.create_run(&test_run_id("run-1")).await.unwrap();
+        append_created(&run, "run-1", dt("2026-03-27T12:00:00Z")).await;
+
+        let main_events = store.main_events().await.unwrap();
+        main_events
+            .append(main_event_body(test_run_id("run-1"), "run.started"))
+            .await
+            .unwrap();
+
+        store.delete_run(&test_run_id("run-1")).await.unwrap();
+
+        let listed = main_events.list_from_with_limit(1, 10).await.unwrap();
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0].event.event_name(), "fabro.run.started");
     }
 
     #[tokio::test]

--- a/lib/foundation/fabro-types/src/lib.rs
+++ b/lib/foundation/fabro-types/src/lib.rs
@@ -17,6 +17,7 @@ mod id;
 mod input_scalar;
 pub mod interview;
 pub mod llm_backend;
+pub mod main_event;
 pub mod manifest_path;
 pub mod mcp_store;
 pub mod outcome;
@@ -85,6 +86,11 @@ pub use interview::{
     InterviewQuestionRecord, QuestionType, ReviewTarget, ReviewTargetError, ReviewTargetKind,
 };
 pub use llm_backend::AgentBackend;
+pub use main_event::{
+    MainEvent, MainEventBody, MainEventCancelledProps, MainEventCompletedProps,
+    MainEventCreatedProps, MainEventEnvelope, MainEventFailedProps, MainEventLifecycleProps,
+    MainEventSource, MainEventStartedProps,
+};
 pub use manifest_path::{ManifestPath, ManifestPathParseError};
 pub use mcp_store::{
     McpServerDefinition, McpServerDraft, McpServerId, McpServerReplace, McpServerRevision,

--- a/lib/foundation/fabro-types/src/main_event.rs
+++ b/lib/foundation/fabro-types/src/main_event.rs
@@ -1,0 +1,311 @@
+use chrono::{DateTime, Utc};
+use serde::de::Error as DeError;
+use serde::ser::Error as SerError;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde_json::{Map, Value, json};
+
+use crate::{
+    AutomationRef, BilledTokenCounts, FailureCategory, FailureReason, GitContext, Principal, RunId,
+    SuccessReason,
+};
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct MainEventEnvelope {
+    pub seq:   u32,
+    pub event: MainEvent,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct MainEvent {
+    pub id:   String,
+    pub ts:   DateTime<Utc>,
+    pub body: MainEventBody,
+}
+
+#[allow(
+    clippy::large_enum_variant,
+    reason = "Main event bodies stay inline to match the tagged wire format."
+)]
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[serde(tag = "event", content = "properties")]
+pub enum MainEventBody {
+    #[serde(rename = "fabro.run.created")]
+    RunCreated(MainEventCreatedProps),
+    #[serde(rename = "fabro.run.started")]
+    RunStarted(MainEventStartedProps),
+    #[serde(rename = "fabro.run.running")]
+    RunRunning(MainEventLifecycleProps),
+    #[serde(rename = "fabro.run.completed")]
+    RunCompleted(MainEventCompletedProps),
+    #[serde(rename = "fabro.run.failed")]
+    RunFailed(MainEventFailedProps),
+    #[serde(rename = "fabro.run.cancelled")]
+    RunCancelled(MainEventCancelledProps),
+    #[serde(rename = "fabro.run.paused")]
+    RunPaused(MainEventLifecycleProps),
+    #[serde(rename = "fabro.run.unpaused")]
+    RunUnpaused(MainEventLifecycleProps),
+    Unknown {
+        name:       String,
+        properties: Value,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct MainEventSource {
+    pub run_id:            RunId,
+    pub source_event_id:   String,
+    pub source_event_ts:   DateTime<Utc>,
+    pub source_event_name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub actor:             Option<Principal>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct MainEventCreatedProps {
+    #[serde(flatten)]
+    pub source:             MainEventSource,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub title:              Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workflow_slug:      Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub automation:         Option<AutomationRef>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub git:                Option<GitContext>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parent_id:          Option<RunId>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provenance_subject: Option<Principal>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct MainEventLifecycleProps {
+    #[serde(flatten)]
+    pub source: MainEventSource,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct MainEventStartedProps {
+    #[serde(flatten)]
+    pub source:       MainEventSource,
+    pub name:         String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub base_branch:  Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub base_sha:     Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub run_branch:   Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub worktree_dir: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub goal:         Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct MainEventCompletedProps {
+    #[serde(flatten)]
+    pub source:               MainEventSource,
+    pub status:               String,
+    pub reason:               SuccessReason,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub total_usd_micros:     Option<i64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub final_git_commit_sha: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub automation:           Option<AutomationRef>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub billing:              Option<BilledTokenCounts>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct MainEventFailedProps {
+    #[serde(flatten)]
+    pub source:               MainEventSource,
+    pub reason:               FailureReason,
+    pub category:             FailureCategory,
+    pub message:              String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub final_git_commit_sha: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub automation:           Option<AutomationRef>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub billing:              Option<BilledTokenCounts>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct MainEventCancelledProps {
+    #[serde(flatten)]
+    pub source:               MainEventSource,
+    pub reason:               FailureReason,
+    pub category:             FailureCategory,
+    pub message:              String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub final_git_commit_sha: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub automation:           Option<AutomationRef>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub billing:              Option<BilledTokenCounts>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct MainEventRaw {
+    id:         String,
+    ts:         DateTime<Utc>,
+    event:      String,
+    #[serde(default = "default_properties")]
+    properties: Value,
+}
+
+struct MainEventParts<'a> {
+    id:         String,
+    ts:         DateTime<Utc>,
+    event:      &'a str,
+    properties: &'a Value,
+}
+
+impl MainEventBody {
+    pub fn event_name(&self) -> &str {
+        match self {
+            Self::RunCreated(_) => "fabro.run.created",
+            Self::RunStarted(_) => "fabro.run.started",
+            Self::RunRunning(_) => "fabro.run.running",
+            Self::RunCompleted(_) => "fabro.run.completed",
+            Self::RunFailed(_) => "fabro.run.failed",
+            Self::RunCancelled(_) => "fabro.run.cancelled",
+            Self::RunPaused(_) => "fabro.run.paused",
+            Self::RunUnpaused(_) => "fabro.run.unpaused",
+            Self::Unknown { name, .. } => name.as_str(),
+        }
+    }
+
+    fn properties_value(&self) -> serde_json::Result<Value> {
+        if let Self::Unknown { properties, .. } = self {
+            return Ok(properties.clone());
+        }
+
+        match serde_json::to_value(self)? {
+            Value::Object(mut map) => {
+                Ok(map.remove("properties").unwrap_or_else(default_properties))
+            }
+            _ => Ok(default_properties()),
+        }
+    }
+}
+
+fn is_known_main_event_name(event: &str) -> bool {
+    matches!(
+        event,
+        "fabro.run.created"
+            | "fabro.run.started"
+            | "fabro.run.running"
+            | "fabro.run.completed"
+            | "fabro.run.failed"
+            | "fabro.run.cancelled"
+            | "fabro.run.paused"
+            | "fabro.run.unpaused"
+    )
+}
+
+impl MainEvent {
+    pub fn from_value(value: Value) -> serde_json::Result<Self> {
+        let raw: MainEventRaw = serde_json::from_value(value)?;
+        Self::from_parts(MainEventParts {
+            id:         raw.id,
+            ts:         raw.ts,
+            event:      &raw.event,
+            properties: &raw.properties,
+        })
+    }
+
+    pub fn from_ref(value: &Value) -> serde_json::Result<Self> {
+        let obj = value.as_object().ok_or_else(|| {
+            <serde_json::Error as DeError>::custom("main event must be a JSON object")
+        })?;
+        let id = obj.get("id").and_then(Value::as_str).ok_or_else(|| {
+            <serde_json::Error as DeError>::custom("missing or non-string field: id")
+        })?;
+        let ts = obj
+            .get("ts")
+            .ok_or_else(|| <serde_json::Error as DeError>::custom("missing field: ts"))
+            .and_then(DateTime::<Utc>::deserialize)?;
+        let event = obj.get("event").and_then(Value::as_str).ok_or_else(|| {
+            <serde_json::Error as DeError>::custom("missing or non-string field: event")
+        })?;
+        let properties = obj
+            .get("properties")
+            .cloned()
+            .unwrap_or_else(default_properties);
+        Self::from_parts(MainEventParts {
+            id: id.to_string(),
+            ts,
+            event,
+            properties: &properties,
+        })
+    }
+
+    fn from_parts(parts: MainEventParts<'_>) -> serde_json::Result<Self> {
+        let body_payload = json!({
+            "event": parts.event,
+            "properties": parts.properties,
+        });
+        let body: MainEventBody = match serde_json::from_value(body_payload) {
+            Ok(body) => body,
+            Err(err) if is_known_main_event_name(parts.event) => return Err(err),
+            Err(_) => MainEventBody::Unknown {
+                name:       parts.event.to_string(),
+                properties: parts.properties.clone(),
+            },
+        };
+        Ok(Self {
+            id: parts.id,
+            ts: parts.ts,
+            body,
+        })
+    }
+
+    pub fn to_value(&self) -> serde_json::Result<Value> {
+        let mut map = Map::new();
+        map.insert("id".to_string(), Value::String(self.id.clone()));
+        map.insert("ts".to_string(), serde_json::to_value(self.ts)?);
+        map.insert(
+            "event".to_string(),
+            Value::String(self.body.event_name().to_string()),
+        );
+        map.insert("properties".to_string(), self.body.properties_value()?);
+        Ok(Value::Object(map))
+    }
+
+    pub fn event_name(&self) -> &str {
+        self.body.event_name()
+    }
+
+    pub fn properties(&self) -> serde_json::Result<Value> {
+        self.body.properties_value()
+    }
+}
+
+impl Serialize for MainEvent {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        self.to_value()
+            .map_err(S::Error::custom)?
+            .serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for MainEvent {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = Value::deserialize(deserializer)?;
+        Self::from_value(value).map_err(D::Error::custom)
+    }
+}
+
+fn default_properties() -> Value {
+    Value::Object(Map::new())
+}

--- a/lib/foundation/fabro-types/tests/main_event_serde.rs
+++ b/lib/foundation/fabro-types/tests/main_event_serde.rs
@@ -1,0 +1,188 @@
+use chrono::{TimeZone, Utc};
+use fabro_types::{
+    AuthMethod, FailureCategory, FailureReason, IdpIdentity, MainEvent, MainEventBody,
+    MainEventCancelledProps, MainEventCompletedProps, MainEventCreatedProps, MainEventFailedProps,
+    MainEventLifecycleProps, MainEventSource, MainEventStartedProps, Principal, RunId,
+    SuccessReason,
+};
+use serde_json::json;
+
+fn run_id() -> RunId {
+    "01JT56VE4Z5NZ814GZN2JZD65A"
+        .parse()
+        .expect("test run id should parse")
+}
+
+fn actor() -> Principal {
+    Principal::user(
+        IdpIdentity::new("https://github.com", "123").expect("test identity should construct"),
+        "fabian".to_string(),
+        AuthMethod::Github,
+    )
+}
+
+fn source(source_event_name: &str) -> MainEventSource {
+    MainEventSource {
+        run_id:            run_id(),
+        source_event_id:   format!("evt-{source_event_name}"),
+        source_event_ts:   Utc
+            .with_ymd_and_hms(2026, 6, 21, 10, 0, 0)
+            .single()
+            .expect("test source timestamp should be valid"),
+        source_event_name: source_event_name.to_string(),
+        actor:             Some(actor()),
+    }
+}
+
+fn main_event(body: MainEventBody) -> MainEvent {
+    MainEvent {
+        id: "019796d3-d2d0-7c81-a65a-6f3ddc67d4a4".to_string(),
+        ts: Utc
+            .with_ymd_and_hms(2026, 6, 21, 10, 1, 0)
+            .single()
+            .expect("test main event timestamp should be valid"),
+        body,
+    }
+}
+
+#[test]
+fn v1_event_names_are_stable() {
+    let cases = [
+        (
+            MainEventBody::RunCreated(MainEventCreatedProps {
+                source:             source("run.created"),
+                title:              Some("Triage bug".to_string()),
+                workflow_slug:      Some("triage".to_string()),
+                automation:         None,
+                git:                None,
+                parent_id:          None,
+                provenance_subject: Some(actor()),
+            }),
+            "fabro.run.created",
+        ),
+        (
+            MainEventBody::RunStarted(MainEventStartedProps {
+                source:       source("run.started"),
+                name:         "triage".to_string(),
+                base_branch:  Some("main".to_string()),
+                base_sha:     Some("abc123".to_string()),
+                run_branch:   Some("fabro/run-1".to_string()),
+                worktree_dir: None,
+                goal:         Some("Triage bug".to_string()),
+            }),
+            "fabro.run.started",
+        ),
+        (
+            MainEventBody::RunRunning(MainEventLifecycleProps {
+                source: source("run.running"),
+            }),
+            "fabro.run.running",
+        ),
+        (
+            MainEventBody::RunCompleted(MainEventCompletedProps {
+                source:               source("run.completed"),
+                status:               "succeeded".to_string(),
+                reason:               SuccessReason::Completed,
+                total_usd_micros:     Some(12),
+                final_git_commit_sha: Some("abc123".to_string()),
+                automation:           None,
+                billing:              None,
+            }),
+            "fabro.run.completed",
+        ),
+        (
+            MainEventBody::RunFailed(MainEventFailedProps {
+                source:               source("run.failed"),
+                reason:               FailureReason::WorkflowError,
+                category:             FailureCategory::Deterministic,
+                message:              "boom".to_string(),
+                final_git_commit_sha: None,
+                automation:           None,
+                billing:              None,
+            }),
+            "fabro.run.failed",
+        ),
+        (
+            MainEventBody::RunCancelled(MainEventCancelledProps {
+                source:               source("run.failed"),
+                reason:               FailureReason::Cancelled,
+                category:             FailureCategory::Canceled,
+                message:              "cancelled".to_string(),
+                final_git_commit_sha: None,
+                automation:           None,
+                billing:              None,
+            }),
+            "fabro.run.cancelled",
+        ),
+        (
+            MainEventBody::RunPaused(MainEventLifecycleProps {
+                source: source("run.paused"),
+            }),
+            "fabro.run.paused",
+        ),
+        (
+            MainEventBody::RunUnpaused(MainEventLifecycleProps {
+                source: source("run.unpaused"),
+            }),
+            "fabro.run.unpaused",
+        ),
+    ];
+
+    for (body, expected) in cases {
+        assert_eq!(body.event_name(), expected);
+        assert_eq!(main_event(body).event_name(), expected);
+    }
+}
+
+#[test]
+fn main_event_round_trips_flat_event_properties() {
+    let event = main_event(MainEventBody::RunCompleted(MainEventCompletedProps {
+        source:               source("run.completed"),
+        status:               "succeeded".to_string(),
+        reason:               SuccessReason::Completed,
+        total_usd_micros:     Some(42),
+        final_git_commit_sha: Some("deadbeef".to_string()),
+        automation:           None,
+        billing:              None,
+    }));
+
+    let value = serde_json::to_value(&event).expect("main event should serialize");
+    assert_eq!(value["event"], "fabro.run.completed");
+    assert_eq!(value["properties"]["run_id"], run_id().to_string());
+    assert_eq!(value["properties"]["source_event_name"], "run.completed");
+    assert_eq!(value["properties"]["status"], "succeeded");
+
+    let parsed: MainEvent =
+        serde_json::from_value(value.clone()).expect("main event should deserialize");
+    assert_eq!(
+        serde_json::to_value(parsed).expect("parsed main event should serialize"),
+        value
+    );
+}
+
+#[test]
+fn unknown_main_event_preserves_name_and_properties() {
+    let value = json!({
+        "id": "019796d3-d2d0-7c81-a65a-6f3ddc67d4a4",
+        "ts": "2026-06-21T10:01:00Z",
+        "event": "github.issue_comment.created",
+        "properties": {
+            "delivery_id": "delivery-1",
+            "action": "created"
+        }
+    });
+
+    let parsed: MainEvent =
+        serde_json::from_value(value.clone()).expect("unknown main event should deserialize");
+    match &parsed.body {
+        MainEventBody::Unknown { name, properties } => {
+            assert_eq!(name, "github.issue_comment.created");
+            assert_eq!(properties["delivery_id"], "delivery-1");
+        }
+        other => panic!("expected unknown event, got {other:?}"),
+    }
+    assert_eq!(
+        serde_json::to_value(parsed).expect("unknown main event should serialize"),
+        value
+    );
+}


### PR DESCRIPTION
## Summary

Adds a durable, server-wide main event stream under `events/main/<seq-ts>`.

Run events remain the canonical per-run record for projections, APIs, SSE, CLI progress, and detailed execution history. The new main stream is a compact global mirror for cross-run consumers. It has its own sequence, survives run deletion, and can be replayed after a server restart.

This PR adds:

- typed `MainEvent`, `MainEventEnvelope`, and lifecycle payloads in `fabro-types`, including forward-compatible preservation of unknown event names and properties;
- `fabro-store::MainEventStore` with append, replay, subscribe, and sequence recovery;
- server-owned mapping from selected `RunEvent` values to compact main events;
- mirroring for `run.created`, `run.started`, `run.running`, `run.completed`, `run.failed`, cancellation, pause, and unpause.

`run.created` is mirrored immediately after the run is persisted, before the live forwarder exists. This append is required for the create request to succeed. Later lifecycle events are mirrored by the existing live run-event forwarder. Those appends are best-effort: failures produce a structured warning and do not stop the workflow or block the existing in-memory broadcast.

## Boundaries

This does not replace or alter the run event stream. It also does not add a public API, CLI commands, SSE endpoints, webhook ingestion, automation matching, listener cursors, or trigger delivery guarantees.

Detailed stage, agent, tool, transcript, sandbox, graph, settings, patch, and tool-output events are intentionally excluded. `run.cancel.requested` is also excluded; terminal cancellation is represented as `fabro.run.cancelled` when the canonical `run.failed` event carries `FailureReason::Cancelled`.

The server owns the filtering policy. `fabro-store` only persists and replays typed main events.

## Verification

- `cargo +nightly-2026-04-14 fmt --check --all`
- `cargo +nightly-2026-04-14 clippy -p fabro-types -p fabro-store -p fabro-server --all-targets -- -D warnings`
- `cargo nextest run -p fabro-types -p fabro-store` (710 passed)
- focused `fabro-server` tests for persisted creation, live lifecycle mirroring, filtering, and cancellation mapping

Refreshed on 2026-08-21 against current `upstream/main`.