### PR TITLE
security: patch tar CVE alert

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7489,9 +7489,9 @@ dependencies = [
 
 [[package]]
 name = "tar"
-version = "0.4.45"
+version = "0.4.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
 dependencies = [
  "filetime",
  "libc",


### PR DESCRIPTION
## Summary
- Updates transitive Rust dependency `tar` from `0.4.45` to `0.4.46` in `Cargo.lock`.
- Expected to resolve Dependabot alert: https://github.com/fabro-sh/fabro/security/dependabot/30
- Dependency path: `fabro-sandbox` -> `tar`.

## Grouping
- Kept this separate from the web alerts because it is a Rust lockfile-only patch with a separate verification path.

## Verification
- `cargo tree -i tar` resolves `tar v0.4.46`.
- `cargo build --workspace`
- `cargo nextest run --workspace` (6860 passed, 185 skipped; nextest reported 1 leaky test warning as non-fatal)
- `git diff --check`

## Residual alerts
- React Router alerts 31-37 are intentionally handled in a separate web PR.