### PR TITLE
security: patch react-router CVE alerts

### DIFF
--- a/apps/fabro-web/package.json
+++ b/apps/fabro-web/package.json
@@ -32,7 +32,7 @@
     "marked": "^18.0.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
-    "react-router": "7.12.0",
+    "react-router": "7.15.1",
     "remark-gfm": "^4.0.1",
     "sonner": "^2.0.7",
     "swr": "^2.4.1"

--- a/bun.lock
+++ b/bun.lock
@@ -29,7 +29,7 @@
         "marked": "^18.0.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
-        "react-router": "7.12.0",
+        "react-router": "7.15.1",
         "remark-gfm": "^4.0.1",
         "sonner": "^2.0.7",
         "swr": "^2.4.1",
@@ -1534,7 +1534,7 @@
 
     "react-remove-scroll-bar": ["react-remove-scroll-bar@2.3.8", "", { "dependencies": { "react-style-singleton": "^2.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react"] }, "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q=="],
 
-    "react-router": ["react-router@7.12.0", "", { "dependencies": { "cookie": "^1.0.1", "set-cookie-parser": "^2.6.0" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" }, "optionalPeers": ["react-dom"] }, "sha512-kTPDYPFzDVGIIGNLS5VJykK0HfHLY5MF3b+xj0/tTyNYL1gF1qs7u67Z9jEhQk2sQ98SUaHxlG31g1JtF7IfVw=="],
+    "react-router": ["react-router@7.15.1", "", { "dependencies": { "cookie": "^1.0.1", "set-cookie-parser": "^2.6.0" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" }, "optionalPeers": ["react-dom"] }, "sha512-R8rl9HhgikFYoPJymnUtPXWbnDb3oget6lQnfIoupbt61aT9aOhRkDsY2XRhZRyX1Z/8a5sL74fXmFNm3NRK5A=="],
 
     "react-style-singleton": ["react-style-singleton@2.2.3", "", { "dependencies": { "get-nonce": "^1.0.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ=="],
 


### PR DESCRIPTION
## Summary
- Updates direct web runtime dependency `react-router` from `7.12.0` to `7.15.1` in `apps/fabro-web`.
- Regenerates the root Bun workspace lockfile.
- Expected to resolve Dependabot alerts:
  - https://github.com/fabro-sh/fabro/security/dependabot/31
  - https://github.com/fabro-sh/fabro/security/dependabot/32
  - https://github.com/fabro-sh/fabro/security/dependabot/33
  - https://github.com/fabro-sh/fabro/security/dependabot/34
  - https://github.com/fabro-sh/fabro/security/dependabot/35
  - https://github.com/fabro-sh/fabro/security/dependabot/36
  - https://github.com/fabro-sh/fabro/security/dependabot/37

## Grouping
- Grouped these alerts because they all affect the same direct package, same manifest, same runtime scope, and same verification path.
- Kept separate from the Rust `tar` alert because it touches a different ecosystem and lockfile.

## Verification
- `bun pm why react-router` resolves `react-router@7.15.1` for `fabro-web`.
- `cd apps/fabro-web && bun run typecheck`
- `cd apps/fabro-web && bun test --isolate` (625 passed, 0 failed)
- `cd apps/fabro-web && bun run build`
- `git diff --check`

## Residual alerts
- Rust `tar` alert 30 is handled separately in https://github.com/fabro-sh/fabro/pull/534.