### PR TITLE
Move variables to SQLite storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -376,6 +376,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atoi"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "atomic"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -431,7 +440,7 @@ dependencies = [
  "fastrand",
  "hex",
  "http 1.4.0",
- "sha1",
+ "sha1 0.10.6",
  "time",
  "tokio",
  "tracing",
@@ -834,7 +843,7 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
- "sha1",
+ "sha1 0.10.6",
  "sync_wrapper",
  "tokio",
  "tokio-tungstenite 0.28.0",
@@ -980,6 +989,9 @@ name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "block-buffer"
@@ -1097,6 +1109,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1144,6 +1162,17 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "chrono"
@@ -1323,7 +1352,7 @@ checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
 dependencies = [
  "aes-gcm",
  "base64",
- "hkdf",
+ "hkdf 0.12.4",
  "hmac 0.12.1",
  "percent-encoding",
  "rand 0.8.6",
@@ -1412,6 +1441,21 @@ checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "crc"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
 
 [[package]]
 name = "crc32fast"
@@ -2021,6 +2065,9 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "email_address"
@@ -2081,6 +2128,16 @@ checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
 dependencies = [
  "cc",
  "libc",
+]
+
+[[package]]
+name = "etcetera"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de48cc4d1c1d97a20fd819def54b890cadde72ed3ad0c614822a0a433361be96"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2318,7 +2375,7 @@ dependencies = [
  "fs2",
  "futures",
  "git2",
- "hkdf",
+ "hkdf 0.12.4",
  "httpmock",
  "indicatif",
  "insta",
@@ -2430,6 +2487,16 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+]
+
+[[package]]
+name = "fabro-db"
+version = "0.278.0-nightly.0"
+dependencies = [
+ "anyhow",
+ "sqlx",
+ "tempfile",
+ "tokio",
 ]
 
 [[package]]
@@ -2850,6 +2917,7 @@ dependencies = [
  "fabro-build-support",
  "fabro-client",
  "fabro-config",
+ "fabro-db",
  "fabro-environment",
  "fabro-github",
  "fabro-graphviz",
@@ -2879,7 +2947,7 @@ dependencies = [
  "futures-util",
  "globset",
  "hex",
- "hkdf",
+ "hkdf 0.12.4",
  "hmac 0.12.1",
  "http-body-util",
  "httpmock",
@@ -3134,12 +3202,18 @@ dependencies = [
 name = "fabro-variable"
 version = "0.278.0-nightly.0"
 dependencies = [
+ "anyhow",
  "chrono",
+ "fabro-db",
  "fabro-types",
  "serde",
  "serde_json",
+ "sqlx",
+ "strum 0.28.0",
  "tempfile",
- "ulid",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -3333,6 +3407,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "flume"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e139bc46ca777eb5efaf62df0ab8cc5fd400866427e56c68b22e414e53bd3be"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "spin",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3466,7 +3551,7 @@ dependencies = [
  "auto_enums",
  "bytes",
  "equivalent",
- "flume",
+ "flume 0.11.1",
  "foyer-common",
  "foyer-memory",
  "fs4",
@@ -3591,6 +3676,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-intrusive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d930c203dd0b6ff06e0201a4a2fe9149b43c684fd4420555b26d21b1a02956f"
+dependencies = [
+ "futures-core",
+ "lock_api",
+ "parking_lot",
+]
+
+[[package]]
 name = "futures-io"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3701,6 +3797,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -3838,6 +3935,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashlink"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824e001ac4f3012dd16a264bec811403a67ca9deb6c102fc5049b32c4574b35f"
+dependencies = [
+ "hashbrown 0.16.1",
+]
+
+[[package]]
 name = "headers"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3849,7 +3955,7 @@ dependencies = [
  "http 1.4.0",
  "httpdate",
  "mime",
- "sha1",
+ "sha1 0.10.6",
 ]
 
 [[package]]
@@ -3886,6 +3992,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
 dependencies = [
  "hmac 0.12.1",
+]
+
+[[package]]
+name = "hkdf"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4aaa26c720c68b866f2c96ef5c1264b3e6f473fe5d4ce61cd44bbe913e553018"
+dependencies = [
+ "hmac 0.13.0",
 ]
 
 [[package]]
@@ -4656,6 +4771,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "libsqlite3-sys"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f111c8c41e7c61a49cd34e44c7619462967221a6443b0ec299e0ac30cfb9b1"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "libz-sys"
 version = "1.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4853,6 +4979,16 @@ checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
  "digest 0.10.7",
+]
+
+[[package]]
+name = "md-5"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
+dependencies = [
+ "cfg-if",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -5373,7 +5509,7 @@ dependencies = [
  "humantime",
  "hyper",
  "itertools",
- "md-5",
+ "md-5 0.10.6",
  "parking_lot",
  "percent-encoding",
  "quick-xml 0.38.4",
@@ -6127,6 +6263,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.1",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6163,6 +6310,12 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_xoshiro"
@@ -7041,6 +7194,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7238,6 +7402,9 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "socket2"
@@ -7256,6 +7423,175 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 dependencies = [
  "lock_api",
+]
+
+[[package]]
+name = "sqlx"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "378620ccc25c62c89d8be1c819e76a88d59bdcc3304733330788948e619bfd71"
+dependencies = [
+ "sqlx-core",
+ "sqlx-macros",
+ "sqlx-mysql",
+ "sqlx-postgres",
+ "sqlx-sqlite",
+]
+
+[[package]]
+name = "sqlx-core"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05b44e85bf579a8eeb4ceaa77a3a523baf2bf0e9bac7e40f405d537b5d2d5ccb"
+dependencies = [
+ "base64",
+ "bytes",
+ "cfg-if",
+ "crc",
+ "crossbeam-queue",
+ "either",
+ "event-listener",
+ "futures-core",
+ "futures-intrusive",
+ "futures-io",
+ "futures-util",
+ "hashbrown 0.16.1",
+ "hashlink",
+ "indexmap 2.13.0",
+ "log",
+ "memchr",
+ "percent-encoding",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "smallvec",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "sqlx-macros"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd2b84f2bc39a5705ef27ec785a11c934a41bbd4a24941e257927cddc26b60bf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "sqlx-core",
+ "sqlx-macros-core",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "sqlx-macros-core"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb8d96de5fdc85a5c4ec813432b523ec637e80ba98f046555f75f7908ddac7c3"
+dependencies = [
+ "cfg-if",
+ "dotenvy",
+ "either",
+ "heck 0.5.0",
+ "hex",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "sqlx-core",
+ "sqlx-sqlite",
+ "syn 2.0.117",
+ "thiserror 2.0.18",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "sqlx-mysql"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90b8020fe17c5f2c245bfa2505d7ef59c5604839527c740266ad2214acebea27"
+dependencies = [
+ "bitflags",
+ "byteorder",
+ "bytes",
+ "crc",
+ "digest 0.11.3",
+ "dotenvy",
+ "either",
+ "futures-core",
+ "futures-util",
+ "generic-array",
+ "log",
+ "percent-encoding",
+ "serde",
+ "sha1 0.11.0",
+ "sha2 0.11.0",
+ "sqlx-core",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "sqlx-postgres"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87a2bdd6e83f6b3ea525ca9fee568030508b58355a43d0b2c1674d5f79dcd65e"
+dependencies = [
+ "atoi",
+ "base64",
+ "bitflags",
+ "byteorder",
+ "crc",
+ "dotenvy",
+ "etcetera",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "hkdf 0.13.0",
+ "hmac 0.13.0",
+ "itoa",
+ "log",
+ "md-5 0.11.0",
+ "memchr",
+ "rand 0.10.1",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror 2.0.18",
+ "tracing",
+ "whoami",
+]
+
+[[package]]
+name = "sqlx-sqlite"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488e99c397a62007e4229aec669a179816339afc6d2620ca6fa420dbee2e982c"
+dependencies = [
+ "atoi",
+ "flume 0.12.0",
+ "form_urlencoded",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-intrusive",
+ "futures-util",
+ "libsqlite3-sys",
+ "log",
+ "percent-encoding",
+ "serde",
+ "sqlx-core",
+ "thiserror 2.0.18",
+ "tracing",
+ "url",
 ]
 
 [[package]]
@@ -7319,6 +7655,17 @@ name = "stringmetrics"
 version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b3c8667cd96245cbb600b8dec5680a7319edd719c5aa2b5d23c6bff94f39765"
+
+[[package]]
+name = "stringprep"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+ "unicode-properties",
+]
 
 [[package]]
 name = "strsim"
@@ -8002,7 +8349,7 @@ dependencies = [
  "rand 0.9.4",
  "rustls",
  "rustls-pki-types",
- "sha1",
+ "sha1 0.10.6",
  "thiserror 2.0.18",
  "utf-8",
 ]
@@ -8019,7 +8366,7 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.9.4",
- "sha1",
+ "sha1 0.10.6",
  "thiserror 2.0.18",
  "utf-8",
 ]
@@ -8160,6 +8507,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
 name = "unicode-general-category"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8176,6 +8529,21 @@ name = "unicode-linebreak"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "unicode-segmentation"
@@ -8562,6 +8930,12 @@ checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
 dependencies = [
  "rustls-pki-types",
 ]
+
+[[package]]
+name = "whoami"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "998767ef88740d1f5b0682a9c53c24431453923962269c2db68ee43788c5a40d"
 
 [[package]]
 name = "winapi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3209,7 +3209,6 @@ dependencies = [
  "serde",
  "serde_json",
  "sqlx",
- "strum 0.28.0",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ croner = "3.0.1"
 thiserror = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
+sqlx = { version = "0.9", default-features = false, features = ["runtime-tokio", "sqlite-bundled", "migrate", "macros"] }
 tokio = { version = "1", features = ["full"] }
 reqwest = { version = "0.13", default-features = false, features = ["json", "stream", "rustls", "query", "form", "multipart"] }
 sse-stream = "0.2"

--- a/lib/crates/fabro-config/src/storage.rs
+++ b/lib/crates/fabro-config/src/storage.rs
@@ -53,6 +53,11 @@ impl Storage {
     }
 
     #[must_use]
+    pub fn sqlite_path(&self) -> PathBuf {
+        self.root.join("db").join("fabro.sqlite3")
+    }
+
+    #[must_use]
     pub fn runtime_directory(&self) -> RuntimeDirectory {
         RuntimeDirectory::new(self.root.clone())
     }
@@ -191,6 +196,10 @@ mod tests {
         assert_eq!(
             storage.variables_path(),
             std::path::Path::new("/tmp/fabro-data/variables.json")
+        );
+        assert_eq!(
+            storage.sqlite_path(),
+            std::path::Path::new("/tmp/fabro-data/db/fabro.sqlite3")
         );
         assert_eq!(
             storage.objects_dir(),

--- a/lib/crates/fabro-db/Cargo.toml
+++ b/lib/crates/fabro-db/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "fabro-db"
+edition.workspace = true
+version.workspace = true
+publish = false
+license.workspace = true
+description = "SQLite storage foundation for Fabro"
+
+[lib]
+doctest = false
+
+[lints]
+workspace = true
+
+[dependencies]
+anyhow.workspace = true
+sqlx.workspace = true
+tokio.workspace = true
+
+[dev-dependencies]
+tempfile = "3"
+tokio = { workspace = true, features = ["macros"] }

--- a/lib/crates/fabro-db/migrations/2026063001_variables.sql
+++ b/lib/crates/fabro-db/migrations/2026063001_variables.sql
@@ -1,12 +1,3 @@
-CREATE TABLE legacy_imports (
-    import_name TEXT PRIMARY KEY NOT NULL,
-    source_path TEXT NOT NULL,
-    status TEXT NOT NULL CHECK (status IN ('imported', 'skipped_existing_target')),
-    imported_rows INTEGER NOT NULL CHECK (imported_rows >= 0),
-    skipped_rows INTEGER NOT NULL CHECK (skipped_rows >= 0),
-    imported_at TEXT NOT NULL CHECK (length(imported_at) > 0)
-);
-
 CREATE TABLE variables (
     name TEXT PRIMARY KEY NOT NULL,
     value TEXT NOT NULL,

--- a/lib/crates/fabro-db/migrations/2026063001_variables.sql
+++ b/lib/crates/fabro-db/migrations/2026063001_variables.sql
@@ -1,0 +1,21 @@
+CREATE TABLE legacy_imports (
+    import_name TEXT PRIMARY KEY NOT NULL,
+    source_path TEXT NOT NULL,
+    status TEXT NOT NULL CHECK (status IN ('imported', 'skipped_existing_target')),
+    imported_rows INTEGER NOT NULL CHECK (imported_rows >= 0),
+    skipped_rows INTEGER NOT NULL CHECK (skipped_rows >= 0),
+    imported_at TEXT NOT NULL CHECK (length(imported_at) > 0)
+);
+
+CREATE TABLE variables (
+    name TEXT PRIMARY KEY NOT NULL,
+    value TEXT NOT NULL,
+    description TEXT,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    CHECK (length(name) > 0),
+    CHECK (substr(name, 1, 1) GLOB '[A-Za-z_]'),
+    CHECK (name NOT GLOB '*[^A-Za-z0-9_]*'),
+    CHECK (length(created_at) > 0),
+    CHECK (length(updated_at) > 0)
+);

--- a/lib/crates/fabro-db/src/lib.rs
+++ b/lib/crates/fabro-db/src/lib.rs
@@ -1,0 +1,48 @@
+use std::path::Path;
+use std::time::Duration;
+
+use anyhow::Context as _;
+use sqlx::migrate::Migrator;
+use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePoolOptions, SqliteSynchronous};
+use tokio::fs;
+
+pub type DbPool = sqlx::SqlitePool;
+
+static MIGRATOR: Migrator = sqlx::migrate!("./migrations");
+
+pub async fn connect(path: impl AsRef<Path>) -> anyhow::Result<DbPool> {
+    let path = path.as_ref();
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .await
+            .with_context(|| format!("creating SQLite database directory {}", parent.display()))?;
+    }
+
+    let options = SqliteConnectOptions::new()
+        .filename(path)
+        .create_if_missing(true)
+        .foreign_keys(true)
+        .journal_mode(SqliteJournalMode::Wal)
+        .synchronous(SqliteSynchronous::Normal)
+        .busy_timeout(Duration::from_secs(5));
+
+    SqlitePoolOptions::new()
+        .connect_with(options)
+        .await
+        .with_context(|| format!("opening SQLite database {}", path.display()))
+}
+
+pub async fn migrate(pool: &DbPool) -> anyhow::Result<()> {
+    MIGRATOR
+        .run(pool)
+        .await
+        .context("running SQLite migrations")
+}
+
+pub async fn health_check(pool: &DbPool) -> anyhow::Result<()> {
+    sqlx::query("SELECT 1")
+        .execute(pool)
+        .await
+        .context("checking SQLite database health")?;
+    Ok(())
+}

--- a/lib/crates/fabro-db/src/lib.rs
+++ b/lib/crates/fabro-db/src/lib.rs
@@ -10,39 +10,56 @@ pub type DbPool = sqlx::SqlitePool;
 
 static MIGRATOR: Migrator = sqlx::migrate!("./migrations");
 
-pub async fn connect(path: impl AsRef<Path>) -> anyhow::Result<DbPool> {
-    let path = path.as_ref();
-    if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent)
+#[derive(Clone)]
+pub struct Database {
+    pool: DbPool,
+}
+
+impl Database {
+    pub async fn connect(path: impl AsRef<Path>) -> anyhow::Result<Self> {
+        let path = path.as_ref();
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).await.with_context(|| {
+                format!("creating SQLite database directory {}", parent.display())
+            })?;
+        }
+
+        let options = SqliteConnectOptions::new()
+            .filename(path)
+            .create_if_missing(true)
+            .foreign_keys(true)
+            .journal_mode(SqliteJournalMode::Wal)
+            .synchronous(SqliteSynchronous::Normal)
+            .busy_timeout(Duration::from_secs(5));
+
+        let pool = SqlitePoolOptions::new()
+            .connect_with(options)
             .await
-            .with_context(|| format!("creating SQLite database directory {}", parent.display()))?;
+            .with_context(|| format!("opening SQLite database {}", path.display()))?;
+
+        Ok(Self { pool })
     }
 
-    let options = SqliteConnectOptions::new()
-        .filename(path)
-        .create_if_missing(true)
-        .foreign_keys(true)
-        .journal_mode(SqliteJournalMode::Wal)
-        .synchronous(SqliteSynchronous::Normal)
-        .busy_timeout(Duration::from_secs(5));
+    pub async fn migrate(&self) -> anyhow::Result<()> {
+        MIGRATOR
+            .run(&self.pool)
+            .await
+            .context("running SQLite migrations")
+    }
 
-    SqlitePoolOptions::new()
-        .connect_with(options)
-        .await
-        .with_context(|| format!("opening SQLite database {}", path.display()))
-}
+    pub async fn health_check(&self) -> anyhow::Result<()> {
+        sqlx::query("SELECT 1")
+            .execute(&self.pool)
+            .await
+            .context("checking SQLite database health")?;
+        Ok(())
+    }
 
-pub async fn migrate(pool: &DbPool) -> anyhow::Result<()> {
-    MIGRATOR
-        .run(pool)
-        .await
-        .context("running SQLite migrations")
-}
+    pub fn pool(&self) -> &DbPool {
+        &self.pool
+    }
 
-pub async fn health_check(pool: &DbPool) -> anyhow::Result<()> {
-    sqlx::query("SELECT 1")
-        .execute(pool)
-        .await
-        .context("checking SQLite database health")?;
-    Ok(())
+    pub fn clone_pool(&self) -> DbPool {
+        self.pool.clone()
+    }
 }

--- a/lib/crates/fabro-db/tests/sqlite.rs
+++ b/lib/crates/fabro-db/tests/sqlite.rs
@@ -11,12 +11,19 @@ async fn connect_creates_parent_directory_and_migrate_is_idempotent() -> anyhow:
     database.health_check().await?;
 
     assert!(db_path.exists());
-    let table_count: i64 = sqlx::query_scalar(
-        "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name IN ('variables', 'legacy_imports')",
+    let variable_table_count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'variables'",
     )
     .fetch_one(database.pool())
     .await?;
-    assert_eq!(table_count, 2);
+    assert_eq!(variable_table_count, 1);
+
+    let legacy_import_table_count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'legacy_imports'",
+    )
+    .fetch_one(database.pool())
+    .await?;
+    assert_eq!(legacy_import_table_count, 0);
 
     let foreign_keys: i64 = sqlx::query("PRAGMA foreign_keys")
         .fetch_one(database.pool())

--- a/lib/crates/fabro-db/tests/sqlite.rs
+++ b/lib/crates/fabro-db/tests/sqlite.rs
@@ -5,21 +5,21 @@ async fn connect_creates_parent_directory_and_migrate_is_idempotent() -> anyhow:
     let dir = tempfile::tempdir()?;
     let db_path = dir.path().join("nested").join("fabro.sqlite3");
 
-    let pool = fabro_db::connect(&db_path).await?;
-    fabro_db::migrate(&pool).await?;
-    fabro_db::migrate(&pool).await?;
-    fabro_db::health_check(&pool).await?;
+    let database = fabro_db::Database::connect(&db_path).await?;
+    database.migrate().await?;
+    database.migrate().await?;
+    database.health_check().await?;
 
     assert!(db_path.exists());
     let table_count: i64 = sqlx::query_scalar(
         "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name IN ('variables', 'legacy_imports')",
     )
-    .fetch_one(&pool)
+    .fetch_one(database.pool())
     .await?;
     assert_eq!(table_count, 2);
 
     let foreign_keys: i64 = sqlx::query("PRAGMA foreign_keys")
-        .fetch_one(&pool)
+        .fetch_one(database.pool())
         .await?
         .get(0);
     assert_eq!(foreign_keys, 1);
@@ -30,15 +30,15 @@ async fn connect_creates_parent_directory_and_migrate_is_idempotent() -> anyhow:
 #[tokio::test]
 async fn variables_schema_enforces_env_style_names() -> anyhow::Result<()> {
     let dir = tempfile::tempdir()?;
-    let pool = fabro_db::connect(dir.path().join("fabro.sqlite3")).await?;
-    fabro_db::migrate(&pool).await?;
+    let database = fabro_db::Database::connect(dir.path().join("fabro.sqlite3")).await?;
+    database.migrate().await?;
 
     sqlx::query("INSERT INTO variables (name, value, created_at, updated_at) VALUES (?, ?, ?, ?)")
         .bind("OK_123")
         .bind("")
         .bind("2026-06-30T00:00:00Z")
         .bind("2026-06-30T00:00:00Z")
-        .execute(&pool)
+        .execute(database.pool())
         .await?;
 
     let invalid = sqlx::query(
@@ -48,7 +48,7 @@ async fn variables_schema_enforces_env_style_names() -> anyhow::Result<()> {
     .bind("value")
     .bind("2026-06-30T00:00:00Z")
     .bind("2026-06-30T00:00:00Z")
-    .execute(&pool)
+    .execute(database.pool())
     .await;
     assert!(invalid.is_err());
 

--- a/lib/crates/fabro-db/tests/sqlite.rs
+++ b/lib/crates/fabro-db/tests/sqlite.rs
@@ -1,0 +1,56 @@
+use sqlx::Row as _;
+
+#[tokio::test]
+async fn connect_creates_parent_directory_and_migrate_is_idempotent() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let db_path = dir.path().join("nested").join("fabro.sqlite3");
+
+    let pool = fabro_db::connect(&db_path).await?;
+    fabro_db::migrate(&pool).await?;
+    fabro_db::migrate(&pool).await?;
+    fabro_db::health_check(&pool).await?;
+
+    assert!(db_path.exists());
+    let table_count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name IN ('variables', 'legacy_imports')",
+    )
+    .fetch_one(&pool)
+    .await?;
+    assert_eq!(table_count, 2);
+
+    let foreign_keys: i64 = sqlx::query("PRAGMA foreign_keys")
+        .fetch_one(&pool)
+        .await?
+        .get(0);
+    assert_eq!(foreign_keys, 1);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn variables_schema_enforces_env_style_names() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let pool = fabro_db::connect(dir.path().join("fabro.sqlite3")).await?;
+    fabro_db::migrate(&pool).await?;
+
+    sqlx::query("INSERT INTO variables (name, value, created_at, updated_at) VALUES (?, ?, ?, ?)")
+        .bind("OK_123")
+        .bind("")
+        .bind("2026-06-30T00:00:00Z")
+        .bind("2026-06-30T00:00:00Z")
+        .execute(&pool)
+        .await?;
+
+    let invalid = sqlx::query(
+        "INSERT INTO variables (name, value, created_at, updated_at) VALUES (?, ?, ?, ?)",
+    )
+    .bind("1BAD")
+    .bind("value")
+    .bind("2026-06-30T00:00:00Z")
+    .bind("2026-06-30T00:00:00Z")
+    .execute(&pool)
+    .await;
+    assert!(invalid.is_err());
+
+    Ok(())
+}

--- a/lib/crates/fabro-server/Cargo.toml
+++ b/lib/crates/fabro-server/Cargo.toml
@@ -45,6 +45,7 @@ fabro-types = { path = "../fabro-types" }
 fabro-util = { path = "../fabro-util" }
 fabro-api = { path = "../fabro-api" }
 fabro-client = { path = "../fabro-client" }
+fabro-db = { path = "../fabro-db" }
 fabro-store = { path = "../fabro-store" }
 fabro-vault = { path = "../fabro-vault" }
 fabro-variable = { path = "../fabro-variable" }

--- a/lib/crates/fabro-server/src/diagnostics.rs
+++ b/lib/crates/fabro-server/src/diagnostics.rs
@@ -886,6 +886,7 @@ mod tests {
             .provider_base_url("openai", server.url("/v1"))
             .build();
         state
+            .stores
             .vault
             .write()
             .await
@@ -967,6 +968,7 @@ mod tests {
             .provider_base_url("openai", server.url("/v1"))
             .build();
         state
+            .stores
             .vault
             .write()
             .await

--- a/lib/crates/fabro-server/src/run_manifest.rs
+++ b/lib/crates/fabro-server/src/run_manifest.rs
@@ -2317,6 +2317,7 @@ id = "daytona"
             .provider_base_url("openai", server.url("/v1"))
             .build();
         state
+            .stores
             .vault
             .write()
             .await

--- a/lib/crates/fabro-server/src/serve.rs
+++ b/lib/crates/fabro-server/src/serve.rs
@@ -649,6 +649,7 @@ where
     let storage = Storage::new(&data_dir);
     let vault_path = storage.secrets_path();
     let variables_path = storage.variables_path();
+    let sqlite_path = storage.sqlite_path();
     let server_env_path = storage.runtime_directory().env_path();
     runtime_settings.server_settings = runtime_settings
         .server_settings
@@ -680,6 +681,16 @@ where
     let shared_settings = Arc::new(RwLock::new(disk_document));
     std::fs::create_dir_all(&data_dir)
         .with_context(|| format!("creating data directory {}", data_dir.display()))?;
+    let db_pool = fabro_db::connect(&sqlite_path).await?;
+    fabro_db::migrate(&db_pool).await?;
+    fabro_variable::import_legacy_json_once(&db_pool, &variables_path)
+        .await
+        .with_context(|| {
+            format!(
+                "importing legacy variables file {}",
+                variables_path.display()
+            )
+        })?;
     let max_concurrent_runs = resolved_server_settings.scheduler.max_concurrent_runs;
     // In `--watch-web` mode the build watcher will populate `dist/` shortly
     // after startup. Treat that the same as assets being present so the web
@@ -735,7 +746,7 @@ where
         store,
         artifact_store,
         vault_path,
-        variables_path,
+        db_pool,
         preloaded_vault: Some(startup_vault),
         server_secrets,
         env_lookup,

--- a/lib/crates/fabro-server/src/serve.rs
+++ b/lib/crates/fabro-server/src/serve.rs
@@ -681,9 +681,9 @@ where
     let shared_settings = Arc::new(RwLock::new(disk_document));
     std::fs::create_dir_all(&data_dir)
         .with_context(|| format!("creating data directory {}", data_dir.display()))?;
-    let db_pool = fabro_db::connect(&sqlite_path).await?;
-    fabro_db::migrate(&db_pool).await?;
-    fabro_variable::import_legacy_json_once(&db_pool, &variables_path)
+    let database = fabro_db::Database::connect(&sqlite_path).await?;
+    database.migrate().await?;
+    fabro_variable::import_legacy_json_once(database.pool(), &variables_path)
         .await
         .with_context(|| {
             format!(
@@ -691,6 +691,7 @@ where
                 variables_path.display()
             )
         })?;
+    let db_pool = database.clone_pool();
     let max_concurrent_runs = resolved_server_settings.scheduler.max_concurrent_runs;
     // In `--watch-web` mode the build watcher will populate `dist/` shortly
     // after startup. Treat that the same as assets being present so the web

--- a/lib/crates/fabro-server/src/server.rs
+++ b/lib/crates/fabro-server/src/server.rs
@@ -53,6 +53,7 @@ use fabro_auth::{CredentialSource, VaultCredentialSource, auth_issue_message};
 use fabro_automation::AutomationStore;
 use fabro_config::daemon::ServerDaemon;
 use fabro_config::{RunLayer, Storage, WorkflowSettingsBuilder};
+use fabro_db::DbPool;
 use fabro_environment::EnvironmentStore;
 use fabro_interview::{
     Answer, AnswerSubmission, ControlInterviewer, Interviewer, Question, WorkerControlEnvelope,
@@ -744,7 +745,7 @@ impl SlackService {
             return;
         };
         let event_name = event.body.event_name();
-        let projection = match state.store.get_cached_run(&event.run_id).await {
+        let projection = match state.stores.runs.get_cached_run(&event.run_id).await {
             Ok(Some(cached)) => cached.projection,
             Ok(None) => {
                 warn!(
@@ -939,7 +940,7 @@ async fn load_prior_slack_lifecycle_event_details(
     run_id: RunId,
     before_seq: u32,
 ) -> PriorSlackLifecycleEventDetails {
-    let run_store = match state.store.open_run_reader(&run_id).await {
+    let run_store = match state.stores.runs.open_run_reader(&run_id).await {
         Ok(run_store) => run_store,
         Err(err) => {
             warn!(
@@ -1061,12 +1062,10 @@ fn resolve_slack_lifecycle_route_channel(
 pub struct AppState {
     runs: Mutex<HashMap<RunId, ManagedRun>>,
     aggregate_billing: Mutex<BillingAccumulator>,
-    store: Arc<Database>,
+    pub(crate) stores: AppStores,
     session_runtimes: SessionRuntimeManager,
     artifact_store: ArtifactStore,
-    automation_store: Arc<AutomationStore>,
     automation_repo_cache: Arc<GitRepoCache>,
-    environment_store: Arc<EnvironmentStore>,
     #[cfg(any(test, feature = "test-support"))]
     automation_materializer_override: Option<Arc<dyn AutomationRunMaterializer>>,
     worker_tokens: WorkerTokenKeys,
@@ -1085,8 +1084,6 @@ pub struct AppState {
     pull_request_create_locks: PullRequestCreateLocks,
     parent_link_lock: AsyncMutex<()>,
 
-    pub(crate) vault: Arc<AsyncRwLock<Vault>>,
-    pub(crate) variables: Arc<AsyncRwLock<VariableStore>>,
     pub(super) server_secrets: ServerSecrets,
     pub(crate) llm_source: Arc<dyn CredentialSource>,
     manifest_run_defaults: RwLock<Arc<RunLayer>>,
@@ -1106,15 +1103,23 @@ pub struct AppState {
     slack_started: AtomicBool,
 }
 
+pub(crate) struct AppStores {
+    pub(crate) runs:         Arc<Database>,
+    pub(crate) automations:  Arc<AutomationStore>,
+    pub(crate) environments: Arc<EnvironmentStore>,
+    pub(crate) vault:        Arc<AsyncRwLock<Vault>>,
+    pub(crate) variables:    Arc<VariableStore>,
+}
+
 type PullRequestCreateLocks = Arc<Mutex<HashMap<RunId, Arc<AsyncMutex<()>>>>>;
 
 impl AppState {
     pub(crate) fn automation_store(&self) -> &AutomationStore {
-        &self.automation_store
+        &self.stores.automations
     }
 
     pub(crate) fn environment_store(&self) -> &EnvironmentStore {
-        &self.environment_store
+        &self.stores.environments
     }
 
     pub(crate) async fn materialize_automation_run(
@@ -1135,7 +1140,7 @@ impl AppState {
             credentials,
             self.github_api_base_url.clone(),
             self.http_client.clone(),
-            (*self.environment_store.catalog_layer()).clone(),
+            (*self.stores.environments.catalog_layer()).clone(),
             Arc::clone(&self.automation_repo_cache),
         )
         .materialize(input)
@@ -1238,7 +1243,7 @@ pub(crate) struct AppStateConfig {
     pub(crate) store: Arc<Database>,
     pub(crate) artifact_store: ArtifactStore,
     pub(crate) vault_path: PathBuf,
-    pub(crate) variables_path: PathBuf,
+    pub(crate) db_pool: DbPool,
     pub(crate) preloaded_vault: Option<Vault>,
     pub(crate) server_secrets: ServerSecrets,
     pub(crate) env_lookup: EnvLookup,
@@ -1336,7 +1341,7 @@ impl AppState {
         let manifest_run_defaults = self.manifest_run_defaults();
         let manifest_run_settings = resolve_manifest_run_settings_with_catalog(
             manifest_run_defaults.as_ref(),
-            &self.environment_store,
+            &self.stores.environments,
         );
         *self
             .manifest_run_settings
@@ -1423,7 +1428,8 @@ impl AppState {
     }
 
     pub(crate) fn vault_secret(&self, name: &str) -> Option<String> {
-        self.vault
+        self.stores
+            .vault
             .try_read()
             .ok()
             .and_then(|vault| vault.get(name).map(str::to_string))
@@ -1451,7 +1457,7 @@ impl AppState {
     /// Borrow the persistent store so sibling modules can open run readers
     /// without cross-module state coupling on the `AppState` field layout.
     pub(crate) fn store_ref(&self) -> &Arc<Database> {
-        &self.store
+        &self.stores.runs
     }
 
     pub(crate) fn session_runtimes(&self) -> &SessionRuntimeManager {
@@ -1576,7 +1582,7 @@ impl AppState {
             effective_web_url(&server_settings.server, |name| (self.env_lookup)(name));
         let manifest_run_settings = resolve_manifest_run_settings_with_catalog(
             manifest_run_defaults.as_ref(),
-            &self.environment_store,
+            &self.stores.environments,
         );
         let catalog = Arc::new(
             Catalog::from_builtin_with_overrides(&llm_catalog_settings)
@@ -2287,7 +2293,7 @@ pub(crate) fn build_app_state(config: AppStateConfig) -> anyhow::Result<Arc<AppS
         store,
         artifact_store,
         vault_path,
-        variables_path,
+        db_pool,
         preloaded_vault,
         server_secrets,
         env_lookup,
@@ -2323,8 +2329,7 @@ pub(crate) fn build_app_state(config: AppStateConfig) -> anyhow::Result<Arc<AppS
             .map_err(anyhow::Error::new)
             .context("load environments")?,
     );
-    let variables = VariableStore::load(variables_path).context("load variables")?;
-    let variables = Arc::new(AsyncRwLock::new(variables));
+    let variables = Arc::new(VariableStore::new(db_pool));
     let vault = match preloaded_vault {
         Some(vault) => vault,
         None => load_startup_vault(&vault_path)?,
@@ -2430,12 +2435,16 @@ pub(crate) fn build_app_state(config: AppStateConfig) -> anyhow::Result<Arc<AppS
     Ok(Arc::new(AppState {
         runs: Mutex::new(HashMap::new()),
         aggregate_billing: Mutex::new(BillingAccumulator::default()),
-        store,
+        stores: AppStores {
+            runs: store,
+            automations: automation_store,
+            environments: environment_store,
+            vault,
+            variables,
+        },
         session_runtimes: SessionRuntimeManager::new(),
         artifact_store,
-        automation_store,
         automation_repo_cache,
-        environment_store,
         #[cfg(any(test, feature = "test-support"))]
         automation_materializer_override,
         worker_tokens,
@@ -2450,8 +2459,6 @@ pub(crate) fn build_app_state(config: AppStateConfig) -> anyhow::Result<Arc<AppS
         files_in_flight: new_files_in_flight(),
         pull_request_create_locks: Arc::new(Mutex::new(HashMap::new())),
         parent_link_lock: AsyncMutex::new(()),
-        vault,
-        variables,
         server_secrets,
         llm_source,
         manifest_run_defaults: RwLock::new(current_manifest_run_defaults),
@@ -2554,7 +2561,8 @@ async fn delete_run_internal(
     }
 
     state
-        .store
+        .stores
+        .runs
         .delete_run(&id)
         .await
         .map_err(|err| ApiError::new(StatusCode::INTERNAL_SERVER_ERROR, err.to_string()))?;
@@ -2572,7 +2580,7 @@ async fn delete_run_internal(
 }
 
 async fn load_durable_run_status(state: &AppState, id: &RunId) -> Option<RunStatus> {
-    let run_store = state.store.open_run(id).await.ok()?;
+    let run_store = state.stores.runs.open_run(id).await.ok()?;
     let projection = run_store.state().await.ok()?;
     Some(projection.status)
 }
@@ -2582,7 +2590,7 @@ async fn delete_run_sandbox_resource(
     id: RunId,
     force: bool,
 ) -> Result<SandboxDeleteOutcome, ApiError> {
-    let Ok(run_store) = state.store.open_run(&id).await else {
+    let Ok(run_store) = state.stores.runs.open_run(&id).await else {
         return Ok(SandboxDeleteOutcome::Absent);
     };
     let projection = match run_store.state().await {
@@ -2690,7 +2698,7 @@ async fn reject_active_delete_without_force(
         return Ok(());
     }
 
-    match state.store.runs().find(run_id).await {
+    match state.stores.runs.runs().find(run_id).await {
         Ok(Some(summary)) if summary.lifecycle.status.requires_force_to_delete() => {
             Err(ApiError::new(
                 StatusCode::CONFLICT,
@@ -2957,7 +2965,8 @@ pub(crate) async fn reconcile_incomplete_runs_on_startup(
     state: &Arc<AppState>,
 ) -> anyhow::Result<usize> {
     let summaries = state
-        .store
+        .stores
+        .runs
         .list_runs(&fabro_store::ListRunsQuery::default(), chrono::Utc::now())
         .await?;
     let mut reconciled = 0usize;
@@ -2967,7 +2976,7 @@ pub(crate) async fn reconcile_incomplete_runs_on_startup(
             continue;
         }
 
-        let run_store = state.store.open_run(&summary.id).await?;
+        let run_store = state.stores.runs.open_run(&summary.id).await?;
         let (error, reason) = failure_for_incomplete_run(
             summary.lifecycle.pending_control,
             "Fabro server restarted before the run reached a terminal state.".to_string(),
@@ -3013,7 +3022,7 @@ async fn persist_shutdown_run_failures(
         .collect::<HashSet<_>>();
 
     for run_id in run_ids {
-        let run_store = state.store.open_run(&run_id).await?;
+        let run_store = state.stores.runs.open_run(&run_id).await?;
         let run_state = run_store.state().await?;
         if run_state.status.is_terminal() {
             continue;
@@ -3109,7 +3118,7 @@ async fn alive_refs(state: &AppState, refs: &[WorkerRef]) -> Vec<WorkerRef> {
 }
 
 async fn persist_cancelled_run_status(state: &AppState, run_id: RunId) -> anyhow::Result<()> {
-    let run_store = state.store.open_run(&run_id).await?;
+    let run_store = state.stores.runs.open_run(&run_id).await?;
     let run_state = run_store.state().await?;
     if run_state.status.is_terminal() {
         return Ok(());
@@ -3167,7 +3176,7 @@ async fn fail_run_before_execution(
     reason: FailureReason,
     message: String,
 ) {
-    match state.store.open_run(&run_id).await {
+    match state.stores.runs.open_run(&run_id).await {
         Ok(run_store) => {
             let failure_event = workflow_event::Event::workflow_run_failed_from_error(
                 &WorkflowError::engine(message.clone()),
@@ -3252,7 +3261,8 @@ async fn load_pending_control(
     run_id: RunId,
 ) -> anyhow::Result<Option<RunControlAction>> {
     Ok(state
-        .store
+        .stores
+        .runs
         .runs()
         .find(&run_id)
         .await?
@@ -3261,7 +3271,8 @@ async fn load_pending_control(
 
 async fn durable_run_status(state: &AppState, run_id: RunId) -> anyhow::Result<Option<RunStatus>> {
     Ok(state
-        .store
+        .stores
+        .runs
         .runs()
         .find(&run_id)
         .await?
@@ -3614,7 +3625,7 @@ async fn load_pending_interview(
     run_id: RunId,
     qid: &str,
 ) -> Result<LoadedPendingInterview, Response> {
-    let cached = match state.store.get_cached_run(&run_id).await {
+    let cached = match state.stores.runs.get_cached_run(&run_id).await {
         Ok(Some(cached)) => cached,
         Ok(None) => return Err(ApiError::not_found("Run not found.").into_response()),
         Err(err) => {
@@ -3867,7 +3878,7 @@ async fn execute_run_in_process(state: Arc<AppState>, run_id: RunId) {
         return;
     }
 
-    let run_store = match state.store.open_run(&run_id).await {
+    let run_store = match state.stores.runs.open_run(&run_id).await {
         Ok(run_store) => run_store,
         Err(e) => {
             tracing::error!(run_id = %run_id, error = %e, "Failed to open run store");
@@ -3983,7 +3994,7 @@ async fn execute_run_in_process(state: Arc<AppState>, run_id: RunId) {
         run_control: None,
         github_app,
         github_permissions,
-        vault: Some(Arc::clone(&state.vault)),
+        vault: Some(Arc::clone(&state.stores.vault)),
         catalog: state.catalog(),
         on_node: None,
         registry_override,
@@ -4107,7 +4118,7 @@ async fn execute_run_subprocess(state: Arc<AppState>, run_id: RunId) {
         (run_dir, managed_run.execution_mode)
     };
 
-    let run_store = match state.store.open_run(&run_id).await {
+    let run_store = match state.stores.runs.open_run(&run_id).await {
         Ok(run_store) => run_store,
         Err(err) => {
             tracing::error!(run_id = %run_id, error = %err, "Failed to open run store");
@@ -4348,7 +4359,7 @@ async fn append_control_request(
     action: RunControlAction,
     actor: Option<Principal>,
 ) -> anyhow::Result<()> {
-    let run_store = state.store.open_run(&run_id).await?;
+    let run_store = state.stores.runs.open_run(&run_id).await?;
     let event = match action {
         RunControlAction::Cancel => workflow_event::Event::RunCancelRequested { actor },
         RunControlAction::Pause => workflow_event::Event::RunPauseRequested { actor },
@@ -4361,7 +4372,7 @@ async fn append_control_request(
 /// run is currently archived. Returns `None` otherwise (including when the run
 /// doesn't exist — the caller's own not-found handling will surface that).
 async fn reject_if_archived(state: &AppState, run_id: &RunId) -> Option<Response> {
-    let run_store = state.store.open_run_reader(run_id).await.ok()?;
+    let run_store = state.stores.runs.open_run_reader(run_id).await.ok()?;
     let projection = run_store.state().await.ok()?;
     projection.archived_at.is_some().then(|| {
         ApiError::new(

--- a/lib/crates/fabro-server/src/server/automation_scheduler.rs
+++ b/lib/crates/fabro-server/src/server/automation_scheduler.rs
@@ -419,7 +419,8 @@ mod tests {
 
     async fn cached_runs(state: &AppState) -> Vec<fabro_types::Run> {
         state
-            .store
+            .stores
+            .runs
             .list_cached_runs(&ListRunsQuery::default(), Utc::now())
             .await
             .expect("cached runs should list")

--- a/lib/crates/fabro-server/src/server/handler/artifacts.rs
+++ b/lib/crates/fabro-server/src/server/handler/artifacts.rs
@@ -68,7 +68,7 @@ async fn get_checkpoint(
         Ok(id) => id,
         Err(response) => return response,
     };
-    match state.store.get_cached_run(&id).await {
+    match state.stores.runs.get_cached_run(&id).await {
         Ok(Some(cached)) => match cached.projection.current_checkpoint() {
             Some(cp) => (StatusCode::OK, Json(cp.clone())).into_response(),
             None => (StatusCode::OK, Json(serde_json::json!(null))).into_response(),
@@ -88,7 +88,7 @@ async fn write_run_blob(
     if let Some(response) = reject_if_archived(state.as_ref(), &id).await {
         return response;
     }
-    match state.store.open_run(&id).await {
+    match state.stores.runs.open_run(&id).await {
         Ok(run_store) => match run_store.write_blob(&body).await {
             Ok(blob_id) => Json(WriteBlobResponse {
                 id: blob_id.to_string(),
@@ -106,7 +106,7 @@ async fn read_run_blob(
     RequireRunBlob(id, blob_id): RequireRunBlob,
     State(state): State<Arc<AppState>>,
 ) -> Response {
-    match state.store.open_run_reader(&id).await {
+    match state.stores.runs.open_run_reader(&id).await {
         Ok(run_store) => match run_store.read_blob(&blob_id).await {
             Ok(Some(bytes)) => octet_stream_response(bytes),
             Ok(None) => ApiError::not_found("Blob not found.").into_response(),
@@ -120,7 +120,8 @@ async fn read_run_blob(
 
 async fn load_run_spec(state: &AppState, run_id: &RunId) -> Result<fabro_types::RunSpec, Response> {
     let run_store = state
-        .store
+        .stores
+        .runs
         .open_run_reader(run_id)
         .await
         .map_err(|_| ApiError::not_found("Run not found.").into_response())?;

--- a/lib/crates/fabro-server/src/server/handler/automations.rs
+++ b/lib/crates/fabro-server/src/server/handler/automations.rs
@@ -74,7 +74,8 @@ async fn list_automation_runs(
     }
 
     let entries = match state
-        .store
+        .stores
+        .runs
         .list_cached_runs(&fabro_store::ListRunsQuery::default(), Utc::now())
         .await
     {

--- a/lib/crates/fabro-server/src/server/handler/billing.rs
+++ b/lib/crates/fabro-server/src/server/handler/billing.rs
@@ -27,7 +27,7 @@ async fn list_run_stages(
         Err(response) => return response,
     };
 
-    let cached = match state.store.get_cached_run(&id).await {
+    let cached = match state.stores.runs.get_cached_run(&id).await {
         Ok(Some(cached)) => cached,
         Ok(None) => return ApiError::not_found("Run not found.").into_response(),
         Err(err) => {
@@ -70,7 +70,7 @@ async fn get_run_billing(
     State(state): State<Arc<AppState>>,
     Path(id): Path<RunId>,
 ) -> Response {
-    let cached = match state.store.get_cached_run(&id).await {
+    let cached = match state.stores.runs.get_cached_run(&id).await {
         Ok(Some(cached)) => cached,
         Ok(None) => return ApiError::not_found("Run not found.").into_response(),
         Err(err) => {

--- a/lib/crates/fabro-server/src/server/handler/events.rs
+++ b/lib/crates/fabro-server/src/server/handler/events.rs
@@ -180,7 +180,7 @@ async fn append_run_event(
         Err(err) => return ApiError::bad_request(err.to_string()).into_response(),
     };
 
-    match state.store.open_run(&id).await {
+    match state.stores.runs.open_run(&id).await {
         Ok(run_store) => match run_store.append_event(&payload).await {
             Ok(seq) => {
                 update_live_run_from_event(&state, id, &event);
@@ -204,7 +204,7 @@ async fn list_run_events(
 ) -> Response {
     let since_seq = params.since_seq();
     let limit = params.limit();
-    match state.store.open_run_reader(&id).await {
+    match state.stores.runs.open_run_reader(&id).await {
         Ok(run_store) => match run_store
             .list_events_from_with_limit(since_seq, limit)
             .await
@@ -240,7 +240,7 @@ async fn list_run_stage_events(
     };
     let since_seq = params.since_seq();
     let limit = params.limit();
-    match state.store.open_run_reader(&id).await {
+    match state.stores.runs.open_run_reader(&id).await {
         Ok(run_store) => match run_store
             .list_events_for_stage_from_with_limit(&stage_id, since_seq, limit)
             .await
@@ -272,7 +272,7 @@ async fn get_run_event_detail(
     Query(params): Query<EventDetailParams>,
 ) -> Response {
     let max_content_length = params.max_content_length();
-    match state.store.open_run_reader(&id).await {
+    match state.stores.runs.open_run_reader(&id).await {
         Ok(run_store) => match run_store.get_event(seq).await {
             Ok(event) => {
                 let Some(envelope) = event else {
@@ -384,7 +384,7 @@ async fn attach_run_events(
         Ok(id) => id,
         Err(response) => return response,
     };
-    let Ok(run_store) = state.store.open_run_reader(&id).await else {
+    let Ok(run_store) = state.stores.runs.open_run_reader(&id).await else {
         return ApiError::not_found("Run not found.").into_response();
     };
     let start_seq = match params.since_seq {

--- a/lib/crates/fabro-server/src/server/handler/graph.rs
+++ b/lib/crates/fabro-server/src/server/handler/graph.rs
@@ -240,7 +240,7 @@ async fn load_run_dot_source(state: &AppState, id: &RunId) -> Result<String, Res
     let dot_source = if let Some(dot) = live_dot_source.filter(|d| !d.is_empty()) {
         Some(dot)
     } else {
-        match state.store.open_run_reader(id).await {
+        match state.stores.runs.open_run_reader(id).await {
             Ok(run_store) => match run_store.state().await {
                 Ok(run_state) => run_state.spec.graph_source,
                 Err(err) => {

--- a/lib/crates/fabro-server/src/server/handler/lifecycle.rs
+++ b/lib/crates/fabro-server/src/server/handler/lifecycle.rs
@@ -40,7 +40,7 @@ pub(super) fn routes() -> Router<Arc<AppState>> {
 }
 
 async fn run_response(state: &AppState, id: RunId, status: StatusCode) -> Response {
-    match state.store.get_cached_summary(&id, Utc::now()).await {
+    match state.stores.runs.get_cached_summary(&id, Utc::now()).await {
         Ok(Some(summary)) => {
             (status, Json(state.decorate_run_summary(summary).await)).into_response()
         }
@@ -102,7 +102,7 @@ pub(in crate::server) async fn queue_run_start(
         }
     }
 
-    let Ok(run_store) = state.store.open_run(&id).await else {
+    let Ok(run_store) = state.stores.runs.open_run(&id).await else {
         return Err(ApiError::not_found("Run not found."));
     };
     let run_state = match run_store.state().await {
@@ -213,7 +213,7 @@ async fn approve_run(
     if let Some(response) = reject_if_archived(state.as_ref(), &id).await {
         return response;
     }
-    let Ok(run_store) = state.store.open_run(&id).await else {
+    let Ok(run_store) = state.stores.runs.open_run(&id).await else {
         return ApiError::not_found("Run not found.").into_response();
     };
     let run_state = match run_store.state().await {
@@ -295,7 +295,7 @@ async fn deny_run(
     let message = reason
         .clone()
         .unwrap_or_else(|| "Not approved for execution".to_string());
-    let Ok(run_store) = state.store.open_run(&id).await else {
+    let Ok(run_store) = state.stores.runs.open_run(&id).await else {
         return ApiError::not_found("Run not found.").into_response();
     };
     let run_state = match run_store.state().await {
@@ -371,7 +371,7 @@ async fn cancel_run(
     if let Some(response) = reject_if_archived(state.as_ref(), &id).await {
         return response;
     }
-    let durable_summary = match state.store.runs().find(&id).await {
+    let durable_summary = match state.stores.runs.runs().find(&id).await {
         Ok(summary) => summary,
         Err(err) => {
             return ApiError::new(StatusCode::INTERNAL_SERVER_ERROR, err.to_string())
@@ -802,7 +802,7 @@ async fn rewind_run(
     };
     let input = operations::RewindInput { run_id: id, target };
     match Box::pin(operations::rewind(
-        &state.store,
+        &state.stores.runs,
         &input,
         Some(Principal::User(subject.0.clone())),
     ))
@@ -865,7 +865,7 @@ async fn fork_run(
         source_run_id: id,
         target,
     };
-    match Box::pin(operations::fork_run(&state.store, &input)).await {
+    match Box::pin(operations::fork_run(&state.stores.runs, &input)).await {
         Ok(outcome) => (
             StatusCode::OK,
             Json(ForkResponse {
@@ -897,7 +897,7 @@ async fn retry_run(
         provenance: run_provenance(&headers, &actor),
         web_url: state.run_web_url(&new_run_id),
     };
-    match Box::pin(operations::retry_run(&state.store, &input)).await {
+    match Box::pin(operations::retry_run(&state.stores.runs, &input)).await {
         Ok(outcome) => {
             let new_run_id = outcome.new_run_id;
             if let Err(err) = queue_run_start(state.as_ref(), new_run_id, false, actor).await {
@@ -918,7 +918,7 @@ async fn run_timeline(
         Ok(id) => id,
         Err(response) => return response,
     };
-    match operations::timeline(&state.store, &id).await {
+    match operations::timeline(&state.stores.runs, &id).await {
         Ok(entries) => Json(
             entries
                 .into_iter()
@@ -1105,7 +1105,7 @@ async fn batch_run_archive_item(
         }
     };
 
-    match state.store.get_cached_summary(&id, Utc::now()).await {
+    match state.stores.runs.get_cached_summary(&id, Utc::now()).await {
         Ok(Some(summary)) => BatchRunLifecycleResult {
             run_id: id.to_string(),
             ok: true,
@@ -1150,30 +1150,26 @@ async fn run_archive_operation(
     action: ArchiveAction,
 ) -> Result<BatchRunLifecycleResultOutcome, WorkflowError> {
     match action {
-        ArchiveAction::Archive => {
-            operations::archive(&state.store, id, actor)
-                .await
-                .map(|outcome| match outcome {
-                    operations::ArchiveOutcome::Archived { .. } => {
-                        BatchRunLifecycleResultOutcome::Archived
-                    }
-                    operations::ArchiveOutcome::AlreadyArchived => {
-                        BatchRunLifecycleResultOutcome::AlreadyArchived
-                    }
-                })
-        }
-        ArchiveAction::Unarchive => {
-            operations::unarchive(&state.store, id, actor)
-                .await
-                .map(|outcome| match outcome {
-                    operations::UnarchiveOutcome::Unarchived { .. } => {
-                        BatchRunLifecycleResultOutcome::Unarchived
-                    }
-                    operations::UnarchiveOutcome::NotArchived { .. } => {
-                        BatchRunLifecycleResultOutcome::NotArchived
-                    }
-                })
-        }
+        ArchiveAction::Archive => operations::archive(&state.stores.runs, id, actor)
+            .await
+            .map(|outcome| match outcome {
+                operations::ArchiveOutcome::Archived { .. } => {
+                    BatchRunLifecycleResultOutcome::Archived
+                }
+                operations::ArchiveOutcome::AlreadyArchived => {
+                    BatchRunLifecycleResultOutcome::AlreadyArchived
+                }
+            }),
+        ArchiveAction::Unarchive => operations::unarchive(&state.stores.runs, id, actor)
+            .await
+            .map(|outcome| match outcome {
+                operations::UnarchiveOutcome::Unarchived { .. } => {
+                    BatchRunLifecycleResultOutcome::Unarchived
+                }
+                operations::UnarchiveOutcome::NotArchived { .. } => {
+                    BatchRunLifecycleResultOutcome::NotArchived
+                }
+            }),
     }
 }
 
@@ -1209,7 +1205,7 @@ async fn synchronous_transition(
     id: RunId,
     append_events: impl FnOnce(&mut Vec<workflow_event::Event>),
 ) -> Option<Response> {
-    let run_store = match state.store.open_run(&id).await {
+    let run_store = match state.stores.runs.open_run(&id).await {
         Ok(run_store) => run_store,
         Err(err) => {
             return Some(

--- a/lib/crates/fabro-server/src/server/handler/pair.rs
+++ b/lib/crates/fabro-server/src/server/handler/pair.rs
@@ -689,7 +689,7 @@ async fn open_pair_run_reader(
     state: &AppState,
     id: &RunId,
 ) -> Result<fabro_store::RunDatabase, Response> {
-    match state.store.open_run_reader(id).await {
+    match state.stores.runs.open_run_reader(id).await {
         Ok(run_store) => Ok(run_store),
         Err(_) => match durable_run_status(state, *id).await {
             Ok(Some(_)) => Err(worker_unavailable(
@@ -704,7 +704,7 @@ async fn open_pair_run_reader(
 }
 
 async fn list_all_events(state: &AppState, id: &RunId) -> Result<Vec<EventEnvelope>, Response> {
-    match state.store.open_run_reader(id).await {
+    match state.stores.runs.open_run_reader(id).await {
         Ok(run_store) => run_store.list_events().await.map_err(|err| {
             ApiError::new(StatusCode::INTERNAL_SERVER_ERROR, err.to_string()).into_response()
         }),
@@ -725,7 +725,7 @@ async fn transcript_page(
     since_seq: u32,
     limit: usize,
 ) -> Result<TranscriptPage, Response> {
-    match state.store.open_run_reader(id).await {
+    match state.stores.runs.open_run_reader(id).await {
         Ok(run_store) => {
             let mut next_seq = since_seq.max(window.start_seq);
             let mut highest_scanned_seq = since_seq.saturating_sub(1);

--- a/lib/crates/fabro-server/src/server/handler/pull_requests.rs
+++ b/lib/crates/fabro-server/src/server/handler/pull_requests.rs
@@ -129,7 +129,8 @@ async fn load_pull_request_record(
     id: &RunId,
 ) -> Result<PullRequestLink, ApiError> {
     let run_store = state
-        .store
+        .stores
+        .runs
         .open_run_reader(id)
         .await
         .map_err(|_| ApiError::not_found("Run not found."))?;
@@ -290,7 +291,7 @@ async fn create_run_pull_request(
     Json(body): Json<CreateRunPullRequestRequest>,
 ) -> Response {
     let _create_guard = lock_pull_request_create(&state.pull_request_create_locks, &id).await;
-    let Ok(run_store) = state.store.open_run(&id).await else {
+    let Ok(run_store) = state.stores.runs.open_run(&id).await else {
         return ApiError::not_found("Run not found.").into_response();
     };
     let run_state = match run_store.state().await {
@@ -373,7 +374,7 @@ async fn link_run_pull_request(
         Ok(record) => record,
         Err(err) => return err.into_response(),
     };
-    let Ok(run_store) = state.store.open_run(&id).await else {
+    let Ok(run_store) = state.stores.runs.open_run(&id).await else {
         return ApiError::not_found("Run not found.").into_response();
     };
     let event = workflow_event::Event::PullRequestLinked {
@@ -391,7 +392,7 @@ async fn unlink_run_pull_request(
     State(state): State<Arc<AppState>>,
 ) -> Response {
     let _create_guard = lock_pull_request_create(&state.pull_request_create_locks, &id).await;
-    let Ok(run_store) = state.store.open_run(&id).await else {
+    let Ok(run_store) = state.stores.runs.open_run(&id).await else {
         return ApiError::not_found("Run not found.").into_response();
     };
     let run_state = match run_store.state().await {

--- a/lib/crates/fabro-server/src/server/handler/runs.rs
+++ b/lib/crates/fabro-server/src/server/handler/runs.rs
@@ -33,7 +33,7 @@ use tokio::fs;
 use tracing::info;
 
 use super::super::{
-    AppState, DeleteRunOutcome, ListResponse, PaginationParams, RunExecutionMode,
+    AppState, DeleteRunOutcome, ListResponse, PaginationParams, RunExecutionMode, VariableError,
     answer_from_request, api_question_from_pending_interview, default_page_limit,
     delete_run_internal, load_pending_interview, managed_run, paginate_items, parse_run_id_path,
     parse_stage_id_path, reject_if_archived, submit_pending_interview_answer, workflow_event,
@@ -242,7 +242,12 @@ async fn link_run_parent(
         }
     };
     let _parent_link_guard = state.parent_link_lock.lock().await;
-    let child = match state.store.get_cached_summary(&child_id, Utc::now()).await {
+    let child = match state
+        .stores
+        .runs
+        .get_cached_summary(&child_id, Utc::now())
+        .await
+    {
         Ok(Some(summary)) => summary,
         Ok(None) => return ApiError::not_found("Run not found.").into_response(),
         Err(err) => {
@@ -264,7 +269,7 @@ async fn link_run_parent(
             .into_response();
     }
 
-    let Ok(run_store) = state.store.open_run(&child_id).await else {
+    let Ok(run_store) = state.stores.runs.open_run(&child_id).await else {
         return ApiError::not_found("Run not found.").into_response();
     };
     if let Err(err) = workflow_event::append_event(
@@ -288,7 +293,12 @@ async fn unlink_run_parent(
     State(state): State<Arc<AppState>>,
 ) -> Response {
     let _parent_link_guard = state.parent_link_lock.lock().await;
-    let child = match state.store.get_cached_summary(&child_id, Utc::now()).await {
+    let child = match state
+        .stores
+        .runs
+        .get_cached_summary(&child_id, Utc::now())
+        .await
+    {
         Ok(Some(summary)) => summary,
         Ok(None) => return ApiError::not_found("Run not found.").into_response(),
         Err(err) => {
@@ -304,7 +314,7 @@ async fn unlink_run_parent(
             .into_response();
     };
 
-    let Ok(run_store) = state.store.open_run(&child_id).await else {
+    let Ok(run_store) = state.stores.runs.open_run(&child_id).await else {
         return ApiError::not_found("Run not found.").into_response();
     };
     if let Err(err) = workflow_event::append_event(
@@ -337,7 +347,8 @@ async fn validate_parent_link(
             return Err(ApiError::bad_request("Parent link would create a cycle."));
         }
         let summary = state
-            .store
+            .stores
+            .runs
             .get_cached_summary(&current_id, Utc::now())
             .await
             .map_err(|err| ApiError::new(StatusCode::INTERNAL_SERVER_ERROR, err.to_string()))?;
@@ -353,7 +364,12 @@ async fn validate_parent_link(
 }
 
 async fn updated_run_response(state: &AppState, run_id: &RunId) -> Response {
-    match state.store.get_cached_summary(run_id, Utc::now()).await {
+    match state
+        .stores
+        .runs
+        .get_cached_summary(run_id, Utc::now())
+        .await
+    {
         Ok(Some(summary)) => (
             StatusCode::OK,
             Json(state.decorate_run_summary(summary).await),
@@ -372,7 +388,8 @@ async fn list_runs(
     ExtraQuery(params): ExtraQuery<ListRunsParams>,
 ) -> Response {
     let entries = match state
-        .store
+        .stores
+        .runs
         .list_cached_runs(
             &fabro_store::ListRunsQuery {
                 parent_id: params.parent_id,
@@ -462,7 +479,8 @@ async fn resolve_run(
     Query(query): Query<ResolveRunQuery>,
 ) -> Response {
     let runs = match state
-        .store
+        .stores
+        .runs
         .list_runs(&fabro_store::ListRunsQuery::default(), Utc::now())
         .await
     {
@@ -540,7 +558,7 @@ async fn update_run(
         Ok(title) => title,
         Err(err) => return ApiError::bad_request(err.to_string()).into_response(),
     };
-    let current = match state.store.get_cached_summary(&id, Utc::now()).await {
+    let current = match state.stores.runs.get_cached_summary(&id, Utc::now()).await {
         Ok(Some(summary)) => summary,
         Ok(None) => return ApiError::not_found("Run not found.").into_response(),
         Err(err) => {
@@ -556,7 +574,7 @@ async fn update_run(
             .into_response();
     }
 
-    let run_store = match state.store.open_run(&id).await {
+    let run_store = match state.stores.runs.open_run(&id).await {
         Ok(run_store) => run_store,
         Err(err) => {
             return ApiError::new(StatusCode::INTERNAL_SERVER_ERROR, err.to_string())
@@ -573,7 +591,7 @@ async fn update_run(
         return ApiError::new(StatusCode::INTERNAL_SERVER_ERROR, err.to_string()).into_response();
     }
 
-    match state.store.get_cached_summary(&id, Utc::now()).await {
+    match state.stores.runs.get_cached_summary(&id, Utc::now()).await {
         Ok(Some(summary)) => (
             StatusCode::OK,
             Json(state.decorate_run_summary(summary).await),
@@ -645,7 +663,13 @@ pub(crate) async fn create_run_from_manifest(
         Ok(prepared) => prepared,
         Err(err) => return ApiError::bad_request(err.to_string()).into_response(),
     };
-    let vars = snapshot_run_variables(&state).await;
+    let vars = match snapshot_run_variables(&state).await {
+        Ok(vars) => vars,
+        Err(err) => {
+            return ApiError::new(StatusCode::INTERNAL_SERVER_ERROR, err.to_string())
+                .into_response();
+        }
+    };
     if let Err(err) = substitute_run_variables(&vars, &mut prepared.settings) {
         return ApiError::bad_request(format!("Run config variable interpolation failed: {err}"))
             .into_response();
@@ -700,7 +724,7 @@ pub(crate) async fn create_run_from_manifest(
 
     let storage_root = state.server_storage_dir();
     let created = match Box::pin(operations::create(
-        state.store.as_ref(),
+        state.stores.runs.as_ref(),
         create_input,
         storage_root,
         catalog,
@@ -721,7 +745,8 @@ pub(crate) async fn create_run_from_manifest(
     };
     let created_at = created.run_id.created_at();
     let summary = match state
-        .store
+        .stores
+        .runs
         .get_cached_summary(&created.run_id, Utc::now())
         .await
     {
@@ -812,7 +837,8 @@ fn spawn_generated_title_task(task: GeneratedTitleTask) {
 
         let current = match task
             .state
-            .store
+            .stores
+            .runs
             .get_cached_summary(&task.run_id, Utc::now())
             .await
         {
@@ -826,7 +852,7 @@ fn spawn_generated_title_task(task: GeneratedTitleTask) {
         if current.title != task.deterministic_title {
             return;
         }
-        let run_store = match task.state.store.open_run(&task.run_id).await {
+        let run_store = match task.state.stores.runs.open_run(&task.run_id).await {
             Ok(store) => store,
             Err(err) => {
                 tracing::debug!(run_id = %task.run_id, error = %err, "Failed to open run store for title update");
@@ -903,7 +929,13 @@ async fn run_preflight(
         Ok(prepared) => prepared,
         Err(err) => return ApiError::bad_request(err.to_string()).into_response(),
     };
-    let vars = snapshot_run_variables(&state).await;
+    let vars = match snapshot_run_variables(&state).await {
+        Ok(vars) => vars,
+        Err(err) => {
+            return ApiError::new(StatusCode::INTERNAL_SERVER_ERROR, err.to_string())
+                .into_response();
+        }
+    };
     if let Err(err) = substitute_run_variables(&vars, &mut prepared.settings) {
         return ApiError::bad_request(format!("Run config variable interpolation failed: {err}"))
             .into_response();
@@ -945,7 +977,13 @@ async fn validate_run_manifest(
         Ok(prepared) => prepared,
         Err(err) => return ApiError::bad_request(err.to_string()).into_response(),
     };
-    let vars = snapshot_run_variables(&state).await;
+    let vars = match snapshot_run_variables(&state).await {
+        Ok(vars) => vars,
+        Err(err) => {
+            return ApiError::new(StatusCode::INTERNAL_SERVER_ERROR, err.to_string())
+                .into_response();
+        }
+    };
     if let Err(err) = substitute_run_variables(&vars, &mut prepared.settings) {
         return ApiError::bad_request(format!("Run config variable interpolation failed: {err}"))
             .into_response();
@@ -968,8 +1006,10 @@ async fn validate_run_manifest(
         .into_response()
 }
 
-async fn snapshot_run_variables(state: &AppState) -> HashMap<String, String> {
-    state.variables.read().await.value_map()
+async fn snapshot_run_variables(
+    state: &AppState,
+) -> Result<HashMap<String, String>, VariableError> {
+    state.stores.variables.value_map().await
 }
 
 fn substitute_run_variables(
@@ -985,7 +1025,7 @@ async fn get_run_status(
     RequireRunManagementTarget(id, _actor): RequireRunManagementTarget,
     State(state): State<Arc<AppState>>,
 ) -> Response {
-    match state.store.get_cached_summary(&id, Utc::now()).await {
+    match state.stores.runs.get_cached_summary(&id, Utc::now()).await {
         Ok(Some(run)) => {
             (StatusCode::OK, Json(state.decorate_run_summary(run).await)).into_response()
         }
@@ -1005,7 +1045,7 @@ async fn get_run_settings(
         Ok(id) => id,
         Err(response) => return response,
     };
-    let cached = match state.store.get_cached_run(&id).await {
+    let cached = match state.stores.runs.get_cached_run(&id).await {
         Ok(Some(cached)) => cached,
         Ok(None) => return ApiError::not_found("Run not found.").into_response(),
         Err(err) => {
@@ -1024,7 +1064,7 @@ async fn get_questions(
     RequireRunManagementTarget(id, _actor): RequireRunManagementTarget,
     State(state): State<Arc<AppState>>,
 ) -> Response {
-    match state.store.get_cached_run(&id).await {
+    match state.stores.runs.get_cached_run(&id).await {
         Ok(Some(cached)) => {
             let questions = cached
                 .projection
@@ -1069,7 +1109,7 @@ async fn get_run_state(
     RequireRunManagementTarget(id, _actor): RequireRunManagementTarget,
     State(state): State<Arc<AppState>>,
 ) -> Response {
-    match state.store.get_cached_run(&id).await {
+    match state.stores.runs.get_cached_run(&id).await {
         Ok(Some(cached)) => Json((*cached.projection).clone()).into_response(),
         Ok(None) => ApiError::not_found("Run not found.").into_response(),
         Err(err) => {
@@ -1082,7 +1122,7 @@ async fn get_run_logs(
     RequireRunScoped(id): RequireRunScoped,
     State(state): State<Arc<AppState>>,
 ) -> Response {
-    if state.store.open_run_reader(&id).await.is_err() {
+    if state.stores.runs.open_run_reader(&id).await.is_err() {
         return ApiError::not_found("Run not found.").into_response();
     }
 
@@ -1109,7 +1149,7 @@ async fn get_run_stage_context_window(
         Ok(stage_id) => stage_id,
         Err(response) => return response,
     };
-    let cached = match state.store.get_cached_run(&id).await {
+    let cached = match state.stores.runs.get_cached_run(&id).await {
         Ok(Some(cached)) => cached,
         Ok(None) => return ApiError::not_found("Run not found.").into_response(),
         Err(err) => {
@@ -1169,7 +1209,7 @@ async fn get_run_stage_command_log(
         return ApiError::bad_request("limit must be greater than 0").into_response();
     }
     let limit = query.limit.min(MAX_COMMAND_LOG_LIMIT);
-    let Ok(run_store) = state.store.open_run_reader(&id).await else {
+    let Ok(run_store) = state.stores.runs.open_run_reader(&id).await else {
         return ApiError::not_found("Run not found.").into_response();
     };
     let run_state = match run_store.state().await {

--- a/lib/crates/fabro-server/src/server/handler/sandbox.rs
+++ b/lib/crates/fabro-server/src/server/handler/sandbox.rs
@@ -922,7 +922,7 @@ async fn load_run_sandbox_instance(
     state: &Arc<AppState>,
     run_id: &RunId,
 ) -> Result<fabro_types::RunSandboxInstance, Response> {
-    match state.store.open_run_reader(run_id).await {
+    match state.stores.runs.open_run_reader(run_id).await {
         Ok(run_store) => match run_store.state().await {
             Ok(run_state) => run_state
                 .sandbox

--- a/lib/crates/fabro-server/src/server/handler/secrets.rs
+++ b/lib/crates/fabro-server/src/server/handler/secrets.rs
@@ -18,7 +18,7 @@ pub(super) fn routes() -> Router<Arc<AppState>> {
 }
 
 async fn list_secrets(_auth: RequiredUser, State(state): State<Arc<AppState>>) -> Response {
-    let data = state.vault.read().await.list();
+    let data = state.stores.vault.read().await.list();
     (StatusCode::OK, Json(serde_json::json!({ "data": data }))).into_response()
 }
 
@@ -61,7 +61,7 @@ async fn create_secret(
     }
     let state_for_write = Arc::clone(&state);
     let result = spawn_blocking(move || {
-        let mut vault = state_for_write.vault.blocking_write();
+        let mut vault = state_for_write.stores.vault.blocking_write();
         vault.set(&name, &value, secret_type, description.as_deref())
     })
     .await;
@@ -98,7 +98,7 @@ async fn delete_secret_by_name(
     let name = body.name;
     let state_for_write = Arc::clone(&state);
     let result = spawn_blocking(move || {
-        let mut vault = state_for_write.vault.blocking_write();
+        let mut vault = state_for_write.stores.vault.blocking_write();
         vault.remove(&name)
     })
     .await;

--- a/lib/crates/fabro-server/src/server/handler/system.rs
+++ b/lib/crates/fabro-server/src/server/handler/system.rs
@@ -294,7 +294,8 @@ async fn get_system_df(
 ) -> Response {
     let storage_dir = state.server_storage_dir();
     let summaries = match state
-        .store
+        .stores
+        .runs
         .list_runs(&fabro_store::ListRunsQuery::default(), Utc::now())
         .await
     {
@@ -328,7 +329,7 @@ async fn get_system_repair_runs(
     _auth: RequiredUser,
     State(state): State<Arc<AppState>>,
 ) -> Response {
-    let issues = match state.store.list_unreadable_runs().await {
+    let issues = match state.stores.runs.list_unreadable_runs().await {
         Ok(issues) => issues,
         Err(err) => {
             return ApiError::new(StatusCode::INTERNAL_SERVER_ERROR, err.to_string())
@@ -359,7 +360,8 @@ async fn prune_runs(
 ) -> Response {
     let storage_dir = state.server_storage_dir();
     let summaries = match state
-        .store
+        .stores
+        .runs
         .list_runs(&fabro_store::ListRunsQuery::default(), Utc::now())
         .await
     {

--- a/lib/crates/fabro-server/src/server/handler/variables.rs
+++ b/lib/crates/fabro-server/src/server/handler/variables.rs
@@ -1,12 +1,9 @@
 use std::sync::Arc;
 
-use fabro_types::Variable;
-use tokio::task::JoinError;
-
 use super::super::{
     ApiError, AppState, CreateVariableRequest, IntoResponse, Json, Path, RequiredUser, Response,
     Router, State, StatusCode, UpdateVariableRequest, VariableError, VariableListResponse,
-    VariableStore, get, spawn_blocking,
+    VariableStore, get,
 };
 
 pub(super) fn routes() -> Router<Arc<AppState>> {
@@ -21,8 +18,10 @@ pub(super) fn routes() -> Router<Arc<AppState>> {
 }
 
 async fn list_variables(_auth: RequiredUser, State(state): State<Arc<AppState>>) -> Response {
-    let data = state.variables.read().await.list();
-    (StatusCode::OK, Json(VariableListResponse { data })).into_response()
+    match state.stores.variables.list().await {
+        Ok(data) => (StatusCode::OK, Json(VariableListResponse { data })).into_response(),
+        Err(err) => variable_error_response(err),
+    }
 }
 
 async fn create_variable(
@@ -30,17 +29,15 @@ async fn create_variable(
     State(state): State<Arc<AppState>>,
     Json(body): Json<CreateVariableRequest>,
 ) -> Response {
-    let name = body.name;
-    let value = body.value;
-    let description = body.description;
-    let state_for_write = Arc::clone(&state);
-    let result = spawn_blocking(move || {
-        let mut variables = state_for_write.variables.blocking_write();
-        variables.set(&name, &value, description.as_deref())
-    })
-    .await;
-
-    variable_write_response(result)
+    match state
+        .stores
+        .variables
+        .set(&body.name, &body.value, body.description.as_deref())
+        .await
+    {
+        Ok(variable) => (StatusCode::OK, Json(variable)).into_response(),
+        Err(err) => variable_error_response(err),
+    }
 }
 
 async fn get_variable(
@@ -51,9 +48,10 @@ async fn get_variable(
     if let Err(VariableError::InvalidName(_)) = VariableStore::validate_name(&name) {
         return ApiError::bad_request("invalid variable name").into_response();
     }
-    match state.variables.read().await.get(&name) {
-        Some(variable) => (StatusCode::OK, Json(variable)).into_response(),
-        None => ApiError::not_found(format!("variable not found: {name}")).into_response(),
+    match state.stores.variables.get(&name).await {
+        Ok(Some(variable)) => (StatusCode::OK, Json(variable)).into_response(),
+        Ok(None) => ApiError::not_found(format!("variable not found: {name}")).into_response(),
+        Err(err) => variable_error_response(err),
     }
 }
 
@@ -63,16 +61,15 @@ async fn update_variable(
     Path(name): Path<String>,
     Json(body): Json<UpdateVariableRequest>,
 ) -> Response {
-    let value = body.value;
-    let description = body.description;
-    let state_for_write = Arc::clone(&state);
-    let result = spawn_blocking(move || {
-        let mut variables = state_for_write.variables.blocking_write();
-        variables.update_existing(&name, &value, description.as_deref())
-    })
-    .await;
-
-    variable_write_response(result)
+    match state
+        .stores
+        .variables
+        .update_existing(&name, &body.value, body.description.as_deref())
+        .await
+    {
+        Ok(variable) => (StatusCode::OK, Json(variable)).into_response(),
+        Err(err) => variable_error_response(err),
+    }
 }
 
 async fn delete_variable(
@@ -80,33 +77,9 @@ async fn delete_variable(
     State(state): State<Arc<AppState>>,
     Path(name): Path<String>,
 ) -> Response {
-    let state_for_write = Arc::clone(&state);
-    let result = spawn_blocking(move || {
-        let mut variables = state_for_write.variables.blocking_write();
-        variables.remove(&name)
-    })
-    .await;
-
-    match result {
-        Ok(Ok(())) => StatusCode::NO_CONTENT.into_response(),
-        Ok(Err(err)) => variable_error_response(err),
-        Err(err) => ApiError::new(
-            StatusCode::INTERNAL_SERVER_ERROR,
-            format!("variable delete task failed: {err}"),
-        )
-        .into_response(),
-    }
-}
-
-fn variable_write_response(result: Result<Result<Variable, VariableError>, JoinError>) -> Response {
-    match result {
-        Ok(Ok(variable)) => (StatusCode::OK, Json(variable)).into_response(),
-        Ok(Err(err)) => variable_error_response(err),
-        Err(err) => ApiError::new(
-            StatusCode::INTERNAL_SERVER_ERROR,
-            format!("variable write task failed: {err}"),
-        )
-        .into_response(),
+    match state.stores.variables.remove(&name).await {
+        Ok(()) => StatusCode::NO_CONTENT.into_response(),
+        Err(err) => variable_error_response(err),
     }
 }
 
@@ -118,10 +91,14 @@ fn variable_error_response(err: VariableError) -> Response {
         VariableError::NotFound(name) => {
             ApiError::not_found(format!("variable not found: {name}")).into_response()
         }
-        VariableError::Io(err) => {
+        VariableError::Db(err) => {
             ApiError::new(StatusCode::INTERNAL_SERVER_ERROR, err.to_string()).into_response()
         }
-        VariableError::Serde(err) => {
+        VariableError::LegacyRead { .. }
+        | VariableError::LegacyParse { .. }
+        | VariableError::LegacyInvalidName { .. }
+        | VariableError::Timestamp { .. }
+        | VariableError::RowCountOverflow { .. } => {
             ApiError::new(StatusCode::INTERNAL_SERVER_ERROR, err.to_string()).into_response()
         }
     }

--- a/lib/crates/fabro-server/src/server/handler/variables.rs
+++ b/lib/crates/fabro-server/src/server/handler/variables.rs
@@ -97,6 +97,7 @@ fn variable_error_response(err: VariableError) -> Response {
         VariableError::LegacyRead { .. }
         | VariableError::LegacyParse { .. }
         | VariableError::LegacyInvalidName { .. }
+        | VariableError::LegacyBackup { .. }
         | VariableError::Timestamp { .. }
         | VariableError::RowCountOverflow { .. } => {
             ApiError::new(StatusCode::INTERNAL_SERVER_ERROR, err.to_string()).into_response()

--- a/lib/crates/fabro-server/src/server/handler/worker_control.rs
+++ b/lib/crates/fabro-server/src/server/handler/worker_control.rs
@@ -35,7 +35,7 @@ async fn worker_control_stream(
     Query(query): Query<WorkerControlStreamQuery>,
     ws: WebSocketUpgrade,
 ) -> Response {
-    let cached = match state.store.get_cached_run(&id).await {
+    let cached = match state.stores.runs.get_cached_run(&id).await {
         Ok(Some(cached)) => cached,
         Ok(None) => return ApiError::not_found("Run not found.").into_response(),
         Err(err) => {

--- a/lib/crates/fabro-server/src/server/resource_sampler.rs
+++ b/lib/crates/fabro-server/src/server/resource_sampler.rs
@@ -137,7 +137,8 @@ impl ResourceSampler {
         }
 
         let summaries = state
-            .store
+            .stores
+            .runs
             .list_runs(&fabro_store::ListRunsQuery::default(), chrono::Utc::now())
             .await
             .context("failed to list runs for resource sampling")?;

--- a/lib/crates/fabro-server/src/server/tests.rs
+++ b/lib/crates/fabro-server/src/server/tests.rs
@@ -497,6 +497,7 @@ fn webhook_test_app(auth_mode: AuthMode) -> Router {
         |_| None,
     );
     state
+        .stores
         .vault
         .try_write()
         .expect("test vault should not be locked")
@@ -630,7 +631,8 @@ fn pair_test_target() -> PairTarget {
 async fn append_pair_transcript_fixture(state: &Arc<AppState>, run_id: RunId) -> PairId {
     let pair_id = "01HZX6M29F1CD5YYMHT1F5D7WQ".parse().unwrap();
     let run_store = state
-        .store
+        .stores
+        .runs
         .open_run(&run_id)
         .await
         .expect("test run should be openable");
@@ -1347,7 +1349,7 @@ async fn create_secret_stores_file_secret_outside_token_lookups() {
     assert_eq!(body["type"], "file");
     assert_eq!(body["description"], "Test certificate");
 
-    let vault = state.vault.read().await;
+    let vault = state.stores.vault.read().await;
     assert_eq!(
         vault.get_entry("/tmp/test.pem").unwrap().secret_type,
         SecretType::File
@@ -1391,7 +1393,7 @@ async fn create_secret_rejects_bootstrap_secret_names() {
             body["errors"][0]["detail"],
             format!("{name} is a bootstrap secret; configure it with process env or server.env")
         );
-        assert!(state.vault.read().await.get(name).is_none());
+        assert!(state.stores.vault.read().await.get(name).is_none());
     }
 }
 
@@ -1411,7 +1413,7 @@ async fn create_secret_allows_optional_vault_and_custom_secret_names() {
             .unwrap();
 
         assert_status!(response, StatusCode::OK).await;
-        assert_eq!(state.vault.read().await.get(name), Some(value));
+        assert_eq!(state.stores.vault.read().await.get(name), Some(value));
     }
 }
 
@@ -1504,11 +1506,19 @@ async fn create_secret_stores_valid_oauth_entries() {
 
     let response = app.oneshot(req).await.unwrap();
     assert_status!(response, StatusCode::OK).await;
-    let listed = state.vault.read().await.list();
+    let listed = state.stores.vault.read().await.list();
     assert_eq!(listed.len(), 1);
     assert_eq!(listed[0].name, "OPENAI_CODEX");
     assert_eq!(listed[0].secret_type, SecretType::Oauth);
-    assert!(state.vault.read().await.get("OPENAI_CODEX").is_some());
+    assert!(
+        state
+            .stores
+            .vault
+            .read()
+            .await
+            .get("OPENAI_CODEX")
+            .is_some()
+    );
 }
 
 #[tokio::test]
@@ -1532,6 +1542,7 @@ async fn create_secret_rejects_under_scoped_daytona_api_key_and_leaves_vault_unc
         },
     );
     state
+        .stores
         .vault
         .write()
         .await
@@ -1568,7 +1579,12 @@ async fn create_secret_rejects_under_scoped_daytona_api_key_and_leaves_vault_unc
          snapshot and sandbox scopes."
     );
     assert_eq!(
-        state.vault.read().await.get(EnvVars::DAYTONA_API_KEY),
+        state
+            .stores
+            .vault
+            .read()
+            .await
+            .get(EnvVars::DAYTONA_API_KEY),
         Some("existing")
     );
     auth.assert_async().await;
@@ -1608,6 +1624,7 @@ enabled = false
         },
     );
     state
+        .stores
         .vault
         .write()
         .await
@@ -1657,6 +1674,7 @@ async fn resolve_llm_client_reads_openai_token_from_vault() {
         |_| None,
     );
     state
+        .stores
         .vault
         .write()
         .await
@@ -1743,6 +1761,7 @@ async fn llm_source_configured_providers_reads_openai_token_from_vault() {
         |_| None,
     );
     state
+        .stores
         .vault
         .write()
         .await
@@ -1787,6 +1806,7 @@ async fn resolve_llm_client_uses_vault_key_without_env_lookup_openai_settings() 
         .provider_base_url("openai", server.url("/v1"))
         .build();
     state
+        .stores
         .vault
         .write()
         .await
@@ -1828,7 +1848,7 @@ async fn resolve_llm_client_uses_vault_key_without_env_lookup_openai_settings() 
 async fn list_secrets_includes_oauth_metadata() {
     let state = test_app_state();
     {
-        let mut vault = state.vault.write().await;
+        let mut vault = state.stores.vault.write().await;
         vault
             .set(
                 "OPENAI_CODEX",
@@ -1944,7 +1964,7 @@ async fn delete_secret_by_name_removes_file_secret() {
 
     let delete_response = app.oneshot(delete_req).await.unwrap();
     assert_status!(delete_response, StatusCode::NO_CONTENT).await;
-    assert!(state.vault.read().await.list().is_empty());
+    assert!(state.stores.vault.read().await.list().is_empty());
 }
 
 #[test]
@@ -2002,7 +2022,7 @@ fn slack_app_state_with_settings_and_secret_sources(
         max_concurrent_runs: 5,
         store,
         artifact_store,
-        variables_path: vault_path.with_file_name("variables.json"),
+        db_pool: test_db_pool_for_vault_path(&vault_path).expect("test db pool should build"),
         vault_path,
         preloaded_vault: Some(vault),
         server_secrets: load_test_server_secrets(server_env_path, server_secret_env),
@@ -2133,7 +2153,7 @@ fn slack_service_respects_disabled_server_config_even_with_vault_tokens() {
         max_concurrent_runs: 5,
         store,
         artifact_store,
-        variables_path: vault_path.with_file_name("variables.json"),
+        db_pool: test_db_pool_for_vault_path(&vault_path).expect("test db pool should build"),
         vault_path,
         preloaded_vault: Some(vault),
         server_secrets: load_test_server_secrets(
@@ -2266,6 +2286,7 @@ fn worker_command_forwards_github_app_private_key_from_vault() {
     let storage_dir = tempfile::tempdir().unwrap();
     let state = worker_command_test_state(storage_dir.path(), &["dev-token"], Some(TEST_DEV_TOKEN));
     state
+        .stores
         .vault
         .try_write()
         .expect("test vault should not be locked")
@@ -2497,7 +2518,7 @@ methods = ["dev-token"]
         max_concurrent_runs: 5,
         store,
         artifact_store,
-        variables_path: vault_path.with_file_name("variables.json"),
+        db_pool: test_db_pool_for_vault_path(&vault_path).expect("test db pool should build"),
         vault_path,
         preloaded_vault: None,
         server_secrets: ServerSecrets::load(server_env_path, HashMap::new()).unwrap(),
@@ -2582,6 +2603,7 @@ fn build_app_state_migrates_legacy_vault_file_on_boot() {
         .expect("legacy vault should not prevent server boot");
 
     let vault = state
+        .stores
         .vault
         .try_read()
         .expect("test vault should not be locked");
@@ -2624,7 +2646,7 @@ fn build_test_app_state_with_vault_path(vault_path: &Path) -> anyhow::Result<Arc
         max_concurrent_runs: 5,
         store,
         artifact_store,
-        variables_path: vault_path.with_file_name("variables.json"),
+        db_pool: test_db_pool_for_vault_path(vault_path)?,
         vault_path: vault_path.to_path_buf(),
         preloaded_vault: None,
         server_secrets: load_test_server_secrets(
@@ -3147,7 +3169,8 @@ async fn system_repair_runs_lists_catalog_entries_without_projection() {
     let app = crate::test_support::build_test_router(Arc::clone(&state));
     let run_id = RunId::new();
     state
-        .store
+        .stores
+        .runs
         .catalog_index()
         .await
         .unwrap()
@@ -3232,6 +3255,7 @@ async fn create_run_without_explicit_title_returns_deterministic_then_updates_ge
         .env_lookup(|_| None)
         .build();
     state
+        .stores
         .vault
         .write()
         .await
@@ -3257,6 +3281,7 @@ async fn create_run_with_explicit_title_skips_generated_title_work() {
         .env_lookup(|_| None)
         .build();
     state
+        .stores
         .vault
         .write()
         .await
@@ -3273,7 +3298,8 @@ async fn create_run_with_explicit_title_skips_generated_title_work() {
 
     assert_eq!(
         state
-            .store
+            .stores
+            .runs
             .get_cached_summary(&run_id, Utc::now())
             .await
             .unwrap()
@@ -3295,7 +3321,8 @@ async fn create_run_without_ready_llm_provider_skips_generated_title_work() {
 
     assert_eq!(
         state
-            .store
+            .stores
+            .runs
             .get_cached_summary(&run_id, Utc::now())
             .await
             .unwrap()
@@ -3322,6 +3349,7 @@ async fn generated_title_failure_leaves_deterministic_title_unchanged() {
         .env_lookup(|_| None)
         .build();
     state
+        .stores
         .vault
         .write()
         .await
@@ -3336,7 +3364,8 @@ async fn generated_title_failure_leaves_deterministic_title_unchanged() {
 
     assert_eq!(
         state
-            .store
+            .stores
+            .runs
             .get_cached_summary(&run_id, Utc::now())
             .await
             .unwrap()
@@ -3361,6 +3390,7 @@ async fn generated_title_does_not_overwrite_user_title_edit() {
         .env_lookup(|_| None)
         .build();
     state
+        .stores
         .vault
         .write()
         .await
@@ -3384,7 +3414,8 @@ async fn generated_title_does_not_overwrite_user_title_edit() {
 
     assert_eq!(
         state
-            .store
+            .stores
+            .runs
             .get_cached_summary(&run_id, Utc::now())
             .await
             .unwrap()
@@ -3425,7 +3456,8 @@ async fn post_runs_create_regression_keeps_api_behavior_without_automation_metad
     assert!(body["automation"].is_null());
     assert_eq!(body["lifecycle"]["status"]["kind"], "submitted");
     let summary = state
-        .store
+        .stores
+        .runs
         .get_cached_summary(&run_id, Utc::now())
         .await
         .unwrap()
@@ -3460,7 +3492,8 @@ async fn create_run_from_manifest_helper_persists_without_automation_metadata() 
     assert_eq!(body["id"], run_id.to_string());
     assert!(body["automation"].is_null());
     let summary = state
-        .store
+        .stores
+        .runs
         .get_cached_summary(&run_id, Utc::now())
         .await
         .unwrap()
@@ -3507,7 +3540,8 @@ async fn create_run_from_manifest_helper_persists_automation_metadata() {
         automation.trigger_id.as_deref().unwrap()
     );
     let summary = state
-        .store
+        .stores
+        .runs
         .get_cached_summary(&run_id, Utc::now())
         .await
         .unwrap()
@@ -3585,7 +3619,8 @@ async fn mock_openai_title_response<'a>(
 async fn wait_for_run_title(state: &AppState, run_id: RunId, expected: &str) {
     for _ in 0..50 {
         let title = state
-            .store
+            .stores
+            .runs
             .get_cached_summary(&run_id, Utc::now())
             .await
             .unwrap()
@@ -3610,7 +3645,7 @@ async fn wait_for_mock_hits(mock: &httpmock::Mock<'_>, expected: usize) {
 }
 
 async fn title_update_event_count(state: &AppState, run_id: RunId) -> usize {
-    let run_store = state.store.open_run(&run_id).await.unwrap();
+    let run_store = state.stores.runs.open_run(&run_id).await.unwrap();
     run_store
         .list_events()
         .await
@@ -3860,7 +3895,7 @@ async fn create_durable_run_with_events(
     run_id: RunId,
     events: &[workflow_event::Event],
 ) {
-    let run_store = state.store.create_run(&run_id).await.unwrap();
+    let run_store = state.stores.runs.create_run(&run_id).await.unwrap();
     if !matches!(
         events.first(),
         Some(workflow_event::Event::RunCreated { .. })
@@ -4105,7 +4140,7 @@ async fn create_slack_notification_run(
     graph_name: &str,
     workflow_slug: Option<&str>,
 ) -> fabro_store::RunDatabase {
-    let run_store = state.store.create_run(&run_id).await.unwrap();
+    let run_store = state.stores.runs.create_run(&run_id).await.unwrap();
     workflow_event::append_event(&run_store, &run_id, &workflow_event::Event::RunCreated {
         run_id,
         title: None,
@@ -4677,7 +4712,7 @@ async fn persist_cancelled_run_status_ignores_already_terminal_runs() {
         .await
         .unwrap();
 
-    let run_store = state.store.open_run(&run_id).await.unwrap();
+    let run_store = state.stores.runs.open_run(&run_id).await.unwrap();
     let projection = run_store.state().await.unwrap();
     assert_eq!(projection.status, RunStatus::Succeeded {
         reason: SuccessReason::Completed,
@@ -4756,7 +4791,7 @@ async fn append_scoped_stage_event(
     };
     let stored = fabro_workflow::event::to_run_event_at(&run_id, event, Utc::now(), Some(&scope));
     let payload = fabro_workflow::event::build_redacted_event_payload(&stored, &run_id).unwrap();
-    let run_store = state.store.open_run(&run_id).await.unwrap();
+    let run_store = state.stores.runs.open_run(&run_id).await.unwrap();
     run_store.append_event(&payload).await.unwrap();
 }
 
@@ -4964,7 +4999,7 @@ async fn list_run_stages_projects_running_stage_as_cancelled_after_cancelled_run
         },
     )
     .await;
-    let run_store = state.store.open_run(&run_id).await.unwrap();
+    let run_store = state.stores.runs.open_run(&run_id).await.unwrap();
     workflow_event::append_event(
         &run_store,
         &run_id,
@@ -5318,7 +5353,7 @@ async fn run_billing_dedups_retried_nodes_and_sums_their_durations() {
 
     // Checkpoint records `verify` twice (once per visit) — this is what makes
     // the dedup necessary.
-    let run_store = state.store.open_run(&run_id).await.unwrap();
+    let run_store = state.stores.runs.open_run(&run_id).await.unwrap();
     workflow_event::append_event(
         &run_store,
         &run_id,
@@ -5447,7 +5482,7 @@ async fn run_billing_sums_usage_across_retry_visits_and_uses_latest_model() {
     let mut latest_outcome: Outcome<Option<fabro_model::BilledModelUsage>> = Outcome::success();
     latest_outcome.usage = Some(success_usage);
     latest_outcome.timing = Some(fabro_types::StageTiming::wall_only(800));
-    let run_store = state.store.open_run(&run_id).await.unwrap();
+    let run_store = state.stores.runs.open_run(&run_id).await.unwrap();
     workflow_event::append_event(
         &run_store,
         &run_id,
@@ -5864,7 +5899,7 @@ async fn append_raw_run_event(
     properties: serde_json::Value,
     node_id: Option<&str>,
 ) {
-    let run_store = state.store.open_run(&run_id).await.unwrap();
+    let run_store = state.stores.runs.open_run(&run_id).await.unwrap();
     let payload = fabro_store::EventPayload::new(
         json!({
             "id": format!("evt-{seq_hint}"),
@@ -5881,7 +5916,7 @@ async fn append_raw_run_event(
 }
 
 async fn create_unreadable_durable_run(state: &Arc<AppState>, run_id: RunId) {
-    let run_store = state.store.create_run(&run_id).await.unwrap();
+    let run_store = state.stores.runs.create_run(&run_id).await.unwrap();
     append_default_run_created(&run_store, run_id).await;
     workflow_event::append_event(&run_store, &run_id, &workflow_event::Event::RunRunnable {
         source: fabro_types::RunRunnableSource::StartRequested,
@@ -5976,6 +6011,7 @@ fn create_github_token_app_state_with_env_lookup_and_llm_catalog_settings(
         .unwrap_or_else(|| std::path::Path::new("."))
         .join("environments");
     fabro_environment::seed_environments(&environment_dir).expect("test environments should seed");
+    let db_pool = test_db_pool_for_vault_path(&vault_path).expect("test db pool should build");
     let config = AppStateConfig {
         resolved_settings: resolved_runtime_settings_for_tests(
             github_token_settings(),
@@ -5986,7 +6022,7 @@ fn create_github_token_app_state_with_env_lookup_and_llm_catalog_settings(
         max_concurrent_runs: 5,
         store,
         artifact_store,
-        variables_path: vault_path.with_file_name("variables.json"),
+        db_pool,
         vault_path,
         preloaded_vault: None,
         server_secrets: load_test_server_secrets(server_env_path, HashMap::new()),
@@ -6003,6 +6039,7 @@ fn create_github_token_app_state_with_env_lookup_and_llm_catalog_settings(
     let state = build_app_state(config).expect("test app state should build");
     if let Some(token) = token {
         state
+            .stores
             .vault
             .try_write()
             .expect("test vault should not already be locked")
@@ -6037,6 +6074,7 @@ fn github_token_strategy_ignores_gh_token_alias() {
         _ => None,
     });
     state
+        .stores
         .vault
         .try_write()
         .expect("test vault should not already be locked")
@@ -6424,6 +6462,7 @@ async fn list_models_marks_configured_true_when_provider_has_credential_material
         |_| None,
     );
     state
+        .stores
         .vault
         .write()
         .await
@@ -6618,6 +6657,7 @@ async fn list_providers_marks_configured_per_provider_and_omits_secrets() {
         |_| None,
     );
     state
+        .stores
         .vault
         .write()
         .await
@@ -6773,6 +6813,7 @@ async fn test_providers_successful_probe_returns_probe_model() {
         .provider_base_url("openai", server.url("/v1"))
         .build();
     state
+        .stores
         .vault
         .write()
         .await
@@ -6827,6 +6868,7 @@ async fn test_providers_auth_issue_returns_error_without_upstream_call() {
     credential.tokens.expires_at = Utc::now() - ChronoDuration::hours(1);
     credential.tokens.refresh_token = None;
     state
+        .stores
         .vault
         .write()
         .await
@@ -6900,6 +6942,7 @@ reasoning = false
         .llm_catalog_settings(llm_catalog_settings)
         .build();
     state
+        .stores
         .vault
         .write()
         .await
@@ -7018,7 +7061,7 @@ reasoning = false
         .llm_catalog_settings(llm_catalog_settings)
         .build();
     {
-        let mut vault = state.vault.write().await;
+        let mut vault = state.stores.vault.write().await;
         vault
             .set("ALPHA_API_KEY", "alpha-key", SecretType::Token, None)
             .unwrap();
@@ -7078,6 +7121,7 @@ async fn test_providers_response_does_not_leak_api_keys() {
         .provider_base_url("openai", server.url("/v1"))
         .build();
     state
+        .stores
         .vault
         .write()
         .await
@@ -7839,7 +7883,7 @@ async fn get_run_stage_command_log_returns_cas_slice() {
     let state = test_app_state_with_isolated_storage();
     let app = crate::test_support::build_test_router(Arc::clone(&state));
     let run_id = RunId::new();
-    let run_store = state.store.create_run(&run_id).await.unwrap();
+    let run_store = state.stores.runs.create_run(&run_id).await.unwrap();
     append_default_run_created(&run_store, run_id).await;
     let output_blob = run_store
         .write_blob(&serde_json::to_vec("hello world").unwrap())
@@ -7903,7 +7947,7 @@ async fn get_run_stage_command_log_prefers_scratch_when_cas_ref_exists() {
     let app = crate::test_support::build_test_router(Arc::clone(&state));
     let run_id = RunId::new();
     let stage_id = StageId::new("script_node", 1);
-    let run_store = state.store.create_run(&run_id).await.unwrap();
+    let run_store = state.stores.runs.create_run(&run_id).await.unwrap();
     append_default_run_created(&run_store, run_id).await;
     let output_blob = run_store
         .write_blob(&serde_json::to_vec("cas log").unwrap())
@@ -8439,7 +8483,7 @@ async fn unlink_run_pull_request_appends_event_and_clears_projected_state() {
     assert!(state_body["pull_request"].is_null());
 
     let run_id = run_id.parse::<RunId>().unwrap();
-    let run_store = state.store.open_run_reader(&run_id).await.unwrap();
+    let run_store = state.stores.runs.open_run_reader(&run_id).await.unwrap();
     let events = run_store.list_events().await.unwrap();
     assert!(events.iter().any(|event| {
         event.event.event_name() == "pull_request.unlinked"
@@ -8573,6 +8617,7 @@ async fn create_run_pull_request_creates_and_persists_record() {
         llm_catalog_settings_with_provider_base_url("openai", llm.url("/v1")),
     );
     state
+        .stores
         .vault
         .write()
         .await
@@ -9085,9 +9130,9 @@ async fn cache_backed_run_endpoints_reflect_events_appended_after_warmup() {
         .parse::<RunId>()
         .unwrap();
 
-    state.store.warm_projection_cache().await.unwrap();
+    state.stores.runs.warm_projection_cache().await.unwrap();
 
-    let run_store = state.store.open_run(&run_id).await.unwrap();
+    let run_store = state.stores.runs.open_run(&run_id).await.unwrap();
     workflow_event::append_event(&run_store, &run_id, &workflow_event::Event::RunRunnable {
         source: fabro_types::RunRunnableSource::StartRequested,
         actor:  None,
@@ -9403,7 +9448,7 @@ async fn create_run_persists_manifest_and_definition_blobs_without_bundle_file()
     let body = response_json!(response, StatusCode::CREATED).await;
     let run_id = body["id"].as_str().unwrap().parse::<RunId>().unwrap();
 
-    let run_store = state.store.open_run_reader(&run_id).await.unwrap();
+    let run_store = state.stores.runs.open_run_reader(&run_id).await.unwrap();
     let events = run_store.list_events().await.unwrap();
     let created = events[0].event.to_value().unwrap();
     let submitted = events[1].event.to_value().unwrap();
@@ -9713,7 +9758,8 @@ async fn create_run_persists_run_spec() {
         .parse::<RunId>()
         .unwrap();
     let run_state = state
-        .store
+        .stores
+        .runs
         .open_run_reader(&run_id)
         .await
         .unwrap()
@@ -9771,7 +9817,8 @@ async fn create_run_keeps_missing_project_and_workflow_names_absent() {
     let run_id = body["id"].as_str().unwrap().parse::<RunId>().unwrap();
 
     let run_state = state
-        .store
+        .stores
+        .runs
         .open_run_reader(&run_id)
         .await
         .unwrap()
@@ -9812,7 +9859,8 @@ async fn worker_token_accepts_run_scoped_routes_and_falls_back_to_user_jwt() {
     let other_run_id = create_run_with_bearer(&app, &user_jwt).await;
     let other_worker_token = issue_test_worker_token(&other_run_id);
     let blob_id = state
-        .store
+        .stores
+        .runs
         .open_run(&run_id)
         .await
         .unwrap()
@@ -10059,7 +10107,8 @@ async fn run_tool_worker_token_can_use_client_backend_routes_across_runs() {
 
     let created_child = create_run_with_bearer(&app, &run_tool_worker_token).await;
     let cached = state
-        .store
+        .stores
+        .runs
         .get_cached_run(&created_child)
         .await
         .unwrap()
@@ -10338,7 +10387,7 @@ async fn worker_token_controls_command_log_route() {
     let worker_token = issue_test_worker_token(&run_id);
     let other_run_id = create_run_with_bearer(&app, &user_jwt).await;
     let mismatched_worker_token = issue_test_worker_token(&other_run_id);
-    let run_store = state.store.open_run(&run_id).await.unwrap();
+    let run_store = state.stores.runs.open_run(&run_id).await.unwrap();
     workflow_event::append_event(
         &run_store,
         &run_id,
@@ -10678,7 +10727,8 @@ async fn start_run_transitions_to_runnable() {
     assert_eq!(body["title"], "Test");
 
     let status = state
-        .store
+        .stores
+        .runs
         .open_run_reader(&run_id.parse::<RunId>().unwrap())
         .await
         .unwrap()
@@ -10875,7 +10925,7 @@ async fn patch_run_title_updates_active_and_archived_runs() {
     let patch_body = response_json!(patch_response, StatusCode::OK).await;
     assert_eq!(patch_body["title"], "Active title");
 
-    let run_store = state.store.open_run_reader(&run_id).await.unwrap();
+    let run_store = state.stores.runs.open_run_reader(&run_id).await.unwrap();
     let event_count = run_store.list_events().await.unwrap().len();
     let same_title_response = app
         .clone()
@@ -10893,7 +10943,8 @@ async fn patch_run_title_updates_active_and_archived_runs() {
     assert_eq!(same_title_body["title"], "Active title");
     assert_eq!(
         state
-            .store
+            .stores
+            .runs
             .open_run_reader(&run_id)
             .await
             .unwrap()
@@ -10905,7 +10956,7 @@ async fn patch_run_title_updates_active_and_archived_runs() {
         "same-title PATCH should not append an event"
     );
 
-    let run_store = state.store.open_run(&run_id).await.unwrap();
+    let run_store = state.stores.runs.open_run(&run_id).await.unwrap();
     for event in [
         workflow_event::Event::RunRunnable {
             source: fabro_types::RunRunnableSource::StartRequested,
@@ -11090,7 +11141,8 @@ async fn resume_cancelled_run_with_checkpoint_transitions_to_runnable() {
     assert_eq!(body["timing"], serde_json::Value::Null);
 
     let state = state
-        .store
+        .stores
+        .runs
         .open_run_reader(&run_id)
         .await
         .unwrap()
@@ -11122,7 +11174,8 @@ async fn retry_failed_run_creates_and_queues_new_run() {
     ])
     .await;
     let source_events_before = state
-        .store
+        .stores
+        .runs
         .open_run(&source_run_id)
         .await
         .unwrap()
@@ -11150,7 +11203,7 @@ async fn retry_failed_run_creates_and_queues_new_run() {
     assert_eq!(body["created_by"]["login"], "dev");
     assert_eq!(run_json_status(&body)["kind"], "runnable");
 
-    let source_store = state.store.open_run(&source_run_id).await.unwrap();
+    let source_store = state.stores.runs.open_run(&source_run_id).await.unwrap();
     assert_eq!(
         source_store.list_events().await.unwrap().len(),
         source_events_before
@@ -11163,7 +11216,8 @@ async fn retry_failed_run_creates_and_queues_new_run() {
     );
 
     let new_state = state
-        .store
+        .stores
+        .runs
         .open_run(&new_run_id)
         .await
         .unwrap()
@@ -11214,7 +11268,8 @@ async fn retry_succeeded_run_creates_and_queues_new_run() {
     ])
     .await;
     let source_events_before = state
-        .store
+        .stores
+        .runs
         .open_run(&source_run_id)
         .await
         .unwrap()
@@ -11240,7 +11295,7 @@ async fn retry_succeeded_run_creates_and_queues_new_run() {
     assert_eq!(body["retried_from"], source_run_id.to_string());
     assert_eq!(run_json_status(&body)["kind"], "runnable");
 
-    let source_store = state.store.open_run(&source_run_id).await.unwrap();
+    let source_store = state.stores.runs.open_run(&source_run_id).await.unwrap();
     assert_eq!(
         source_store.list_events().await.unwrap().len(),
         source_events_before
@@ -11253,7 +11308,8 @@ async fn retry_succeeded_run_creates_and_queues_new_run() {
     );
 
     let new_state = state
-        .store
+        .stores
+        .runs
         .open_run(&new_run_id)
         .await
         .unwrap()
@@ -13621,7 +13677,8 @@ level = "debug"
             .expect("run_dir should be recorded")
     };
     let run_spec = state
-        .store
+        .stores
+        .runs
         .open_run_reader(&run_id)
         .await
         .unwrap()
@@ -13714,7 +13771,7 @@ async fn cancel_runnable_run_succeeds() {
         "cancelled run should preserve the failed lifecycle status"
     );
 
-    let run_store = state.store.open_run_reader(&run_id).await.unwrap();
+    let run_store = state.stores.runs.open_run_reader(&run_id).await.unwrap();
     let status = run_store.state().await.unwrap().status;
     assert_eq!(status, RunStatus::Failed {
         reason: FailureReason::Cancelled,
@@ -13747,7 +13804,14 @@ async fn cancel_run_overwrites_pending_pause_request() {
     let body = response_json!(response, StatusCode::OK).await;
     assert_eq!(run_json_pending_control(&body).as_str(), Some("cancel"));
 
-    let summary = state.store.runs().find(&run_id).await.unwrap().unwrap();
+    let summary = state
+        .stores
+        .runs
+        .runs()
+        .find(&run_id)
+        .await
+        .unwrap()
+        .unwrap();
     assert_eq!(
         summary.lifecycle.pending_control,
         Some(RunControlAction::Cancel)
@@ -13877,7 +13941,14 @@ async fn pause_run_rejects_when_control_is_already_pending() {
     let response = app.oneshot(req).await.unwrap();
     assert_status!(response, StatusCode::CONFLICT).await;
 
-    let summary = state.store.runs().find(&run_id).await.unwrap().unwrap();
+    let summary = state
+        .stores
+        .runs
+        .runs()
+        .find(&run_id)
+        .await
+        .unwrap()
+        .unwrap();
     assert_eq!(
         summary.lifecycle.pending_control,
         Some(RunControlAction::Cancel)
@@ -13999,7 +14070,14 @@ async fn pause_run_immediately_pauses_blocked_run() {
     );
     assert_eq!(run_json_pending_control(&body), &serde_json::Value::Null);
 
-    let summary = state.store.runs().find(&run_id).await.unwrap().unwrap();
+    let summary = state
+        .stores
+        .runs
+        .runs()
+        .find(&run_id)
+        .await
+        .unwrap()
+        .unwrap();
     assert_eq!(summary.lifecycle.status, RunStatus::Paused {
         prior_block: Some(BlockedReason::HumanInputRequired),
     });
@@ -14032,7 +14110,14 @@ async fn unpause_run_sets_pending_control() {
     assert_eq!(run_json_status(&body)["kind"], "runnable");
     assert_eq!(run_json_pending_control(&body).as_str(), Some("unpause"));
 
-    let summary = state.store.runs().find(&run_id).await.unwrap().unwrap();
+    let summary = state
+        .stores
+        .runs
+        .runs()
+        .find(&run_id)
+        .await
+        .unwrap()
+        .unwrap();
     assert_eq!(
         summary.lifecycle.pending_control,
         Some(RunControlAction::Unpause)
@@ -14110,7 +14195,14 @@ async fn unpause_run_returns_blocked_when_human_gate_is_still_unresolved() {
     );
     assert_eq!(run_json_pending_control(&body), &serde_json::Value::Null);
 
-    let summary = state.store.runs().find(&run_id).await.unwrap().unwrap();
+    let summary = state
+        .stores
+        .runs
+        .runs()
+        .find(&run_id)
+        .await
+        .unwrap()
+        .unwrap();
     assert_eq!(summary.lifecycle.status, RunStatus::Blocked {
         blocked_reason: BlockedReason::HumanInputRequired,
     });
@@ -14150,7 +14242,8 @@ async fn startup_reconciliation_marks_inflight_runs_terminal() {
     assert_eq!(reconciled, 2);
 
     let run_1 = state
-        .store
+        .stores
+        .runs
         .open_run_reader(&fixtures::RUN_1)
         .await
         .unwrap()
@@ -14160,7 +14253,8 @@ async fn startup_reconciliation_marks_inflight_runs_terminal() {
     assert_eq!(run_1.status, RunStatus::Submitted);
 
     let run_2 = state
-        .store
+        .stores
+        .runs
         .open_run_reader(&fixtures::RUN_2)
         .await
         .unwrap()
@@ -14173,7 +14267,8 @@ async fn startup_reconciliation_marks_inflight_runs_terminal() {
     });
 
     let run_3 = state
-        .store
+        .stores
+        .runs
         .open_run_reader(&fixtures::RUN_3)
         .await
         .unwrap()
@@ -14293,7 +14388,8 @@ async fn shutdown_active_workers_terminates_process_groups() {
     assert!(!fabro_proc::process_group_alive(worker_process_id));
 
     let run_state = state
-        .store
+        .stores
+        .runs
         .open_run_reader(&run_id)
         .await
         .unwrap()
@@ -14394,7 +14490,7 @@ id = "local"
     });
     drop(runs);
 
-    let run_store = state.store.open_run_reader(&run_id).await.unwrap();
+    let run_store = state.stores.runs.open_run_reader(&run_id).await.unwrap();
 
     let mut status_record = None;
     for _ in 0..50 {
@@ -15233,7 +15329,7 @@ async fn list_runs_includes_live_metadata_from_run_state() {
         .await
         .parse::<RunId>()
         .unwrap();
-    let run_store = state.store.open_run(&run_id).await.unwrap();
+    let run_store = state.stores.runs.open_run(&run_id).await.unwrap();
     for event in [
         workflow_event::Event::RunStarting,
         workflow_event::Event::RunRunning,
@@ -15318,7 +15414,7 @@ async fn list_runs_page_limit_preserves_metadata_for_paged_items() {
         .unwrap();
 
     for (run_id, sandbox_id) in [(first_run_id, "sb-first"), (second_run_id, "sb-second")] {
-        let run_store = state.store.open_run(&run_id).await.unwrap();
+        let run_store = state.stores.runs.open_run(&run_id).await.unwrap();
         for event in [
             workflow_event::Event::RunStarting,
             workflow_event::Event::RunRunning,

--- a/lib/crates/fabro-server/src/test_support.rs
+++ b/lib/crates/fabro-server/src/test_support.rs
@@ -518,9 +518,9 @@ fn test_db_pool(path: PathBuf) -> anyhow::Result<DbPool> {
             .enable_all()
             .build()?;
         runtime.block_on(async move {
-            let pool = fabro_db::connect(&path).await?;
-            fabro_db::migrate(&pool).await?;
-            Ok(pool)
+            let database = fabro_db::Database::connect(&path).await?;
+            database.migrate().await?;
+            Ok(database.clone_pool())
         })
     })
     .join()

--- a/lib/crates/fabro-server/src/test_support.rs
+++ b/lib/crates/fabro-server/src/test_support.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 #[cfg(test)]
 use std::sync::Mutex;
 use std::sync::{Arc, OnceLock};
@@ -14,6 +14,7 @@ use axum::response::Response;
 use axum::{Router, middleware};
 use chrono::Duration as ChronoDuration;
 use fabro_config::{RunLayer, ServerSettingsBuilder, envfile};
+use fabro_db::DbPool;
 use fabro_interview::Interviewer;
 use fabro_model::catalog::{LlmCatalogSettings, ProviderCatalogSettings};
 use fabro_sandbox::SandboxProviderRegistry;
@@ -24,6 +25,7 @@ use fabro_types::{AuthMethod, IdpIdentity, ServerSettings};
 use fabro_vault::{SecretType, Vault};
 use fabro_workflow::handler::HandlerRegistry;
 use object_store::memory::InMemory as MemoryObjectStore;
+use tokio::runtime::Builder as TokioRuntimeBuilder;
 use tokio_util::sync::CancellationToken;
 use ulid::Ulid;
 
@@ -194,7 +196,7 @@ impl TestAppStateBuilder {
         self
     }
 
-    fn vault_path(mut self, vault_path: PathBuf) -> Self {
+    pub fn vault_path(mut self, vault_path: PathBuf) -> Self {
         self.vault_path = Some(vault_path);
         self
     }
@@ -247,6 +249,7 @@ impl TestAppStateBuilder {
             .join("environments");
         fabro_environment::seed_environments(&environment_dir)
             .expect("test environments should seed");
+        let db_pool = test_db_pool_for_vault_path(&vault_path)?;
         build_app_state(AppStateConfig {
             resolved_settings: resolved_runtime_settings_for_tests(
                 self.server_settings,
@@ -257,7 +260,7 @@ impl TestAppStateBuilder {
             max_concurrent_runs: self.max_concurrent_runs,
             store,
             artifact_store,
-            variables_path: vault_path.with_file_name("variables.json"),
+            db_pool,
             vault_path,
             preloaded_vault: None,
             server_secrets: load_test_server_secrets(server_env_path, self.server_secret_env),
@@ -491,6 +494,37 @@ pub fn test_store_bundle() -> (Arc<Database>, ArtifactStore) {
     ));
     let artifact_store = ArtifactStore::new(object_store, "artifacts");
     (store, artifact_store)
+}
+
+pub(crate) fn test_db_pool_for_vault_path(vault_path: &Path) -> anyhow::Result<DbPool> {
+    test_db_pool(sqlite_path_for_vault_path(vault_path))
+}
+
+fn sqlite_path_for_vault_path(vault_path: &Path) -> PathBuf {
+    vault_path
+        .parent()
+        .unwrap_or_else(|| Path::new("."))
+        .join("db")
+        .join("fabro.sqlite3")
+}
+
+#[expect(
+    clippy::disallowed_methods,
+    reason = "sync test builders may be called inside async tests; a short-lived OS thread avoids nested Tokio runtimes"
+)]
+fn test_db_pool(path: PathBuf) -> anyhow::Result<DbPool> {
+    std::thread::spawn(move || {
+        let runtime = TokioRuntimeBuilder::new_current_thread()
+            .enable_all()
+            .build()?;
+        runtime.block_on(async move {
+            let pool = fabro_db::connect(&path).await?;
+            fabro_db::migrate(&pool).await?;
+            Ok(pool)
+        })
+    })
+    .join()
+    .expect("test database setup thread should not panic")
 }
 
 pub fn test_app_state_with_store_and_runtime_settings(

--- a/lib/crates/fabro-server/src/web_auth.rs
+++ b/lib/crates/fabro-server/src/web_auth.rs
@@ -1657,6 +1657,7 @@ client_id = "github-client-id"
             Some("web-auth-test-key-material-0123456789"),
         );
         state
+            .stores
             .vault
             .write()
             .await

--- a/lib/crates/fabro-server/tests/it/api/variables.rs
+++ b/lib/crates/fabro-server/tests/it/api/variables.rs
@@ -186,6 +186,39 @@ async fn variables_validate_names_and_allow_empty_values() {
 }
 
 #[tokio::test]
+async fn variables_persist_across_rebuilt_app_state() {
+    let vault_path = fabro_server::test_support::test_secret_store_path();
+    let state = fabro_server::test_support::TestAppStateBuilder::new()
+        .vault_path(vault_path.clone())
+        .build();
+    let app = fabro_server::test_support::build_test_router(state);
+
+    let create = app
+        .oneshot(json_request(
+            Method::POST,
+            "/variables",
+            &serde_json::json!({
+                "name": "PERSISTED",
+                "value": "from-sqlite"
+            }),
+        ))
+        .await
+        .expect("POST /variables should route");
+    response_status(create, StatusCode::OK, "POST /api/v1/variables").await;
+
+    let rebuilt_state = fabro_server::test_support::TestAppStateBuilder::new()
+        .vault_path(vault_path)
+        .build();
+    let rebuilt_app = fabro_server::test_support::build_test_router(rebuilt_state);
+    let get = rebuilt_app
+        .oneshot(empty_request(Method::GET, "/variables/PERSISTED"))
+        .await
+        .expect("GET /variables/PERSISTED should route");
+    let body = response_json(get, StatusCode::OK, "GET /api/v1/variables/PERSISTED").await;
+    assert_eq!(body["value"], "from-sqlite");
+}
+
+#[tokio::test]
 async fn run_config_substitutes_variables_before_persisting_settings() {
     let app = fabro_server::test_support::build_test_router(test_app_state());
 

--- a/lib/crates/fabro-variable/Cargo.toml
+++ b/lib/crates/fabro-variable/Cargo.toml
@@ -19,7 +19,6 @@ fabro-types = { path = "../fabro-types" }
 serde.workspace = true
 serde_json.workspace = true
 sqlx.workspace = true
-strum.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 tracing.workspace = true

--- a/lib/crates/fabro-variable/Cargo.toml
+++ b/lib/crates/fabro-variable/Cargo.toml
@@ -14,10 +14,16 @@ workspace = true
 
 [dependencies]
 chrono.workspace = true
+fabro-db = { path = "../fabro-db" }
 fabro-types = { path = "../fabro-types" }
 serde.workspace = true
 serde_json.workspace = true
-ulid.workspace = true
+sqlx.workspace = true
+strum.workspace = true
+thiserror.workspace = true
+tokio.workspace = true
+tracing.workspace = true
 
 [dev-dependencies]
+anyhow.workspace = true
 tempfile = "3"

--- a/lib/crates/fabro-variable/src/lib.rs
+++ b/lib/crates/fabro-variable/src/lib.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 
 use chrono::{DateTime, Utc};
@@ -7,9 +8,7 @@ use fabro_types::{Variable, is_env_style_name};
 use sqlx::Row as _;
 use sqlx::sqlite::SqliteRow;
 use tokio::fs;
-use tracing::{info, warn};
-
-const LEGACY_VARIABLE_IMPORT_NAME: &str = "variables-json-v1";
+use tracing::info;
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
@@ -39,6 +38,14 @@ pub enum Error {
     #[error("legacy variables file {path} contains invalid variable name: {name}")]
     LegacyInvalidName { path: PathBuf, name: String },
 
+    #[error("renaming legacy variables file {source_path} to backup {backup_path}")]
+    LegacyBackup {
+        source_path: PathBuf,
+        backup_path: PathBuf,
+        #[source]
+        source:      std::io::Error,
+    },
+
     #[error("parsing variable timestamp for {name}.{column}")]
     Timestamp {
         name:   String,
@@ -51,17 +58,10 @@ pub enum Error {
     RowCountOverflow { count: usize },
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, strum::Display, strum::IntoStaticStr)]
-#[strum(serialize_all = "snake_case")]
-pub enum ImportStatus {
-    Imported,
-    SkippedExistingTarget,
-}
-
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ImportReport {
-    pub status:         ImportStatus,
     pub source_path:    PathBuf,
+    pub backup_path:    PathBuf,
     pub imported_rows:  i64,
     pub skipped_rows:   i64,
     pub variable_names: Vec<String>,
@@ -228,10 +228,6 @@ pub async fn import_legacy_json_once(
     source_path: impl AsRef<Path>,
 ) -> Result<Option<ImportReport>, Error> {
     let source_path = source_path.as_ref();
-    if legacy_import_exists(pool).await? {
-        return Ok(None);
-    }
-
     let contents = match fs::read_to_string(source_path).await {
         Ok(contents) => contents,
         Err(source) if source.kind() == std::io::ErrorKind::NotFound => return Ok(None),
@@ -242,27 +238,6 @@ pub async fn import_legacy_json_once(
             });
         }
     };
-
-    let existing_names = variable_names(pool).await?;
-    if !existing_names.is_empty() {
-        let report = ImportReport {
-            status:         ImportStatus::SkippedExistingTarget,
-            source_path:    source_path.to_path_buf(),
-            imported_rows:  0,
-            skipped_rows:   row_count(existing_names.len())?,
-            variable_names: existing_names,
-        };
-        insert_import_marker(pool, &report).await?;
-        warn!(
-            import_name = LEGACY_VARIABLE_IMPORT_NAME,
-            source_path = %source_path.display(),
-            imported_rows = report.imported_rows,
-            skipped_rows = report.skipped_rows,
-            variable_names = ?report.variable_names,
-            "skipped legacy variables json import because sqlite already has variables"
-        );
-        return Ok(Some(report));
-    }
 
     let entries = parse_legacy_entries(source_path, &contents)?;
     let mut names = entries.keys().cloned().collect::<Vec<_>>();
@@ -278,10 +253,16 @@ pub async fn import_legacy_json_once(
     }
 
     let mut transaction = pool.begin().await?;
+    let mut imported_names = Vec::new();
+    let mut skipped_rows = 0usize;
     for name in &names {
         let entry = &entries[name];
-        sqlx::query(
-            "INSERT INTO variables (name, value, description, created_at, updated_at) VALUES (?, ?, ?, ?, ?)",
+        let result = sqlx::query(
+            r"
+            INSERT INTO variables (name, value, description, created_at, updated_at)
+            VALUES (?, ?, ?, ?, ?)
+            ON CONFLICT(name) DO NOTHING
+            ",
         )
         .bind(name)
         .bind(&entry.value)
@@ -290,21 +271,28 @@ pub async fn import_legacy_json_once(
         .bind(entry.updated_at.to_rfc3339())
         .execute(&mut *transaction)
         .await?;
+
+        if result.rows_affected() == 0 {
+            skipped_rows += 1;
+        } else {
+            imported_names.push(name.clone());
+        }
     }
 
-    let report = ImportReport {
-        status:         ImportStatus::Imported,
-        source_path:    source_path.to_path_buf(),
-        imported_rows:  row_count(names.len())?,
-        skipped_rows:   0,
-        variable_names: names,
-    };
-    insert_import_marker_in_transaction(&mut transaction, &report).await?;
     transaction.commit().await?;
+    let backup_path = rename_imported_legacy_file(source_path).await?;
+
+    let report = ImportReport {
+        source_path: source_path.to_path_buf(),
+        backup_path,
+        imported_rows: row_count(imported_names.len())?,
+        skipped_rows: row_count(skipped_rows)?,
+        variable_names: imported_names,
+    };
 
     info!(
-        import_name = LEGACY_VARIABLE_IMPORT_NAME,
         source_path = %source_path.display(),
+        backup_path = %report.backup_path.display(),
         imported_rows = report.imported_rows,
         skipped_rows = report.skipped_rows,
         variable_names = ?report.variable_names,
@@ -324,65 +312,25 @@ fn parse_legacy_entries(
     })
 }
 
-async fn legacy_import_exists(pool: &DbPool) -> Result<bool, Error> {
-    let exists: Option<i64> =
-        sqlx::query_scalar("SELECT 1 FROM legacy_imports WHERE import_name = ?")
-            .bind(LEGACY_VARIABLE_IMPORT_NAME)
-            .fetch_optional(pool)
-            .await?;
-    Ok(exists.is_some())
+async fn rename_imported_legacy_file(source_path: &Path) -> Result<PathBuf, Error> {
+    let backup_path = legacy_backup_path(source_path, Utc::now());
+    fs::rename(source_path, &backup_path)
+        .await
+        .map_err(|source| Error::LegacyBackup {
+            source_path: source_path.to_path_buf(),
+            backup_path: backup_path.clone(),
+            source,
+        })?;
+    Ok(backup_path)
 }
 
-async fn variable_names(pool: &DbPool) -> Result<Vec<String>, Error> {
-    let rows = sqlx::query("SELECT name FROM variables ORDER BY name")
-        .fetch_all(pool)
-        .await?;
-    Ok(rows.into_iter().map(|row| row.get("name")).collect())
-}
-
-async fn insert_import_marker(pool: &DbPool, report: &ImportReport) -> Result<(), Error> {
-    sqlx::query(
-        r"
-        INSERT INTO legacy_imports
-            (import_name, source_path, status, imported_rows, skipped_rows, imported_at)
-        VALUES (?, ?, ?, ?, ?, ?)
-        ",
-    )
-    .bind(LEGACY_VARIABLE_IMPORT_NAME)
-    .bind(report.source_path.display().to_string())
-    .bind(import_status_text(report.status))
-    .bind(report.imported_rows)
-    .bind(report.skipped_rows)
-    .bind(Utc::now().to_rfc3339())
-    .execute(pool)
-    .await?;
-    Ok(())
-}
-
-async fn insert_import_marker_in_transaction(
-    transaction: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
-    report: &ImportReport,
-) -> Result<(), Error> {
-    sqlx::query(
-        r"
-        INSERT INTO legacy_imports
-            (import_name, source_path, status, imported_rows, skipped_rows, imported_at)
-        VALUES (?, ?, ?, ?, ?, ?)
-        ",
-    )
-    .bind(LEGACY_VARIABLE_IMPORT_NAME)
-    .bind(report.source_path.display().to_string())
-    .bind(import_status_text(report.status))
-    .bind(report.imported_rows)
-    .bind(report.skipped_rows)
-    .bind(Utc::now().to_rfc3339())
-    .execute(&mut **transaction)
-    .await?;
-    Ok(())
-}
-
-fn import_status_text(status: ImportStatus) -> &'static str {
-    status.into()
+fn legacy_backup_path(source_path: &Path, imported_at: DateTime<Utc>) -> PathBuf {
+    let timestamp = imported_at.format("%Y%m%dT%H%M%S%fZ");
+    let mut file_name = source_path
+        .file_name()
+        .map_or_else(|| OsString::from("variables.json"), OsString::from);
+    file_name.push(format!(".imported-{timestamp}.bak"));
+    source_path.with_file_name(file_name)
 }
 
 fn row_count(count: usize) -> Result<i64, Error> {

--- a/lib/crates/fabro-variable/src/lib.rs
+++ b/lib/crates/fabro-variable/src/lib.rs
@@ -1,17 +1,74 @@
-#![expect(
-    clippy::disallowed_methods,
-    reason = "fabro-variable: sync JSON-file storage; not used on a Tokio hot path"
-)]
-
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
-use std::{fmt, io};
 
 use chrono::{DateTime, Utc};
+use fabro_db::DbPool;
 use fabro_types::{Variable, is_env_style_name};
+use sqlx::Row as _;
+use sqlx::sqlite::SqliteRow;
+use tokio::fs;
+use tracing::{info, warn};
+
+const LEGACY_VARIABLE_IMPORT_NAME: &str = "variables-json-v1";
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("invalid variable name: {0}")]
+    InvalidName(String),
+
+    #[error("variable not found: {0}")]
+    NotFound(String),
+
+    #[error("database error")]
+    Db(#[from] sqlx::Error),
+
+    #[error("reading legacy variables file {path}")]
+    LegacyRead {
+        path:   PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+
+    #[error("parsing legacy variables file {path}")]
+    LegacyParse {
+        path:   PathBuf,
+        #[source]
+        source: serde_json::Error,
+    },
+
+    #[error("legacy variables file {path} contains invalid variable name: {name}")]
+    LegacyInvalidName { path: PathBuf, name: String },
+
+    #[error("parsing variable timestamp for {name}.{column}")]
+    Timestamp {
+        name:   String,
+        column: &'static str,
+        #[source]
+        source: chrono::ParseError,
+    },
+
+    #[error("variable row count {count} exceeds SQLite integer range")]
+    RowCountOverflow { count: usize },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, strum::Display, strum::IntoStaticStr)]
+#[strum(serialize_all = "snake_case")]
+pub enum ImportStatus {
+    Imported,
+    SkippedExistingTarget,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ImportReport {
+    pub status:         ImportStatus,
+    pub source_path:    PathBuf,
+    pub imported_rows:  i64,
+    pub skipped_rows:   i64,
+    pub variable_names: Vec<String>,
+}
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-struct VariableEntry {
+struct LegacyVariableEntry {
     value:       String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     description: Option<String>,
@@ -19,84 +76,36 @@ struct VariableEntry {
     updated_at:  DateTime<Utc>,
 }
 
-#[derive(Debug)]
-pub enum Error {
-    InvalidName(String),
-    NotFound(String),
-    Io(std::io::Error),
-    Serde(serde_json::Error),
-}
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::InvalidName(name) => write!(f, "invalid variable name: {name}"),
-            Self::NotFound(name) => write!(f, "variable not found: {name}"),
-            Self::Io(err) => write!(f, "{err}"),
-            Self::Serde(err) => write!(f, "{err}"),
-        }
-    }
-}
-
-impl std::error::Error for Error {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match self {
-            Self::Io(err) => Some(err),
-            Self::Serde(err) => Some(err),
-            Self::InvalidName(_) | Self::NotFound(_) => None,
-        }
-    }
-}
-
-impl From<std::io::Error> for Error {
-    fn from(value: std::io::Error) -> Self {
-        Self::Io(value)
-    }
-}
-
-impl From<serde_json::Error> for Error {
-    fn from(value: serde_json::Error) -> Self {
-        Self::Serde(value)
-    }
-}
-
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct VariableStore {
-    path:    PathBuf,
-    entries: HashMap<String, VariableEntry>,
+    pool: DbPool,
 }
 
 impl VariableStore {
-    pub fn load(path: PathBuf) -> Result<Self, Error> {
-        let entries = match std::fs::read_to_string(&path) {
-            Ok(contents) => serde_json::from_str(&contents)?,
-            Err(err) if err.kind() == std::io::ErrorKind::NotFound => HashMap::new(),
-            Err(err) => return Err(io_context("read variables", &path, &err).into()),
-        };
-
-        Ok(Self { path, entries })
+    pub fn new(pool: DbPool) -> Self {
+        Self { pool }
     }
 
-    pub fn set(
-        &mut self,
+    pub async fn set(
+        &self,
         name: &str,
         value: &str,
         description: Option<&str>,
     ) -> Result<Variable, Error> {
-        self.set_with_policy(name, value, description, false)
+        self.set_with_policy(name, value, description, false).await
     }
 
-    pub fn update_existing(
-        &mut self,
+    pub async fn update_existing(
+        &self,
         name: &str,
         value: &str,
         description: Option<&str>,
     ) -> Result<Variable, Error> {
-        self.set_with_policy(name, value, description, true)
+        self.set_with_policy(name, value, description, true).await
     }
 
-    fn set_with_policy(
-        &mut self,
+    async fn set_with_policy(
+        &self,
         name: &str,
         value: &str,
         description: Option<&str>,
@@ -104,30 +113,48 @@ impl VariableStore {
     ) -> Result<Variable, Error> {
         Self::validate_name(name)?;
 
-        let now = Utc::now();
-        let existing = self.entries.get(name);
+        let existing = sqlx::query("SELECT description, created_at FROM variables WHERE name = ?")
+            .bind(name)
+            .fetch_optional(&self.pool)
+            .await?;
+
         if require_existing && existing.is_none() {
             return Err(Error::NotFound(name.to_string()));
         }
-        let (created_at, description) = existing.map_or_else(
-            || (now, description.map(str::to_string)),
-            |entry| {
+
+        let now = Utc::now();
+        let (created_at, description) = match existing {
+            Some(row) => {
+                let created_at_text = row.get::<String, _>("created_at");
+                let created_at = parse_timestamp(name, "created_at", &created_at_text)?;
+                let existing_description: Option<String> = row.get("description");
                 (
-                    entry.created_at,
-                    description
-                        .map(str::to_string)
-                        .or_else(|| entry.description.clone()),
+                    created_at,
+                    description.map(str::to_string).or(existing_description),
                 )
-            },
-        );
-        let entry = VariableEntry {
-            value: value.to_string(),
-            description: description.clone(),
-            created_at,
-            updated_at: now,
+            }
+            None => (now, description.map(str::to_string)),
         };
-        self.entries.insert(name.to_string(), entry);
-        self.write_atomic()?;
+        let created_at_text = created_at.to_rfc3339();
+        let updated_at_text = now.to_rfc3339();
+
+        sqlx::query(
+            r"
+            INSERT INTO variables (name, value, description, created_at, updated_at)
+            VALUES (?, ?, ?, ?, ?)
+            ON CONFLICT(name) DO UPDATE SET
+                value = excluded.value,
+                description = excluded.description,
+                updated_at = excluded.updated_at
+            ",
+        )
+        .bind(name)
+        .bind(value)
+        .bind(description.as_deref())
+        .bind(created_at_text)
+        .bind(updated_at_text)
+        .execute(&self.pool)
+        .await?;
 
         Ok(Variable {
             name: name.to_string(),
@@ -138,43 +165,52 @@ impl VariableStore {
         })
     }
 
-    pub fn get(&self, name: &str) -> Option<Variable> {
-        self.entries
-            .get(name)
-            .map(|entry| variable_from_entry(name, entry))
+    pub async fn get(&self, name: &str) -> Result<Option<Variable>, Error> {
+        let row = sqlx::query(
+            "SELECT name, value, description, created_at, updated_at FROM variables WHERE name = ?",
+        )
+        .bind(name)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        row.as_ref().map(variable_from_row).transpose()
     }
 
-    pub fn get_value(&self, name: &str) -> Option<&str> {
-        self.entries.get(name).map(|entry| entry.value.as_str())
-    }
+    pub async fn list(&self) -> Result<Vec<Variable>, Error> {
+        let rows = sqlx::query(
+            "SELECT name, value, description, created_at, updated_at FROM variables ORDER BY name",
+        )
+        .fetch_all(&self.pool)
+        .await?;
 
-    pub fn list(&self) -> Vec<Variable> {
-        let mut data = self
-            .entries
-            .iter()
-            .map(|(name, entry)| variable_from_entry(name, entry))
-            .collect::<Vec<_>>();
-        data.sort_by(|a, b| a.name.cmp(&b.name));
-        data
+        rows.iter().map(variable_from_row).collect()
     }
 
     /// Snapshot every variable as a `name -> value` map, dropping descriptions
     /// and timestamps. Used to seed the template render context (`{{ vars.*
     /// }}`) at run creation.
-    #[must_use]
-    pub fn value_map(&self) -> HashMap<String, String> {
-        self.entries
-            .iter()
-            .map(|(name, entry)| (name.clone(), entry.value.clone()))
-            .collect()
+    pub async fn value_map(&self) -> Result<HashMap<String, String>, Error> {
+        let rows = sqlx::query("SELECT name, value FROM variables")
+            .fetch_all(&self.pool)
+            .await?;
+
+        Ok(rows
+            .into_iter()
+            .map(|row| (row.get("name"), row.get("value")))
+            .collect())
     }
 
-    pub fn remove(&mut self, name: &str) -> Result<(), Error> {
+    pub async fn remove(&self, name: &str) -> Result<(), Error> {
         Self::validate_name(name)?;
-        if self.entries.remove(name).is_none() {
+        let result = sqlx::query("DELETE FROM variables WHERE name = ?")
+            .bind(name)
+            .execute(&self.pool)
+            .await?;
+
+        if result.rows_affected() == 0 {
             return Err(Error::NotFound(name.to_string()));
         }
-        self.write_atomic()?;
+
         Ok(())
     }
 
@@ -185,45 +221,196 @@ impl VariableStore {
             Err(Error::InvalidName(name.to_string()))
         }
     }
-
-    fn write_atomic(&self) -> Result<(), Error> {
-        let parent = self
-            .path
-            .parent()
-            .map_or_else(|| PathBuf::from("."), Path::to_path_buf);
-        std::fs::create_dir_all(&parent)
-            .map_err(|err| io_context("create variables directory", &parent, &err))?;
-
-        let file_name = self
-            .path
-            .file_name()
-            .and_then(|name| name.to_str())
-            .unwrap_or("variables.json");
-        let tmp_path = parent.join(format!(".{file_name}.tmp-{}", ulid::Ulid::new()));
-        let json = serde_json::to_vec_pretty(&self.entries)?;
-        std::fs::write(&tmp_path, json)
-            .map_err(|err| io_context("write variables temp file", &tmp_path, &err))?;
-        std::fs::rename(&tmp_path, &self.path).map_err(|err| {
-            io_context(
-                &format!("rename variables temp file to {}", self.path.display()),
-                &tmp_path,
-                &err,
-            )
-        })?;
-        Ok(())
-    }
 }
 
-fn variable_from_entry(name: &str, entry: &VariableEntry) -> Variable {
-    Variable {
-        name:        name.to_string(),
-        value:       entry.value.clone(),
-        description: entry.description.clone(),
-        created_at:  entry.created_at,
-        updated_at:  entry.updated_at,
+pub async fn import_legacy_json_once(
+    pool: &DbPool,
+    source_path: impl AsRef<Path>,
+) -> Result<Option<ImportReport>, Error> {
+    let source_path = source_path.as_ref();
+    if legacy_import_exists(pool).await? {
+        return Ok(None);
     }
+
+    let contents = match fs::read_to_string(source_path).await {
+        Ok(contents) => contents,
+        Err(source) if source.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(source) => {
+            return Err(Error::LegacyRead {
+                path: source_path.to_path_buf(),
+                source,
+            });
+        }
+    };
+
+    let existing_names = variable_names(pool).await?;
+    if !existing_names.is_empty() {
+        let report = ImportReport {
+            status:         ImportStatus::SkippedExistingTarget,
+            source_path:    source_path.to_path_buf(),
+            imported_rows:  0,
+            skipped_rows:   row_count(existing_names.len())?,
+            variable_names: existing_names,
+        };
+        insert_import_marker(pool, &report).await?;
+        warn!(
+            import_name = LEGACY_VARIABLE_IMPORT_NAME,
+            source_path = %source_path.display(),
+            imported_rows = report.imported_rows,
+            skipped_rows = report.skipped_rows,
+            variable_names = ?report.variable_names,
+            "skipped legacy variables json import because sqlite already has variables"
+        );
+        return Ok(Some(report));
+    }
+
+    let entries = parse_legacy_entries(source_path, &contents)?;
+    let mut names = entries.keys().cloned().collect::<Vec<_>>();
+    names.sort();
+
+    for name in &names {
+        if !is_env_style_name(name) {
+            return Err(Error::LegacyInvalidName {
+                path: source_path.to_path_buf(),
+                name: name.clone(),
+            });
+        }
+    }
+
+    let mut transaction = pool.begin().await?;
+    for name in &names {
+        let entry = &entries[name];
+        sqlx::query(
+            "INSERT INTO variables (name, value, description, created_at, updated_at) VALUES (?, ?, ?, ?, ?)",
+        )
+        .bind(name)
+        .bind(&entry.value)
+        .bind(entry.description.as_deref())
+        .bind(entry.created_at.to_rfc3339())
+        .bind(entry.updated_at.to_rfc3339())
+        .execute(&mut *transaction)
+        .await?;
+    }
+
+    let report = ImportReport {
+        status:         ImportStatus::Imported,
+        source_path:    source_path.to_path_buf(),
+        imported_rows:  row_count(names.len())?,
+        skipped_rows:   0,
+        variable_names: names,
+    };
+    insert_import_marker_in_transaction(&mut transaction, &report).await?;
+    transaction.commit().await?;
+
+    info!(
+        import_name = LEGACY_VARIABLE_IMPORT_NAME,
+        source_path = %source_path.display(),
+        imported_rows = report.imported_rows,
+        skipped_rows = report.skipped_rows,
+        variable_names = ?report.variable_names,
+        "imported legacy variables json into sqlite"
+    );
+
+    Ok(Some(report))
 }
 
-fn io_context(op: &str, path: &Path, source: &io::Error) -> io::Error {
-    io::Error::new(source.kind(), format!("{op} {}: {source}", path.display()))
+fn parse_legacy_entries(
+    path: &Path,
+    contents: &str,
+) -> Result<HashMap<String, LegacyVariableEntry>, Error> {
+    serde_json::from_str(contents).map_err(|source| Error::LegacyParse {
+        path: path.to_path_buf(),
+        source,
+    })
+}
+
+async fn legacy_import_exists(pool: &DbPool) -> Result<bool, Error> {
+    let exists: Option<i64> =
+        sqlx::query_scalar("SELECT 1 FROM legacy_imports WHERE import_name = ?")
+            .bind(LEGACY_VARIABLE_IMPORT_NAME)
+            .fetch_optional(pool)
+            .await?;
+    Ok(exists.is_some())
+}
+
+async fn variable_names(pool: &DbPool) -> Result<Vec<String>, Error> {
+    let rows = sqlx::query("SELECT name FROM variables ORDER BY name")
+        .fetch_all(pool)
+        .await?;
+    Ok(rows.into_iter().map(|row| row.get("name")).collect())
+}
+
+async fn insert_import_marker(pool: &DbPool, report: &ImportReport) -> Result<(), Error> {
+    sqlx::query(
+        r"
+        INSERT INTO legacy_imports
+            (import_name, source_path, status, imported_rows, skipped_rows, imported_at)
+        VALUES (?, ?, ?, ?, ?, ?)
+        ",
+    )
+    .bind(LEGACY_VARIABLE_IMPORT_NAME)
+    .bind(report.source_path.display().to_string())
+    .bind(import_status_text(report.status))
+    .bind(report.imported_rows)
+    .bind(report.skipped_rows)
+    .bind(Utc::now().to_rfc3339())
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+async fn insert_import_marker_in_transaction(
+    transaction: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+    report: &ImportReport,
+) -> Result<(), Error> {
+    sqlx::query(
+        r"
+        INSERT INTO legacy_imports
+            (import_name, source_path, status, imported_rows, skipped_rows, imported_at)
+        VALUES (?, ?, ?, ?, ?, ?)
+        ",
+    )
+    .bind(LEGACY_VARIABLE_IMPORT_NAME)
+    .bind(report.source_path.display().to_string())
+    .bind(import_status_text(report.status))
+    .bind(report.imported_rows)
+    .bind(report.skipped_rows)
+    .bind(Utc::now().to_rfc3339())
+    .execute(&mut **transaction)
+    .await?;
+    Ok(())
+}
+
+fn import_status_text(status: ImportStatus) -> &'static str {
+    status.into()
+}
+
+fn row_count(count: usize) -> Result<i64, Error> {
+    i64::try_from(count).map_err(|_| Error::RowCountOverflow { count })
+}
+
+fn variable_from_row(row: &SqliteRow) -> Result<Variable, Error> {
+    let name = row.get::<String, _>("name");
+    let created_at_text = row.get::<String, _>("created_at");
+    let updated_at_text = row.get::<String, _>("updated_at");
+    let created_at = parse_timestamp(&name, "created_at", &created_at_text)?;
+    let updated_at = parse_timestamp(&name, "updated_at", &updated_at_text)?;
+
+    Ok(Variable {
+        name,
+        value: row.get("value"),
+        description: row.get("description"),
+        created_at,
+        updated_at,
+    })
+}
+
+fn parse_timestamp(name: &str, column: &'static str, value: &str) -> Result<DateTime<Utc>, Error> {
+    DateTime::parse_from_rfc3339(value)
+        .map(|timestamp| timestamp.with_timezone(&Utc))
+        .map_err(|source| Error::Timestamp {
+            name: name.to_string(),
+            column,
+            source,
+        })
 }

--- a/lib/crates/fabro-variable/tests/store.rs
+++ b/lib/crates/fabro-variable/tests/store.rs
@@ -1,111 +1,356 @@
-use fabro_variable::{Error, VariableStore};
+use fabro_variable::{Error, ImportStatus, VariableStore, import_legacy_json_once};
+use tokio::fs;
 
-#[test]
-fn load_missing_file_returns_empty_store() {
-    let dir = tempfile::tempdir().unwrap();
-    let store = VariableStore::load(dir.path().join("variables.json")).unwrap();
-
-    assert!(store.list().is_empty());
+struct TestStore {
+    dir:   tempfile::TempDir,
+    pool:  fabro_db::DbPool,
+    store: VariableStore,
 }
 
-#[test]
-fn set_get_list_and_reload_variables() {
-    let dir = tempfile::tempdir().unwrap();
-    let path = dir.path().join("variables.json");
-    let mut store = VariableStore::load(path.clone()).unwrap();
+async fn test_store() -> anyhow::Result<TestStore> {
+    let dir = tempfile::tempdir()?;
+    let pool = fabro_db::connect(dir.path().join("fabro.sqlite3")).await?;
+    fabro_db::migrate(&pool).await?;
+    let store = VariableStore::new(pool.clone());
+    Ok(TestStore { dir, pool, store })
+}
 
-    let first = store.set("ZETA", "last", Some("Last variable")).unwrap();
-    let second = store.set("ALPHA", "", None).unwrap();
+#[tokio::test]
+async fn new_store_lists_empty_database() -> anyhow::Result<()> {
+    let test = test_store().await?;
+
+    assert!(test.store.list().await?.is_empty());
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn set_get_list_and_reopen_variables() -> anyhow::Result<()> {
+    let test = test_store().await?;
+
+    let first = test
+        .store
+        .set("ZETA", "last", Some("Last variable"))
+        .await?;
+    let second = test.store.set("ALPHA", "", None).await?;
 
     assert_eq!(first.name, "ZETA");
     assert_eq!(first.value, "last");
     assert_eq!(first.description.as_deref(), Some("Last variable"));
     assert_eq!(second.value, "");
-    assert_eq!(store.get("ZETA").unwrap().value, "last");
+    assert_eq!(test.store.get("ZETA").await?.unwrap().value, "last");
     assert_eq!(
-        store
+        test.store
             .list()
+            .await?
             .into_iter()
             .map(|variable| variable.name)
             .collect::<Vec<_>>(),
         vec!["ALPHA", "ZETA"]
     );
 
-    let reloaded = VariableStore::load(path).unwrap();
-    assert_eq!(reloaded.get("ALPHA").unwrap().value, "");
+    let reopened = VariableStore::new(test.pool.clone());
+    assert_eq!(reopened.get("ALPHA").await?.unwrap().value, "");
     assert_eq!(
-        reloaded.get("ZETA").unwrap().description.as_deref(),
+        reopened.get("ZETA").await?.unwrap().description.as_deref(),
         Some("Last variable")
     );
+
+    Ok(())
 }
 
-#[test]
-fn upsert_preserves_description_when_omitted_and_updates_when_present() {
-    let dir = tempfile::tempdir().unwrap();
-    let mut store = VariableStore::load(dir.path().join("variables.json")).unwrap();
+#[tokio::test]
+async fn upsert_preserves_description_when_omitted_and_updates_when_present() -> anyhow::Result<()>
+{
+    let test = test_store().await?;
 
-    let created = store
+    let created = test
+        .store
         .set("DEPLOY_ENV", "staging", Some("Deployment target"))
-        .unwrap();
-    let preserved = store.set("DEPLOY_ENV", "production", None).unwrap();
-    let updated = store
+        .await?;
+    let preserved = test.store.set("DEPLOY_ENV", "production", None).await?;
+    let updated = test
+        .store
         .set("DEPLOY_ENV", "preview", Some("Preview target"))
-        .unwrap();
+        .await?;
 
     assert_eq!(preserved.created_at, created.created_at);
     assert_eq!(preserved.description.as_deref(), Some("Deployment target"));
     assert_eq!(updated.description.as_deref(), Some("Preview target"));
     assert!(updated.updated_at >= preserved.updated_at);
+
+    Ok(())
 }
 
-#[test]
-fn update_existing_preserves_description_and_reports_missing() {
-    let dir = tempfile::tempdir().unwrap();
-    let mut store = VariableStore::load(dir.path().join("variables.json")).unwrap();
+#[tokio::test]
+async fn update_existing_preserves_description_and_reports_missing() -> anyhow::Result<()> {
+    let test = test_store().await?;
 
-    let created = store
+    let created = test
+        .store
         .set("DEPLOY_ENV", "staging", Some("Deployment target"))
-        .unwrap();
-    let updated = store
+        .await?;
+    let updated = test
+        .store
         .update_existing("DEPLOY_ENV", "production", None)
-        .unwrap();
+        .await?;
 
     assert_eq!(updated.created_at, created.created_at);
     assert_eq!(updated.value, "production");
     assert_eq!(updated.description.as_deref(), Some("Deployment target"));
     assert!(matches!(
-        store.update_existing("MISSING", "value", None),
+        test.store.update_existing("MISSING", "value", None).await,
         Err(Error::NotFound(name)) if name == "MISSING"
     ));
+
+    Ok(())
 }
 
-#[test]
-fn remove_deletes_variable_and_reports_missing() {
-    let dir = tempfile::tempdir().unwrap();
-    let mut store = VariableStore::load(dir.path().join("variables.json")).unwrap();
-    store.set("DEPLOY_ENV", "staging", None).unwrap();
+#[tokio::test]
+async fn remove_deletes_variable_and_reports_missing() -> anyhow::Result<()> {
+    let test = test_store().await?;
+    test.store.set("DEPLOY_ENV", "staging", None).await?;
 
-    store.remove("DEPLOY_ENV").unwrap();
+    test.store.remove("DEPLOY_ENV").await?;
 
-    assert!(store.get("DEPLOY_ENV").is_none());
+    assert!(test.store.get("DEPLOY_ENV").await?.is_none());
     assert!(matches!(
-        store.remove("DEPLOY_ENV"),
+        test.store.remove("DEPLOY_ENV").await,
         Err(Error::NotFound(name)) if name == "DEPLOY_ENV"
     ));
+
+    Ok(())
 }
 
-#[test]
-fn env_style_names_are_required() {
-    let dir = tempfile::tempdir().unwrap();
-    let mut store = VariableStore::load(dir.path().join("variables.json")).unwrap();
+#[tokio::test]
+async fn env_style_names_are_required() -> anyhow::Result<()> {
+    let test = test_store().await?;
 
     for invalid in ["", "1BAD", "bad-name", "BAD.NAME"] {
         assert!(matches!(
-            store.set(invalid, "value", None),
+            test.store.set(invalid, "value", None).await,
             Err(Error::InvalidName(name)) if name == invalid
         ));
     }
 
-    store.set("_OK", "value", None).unwrap();
-    store.set("OK_123", "value", None).unwrap();
+    test.store.set("_OK", "value", None).await?;
+    test.store.set("OK_123", "value", None).await?;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn value_map_snapshots_values_only() -> anyhow::Result<()> {
+    let test = test_store().await?;
+    test.store
+        .set("DEPLOY_ENV", "staging", Some("Deployment target"))
+        .await?;
+
+    let values = test.store.value_map().await?;
+
+    assert_eq!(
+        values.get("DEPLOY_ENV").map(String::as_str),
+        Some("staging")
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn import_missing_legacy_file_is_noop_without_marker() -> anyhow::Result<()> {
+    let test = test_store().await?;
+    let source = test.dir.path().join("variables.json");
+
+    let report = import_legacy_json_once(&test.pool, &source).await?;
+
+    assert!(report.is_none());
+    assert!(test.store.list().await?.is_empty());
+    assert_eq!(legacy_import_count(&test.pool).await?, 0);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn import_valid_legacy_json_imports_rows_and_marker() -> anyhow::Result<()> {
+    let test = test_store().await?;
+    let source = test.dir.path().join("variables.json");
+    fs::write(
+        &source,
+        r#"{
+  "ALPHA": {
+    "value": "first",
+    "description": "Alpha variable",
+    "created_at": "2026-06-30T10:00:00Z",
+    "updated_at": "2026-06-30T10:01:00Z"
+  },
+  "EMPTY": {
+    "value": "",
+    "created_at": "2026-06-30T10:02:00Z",
+    "updated_at": "2026-06-30T10:03:00Z"
+  }
+}"#,
+    )
+    .await?;
+
+    let report = import_legacy_json_once(&test.pool, &source)
+        .await?
+        .expect("existing legacy file should report import");
+
+    assert_eq!(report.status, ImportStatus::Imported);
+    assert_eq!(report.imported_rows, 2);
+    assert_eq!(report.skipped_rows, 0);
+    assert_eq!(report.variable_names, vec!["ALPHA", "EMPTY"]);
+    assert_eq!(test.store.get("ALPHA").await?.unwrap().value, "first");
+    assert_eq!(
+        test.store
+            .get("ALPHA")
+            .await?
+            .unwrap()
+            .description
+            .as_deref(),
+        Some("Alpha variable")
+    );
+    assert_eq!(test.store.get("EMPTY").await?.unwrap().value, "");
+    assert_eq!(
+        legacy_import_status(&test.pool).await?,
+        Some("imported".to_string())
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn import_empty_legacy_json_records_zero_row_marker() -> anyhow::Result<()> {
+    let test = test_store().await?;
+    let source = test.dir.path().join("variables.json");
+    fs::write(&source, "{}").await?;
+
+    let report = import_legacy_json_once(&test.pool, &source)
+        .await?
+        .expect("existing empty legacy file should report import");
+
+    assert_eq!(report.status, ImportStatus::Imported);
+    assert_eq!(report.imported_rows, 0);
+    assert_eq!(report.skipped_rows, 0);
+    assert!(report.variable_names.is_empty());
+    assert_eq!(
+        legacy_import_status(&test.pool).await?,
+        Some("imported".to_string())
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn import_second_run_is_noop_after_marker() -> anyhow::Result<()> {
+    let test = test_store().await?;
+    let source = test.dir.path().join("variables.json");
+    fs::write(
+        &source,
+        r#"{
+  "ALPHA": {
+    "value": "first",
+    "created_at": "2026-06-30T10:00:00Z",
+    "updated_at": "2026-06-30T10:01:00Z"
+  }
+}"#,
+    )
+    .await?;
+
+    let first = import_legacy_json_once(&test.pool, &source).await?;
+    let second = import_legacy_json_once(&test.pool, &source).await?;
+
+    assert!(first.is_some());
+    assert!(second.is_none());
+    assert_eq!(test.store.list().await?.len(), 1);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn import_skips_legacy_file_when_sqlite_already_has_rows() -> anyhow::Result<()> {
+    let test = test_store().await?;
+    test.store.set("CURRENT", "sqlite wins", None).await?;
+    let source = test.dir.path().join("variables.json");
+    fs::write(
+        &source,
+        r#"{
+  "LEGACY": {
+    "value": "file loses",
+    "created_at": "2026-06-30T10:00:00Z",
+    "updated_at": "2026-06-30T10:01:00Z"
+  }
+}"#,
+    )
+    .await?;
+
+    let report = import_legacy_json_once(&test.pool, &source)
+        .await?
+        .expect("existing SQLite rows should report skipped import");
+
+    assert_eq!(report.status, ImportStatus::SkippedExistingTarget);
+    assert_eq!(report.imported_rows, 0);
+    assert_eq!(report.skipped_rows, 1);
+    assert_eq!(report.variable_names, vec!["CURRENT"]);
+    assert!(test.store.get("LEGACY").await?.is_none());
+    assert_eq!(
+        legacy_import_status(&test.pool).await?,
+        Some("skipped_existing_target".to_string())
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn import_invalid_json_or_name_fails_when_sqlite_is_empty() -> anyhow::Result<()> {
+    let invalid_json = test_store().await?;
+    let invalid_json_source = invalid_json.dir.path().join("variables.json");
+    fs::write(&invalid_json_source, "not json").await?;
+
+    let error = import_legacy_json_once(&invalid_json.pool, &invalid_json_source)
+        .await
+        .expect_err("invalid JSON should fail import");
+    assert!(
+        error
+            .to_string()
+            .contains(&invalid_json_source.display().to_string())
+    );
+
+    let invalid_name = test_store().await?;
+    let invalid_name_source = invalid_name.dir.path().join("variables.json");
+    fs::write(
+        &invalid_name_source,
+        r#"{
+  "BAD-NAME": {
+    "value": "secret-ish value must not be in errors",
+    "created_at": "2026-06-30T10:00:00Z",
+    "updated_at": "2026-06-30T10:01:00Z"
+  }
+}"#,
+    )
+    .await?;
+
+    let error = import_legacy_json_once(&invalid_name.pool, &invalid_name_source)
+        .await
+        .expect_err("invalid name should fail import");
+    let message = error.to_string();
+    assert!(message.contains(&invalid_name_source.display().to_string()));
+    assert!(message.contains("BAD-NAME"));
+    assert!(!message.contains("secret-ish value"));
+
+    Ok(())
+}
+
+async fn legacy_import_count(pool: &fabro_db::DbPool) -> anyhow::Result<i64> {
+    Ok(sqlx::query_scalar("SELECT COUNT(*) FROM legacy_imports")
+        .fetch_one(pool)
+        .await?)
+}
+
+async fn legacy_import_status(pool: &fabro_db::DbPool) -> anyhow::Result<Option<String>> {
+    Ok(sqlx::query_scalar(
+        "SELECT status FROM legacy_imports WHERE import_name = 'variables-json-v1'",
+    )
+    .fetch_optional(pool)
+    .await?)
 }

--- a/lib/crates/fabro-variable/tests/store.rs
+++ b/lib/crates/fabro-variable/tests/store.rs
@@ -1,4 +1,6 @@
-use fabro_variable::{Error, ImportStatus, VariableStore, import_legacy_json_once};
+use std::path::{Path, PathBuf};
+
+use fabro_variable::{Error, VariableStore, import_legacy_json_once};
 use tokio::fs;
 
 struct TestStore {
@@ -158,7 +160,7 @@ async fn value_map_snapshots_values_only() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
-async fn import_missing_legacy_file_is_noop_without_marker() -> anyhow::Result<()> {
+async fn import_missing_legacy_file_is_noop() -> anyhow::Result<()> {
     let test = test_store().await?;
     let source = test.dir.path().join("variables.json");
 
@@ -166,18 +168,15 @@ async fn import_missing_legacy_file_is_noop_without_marker() -> anyhow::Result<(
 
     assert!(report.is_none());
     assert!(test.store.list().await?.is_empty());
-    assert_eq!(legacy_import_count(&test.pool).await?, 0);
 
     Ok(())
 }
 
 #[tokio::test]
-async fn import_valid_legacy_json_imports_rows_and_marker() -> anyhow::Result<()> {
+async fn import_valid_legacy_json_imports_rows_and_renames_source() -> anyhow::Result<()> {
     let test = test_store().await?;
     let source = test.dir.path().join("variables.json");
-    fs::write(
-        &source,
-        r#"{
+    let source_contents = r#"{
   "ALPHA": {
     "value": "first",
     "description": "Alpha variable",
@@ -189,15 +188,13 @@ async fn import_valid_legacy_json_imports_rows_and_marker() -> anyhow::Result<()
     "created_at": "2026-06-30T10:02:00Z",
     "updated_at": "2026-06-30T10:03:00Z"
   }
-}"#,
-    )
-    .await?;
+}"#;
+    fs::write(&source, source_contents).await?;
 
     let report = import_legacy_json_once(&test.pool, &source)
         .await?
         .expect("existing legacy file should report import");
 
-    assert_eq!(report.status, ImportStatus::Imported);
     assert_eq!(report.imported_rows, 2);
     assert_eq!(report.skipped_rows, 0);
     assert_eq!(report.variable_names, vec!["ALPHA", "EMPTY"]);
@@ -212,16 +209,20 @@ async fn import_valid_legacy_json_imports_rows_and_marker() -> anyhow::Result<()
         Some("Alpha variable")
     );
     assert_eq!(test.store.get("EMPTY").await?.unwrap().value, "");
+    assert!(!source.exists());
     assert_eq!(
-        legacy_import_status(&test.pool).await?,
-        Some("imported".to_string())
+        fs::read_to_string(&report.backup_path).await?,
+        source_contents
     );
+    assert_eq!(legacy_backups(test.dir.path()).await?, vec![
+        report.backup_path
+    ]);
 
     Ok(())
 }
 
 #[tokio::test]
-async fn import_empty_legacy_json_records_zero_row_marker() -> anyhow::Result<()> {
+async fn import_empty_legacy_json_still_renames_source() -> anyhow::Result<()> {
     let test = test_store().await?;
     let source = test.dir.path().join("variables.json");
     fs::write(&source, "{}").await?;
@@ -230,20 +231,17 @@ async fn import_empty_legacy_json_records_zero_row_marker() -> anyhow::Result<()
         .await?
         .expect("existing empty legacy file should report import");
 
-    assert_eq!(report.status, ImportStatus::Imported);
     assert_eq!(report.imported_rows, 0);
     assert_eq!(report.skipped_rows, 0);
     assert!(report.variable_names.is_empty());
-    assert_eq!(
-        legacy_import_status(&test.pool).await?,
-        Some("imported".to_string())
-    );
+    assert!(!source.exists());
+    assert_eq!(fs::read_to_string(&report.backup_path).await?, "{}");
 
     Ok(())
 }
 
 #[tokio::test]
-async fn import_second_run_is_noop_after_marker() -> anyhow::Result<()> {
+async fn import_second_run_is_noop_after_source_was_renamed() -> anyhow::Result<()> {
     let test = test_store().await?;
     let source = test.dir.path().join("variables.json");
     fs::write(
@@ -264,20 +262,27 @@ async fn import_second_run_is_noop_after_marker() -> anyhow::Result<()> {
     assert!(first.is_some());
     assert!(second.is_none());
     assert_eq!(test.store.list().await?.len(), 1);
+    assert!(!source.exists());
+    assert_eq!(legacy_backups(test.dir.path()).await?.len(), 1);
 
     Ok(())
 }
 
 #[tokio::test]
-async fn import_skips_legacy_file_when_sqlite_already_has_rows() -> anyhow::Result<()> {
+async fn import_preserves_existing_sqlite_values_and_imports_new_names() -> anyhow::Result<()> {
     let test = test_store().await?;
     test.store.set("CURRENT", "sqlite wins", None).await?;
     let source = test.dir.path().join("variables.json");
     fs::write(
         &source,
         r#"{
-  "LEGACY": {
+  "CURRENT": {
     "value": "file loses",
+    "created_at": "2026-06-30T10:00:00Z",
+    "updated_at": "2026-06-30T10:01:00Z"
+  },
+  "LEGACY": {
+    "value": "file imports",
     "created_at": "2026-06-30T10:00:00Z",
     "updated_at": "2026-06-30T10:01:00Z"
   }
@@ -287,16 +292,34 @@ async fn import_skips_legacy_file_when_sqlite_already_has_rows() -> anyhow::Resu
 
     let report = import_legacy_json_once(&test.pool, &source)
         .await?
-        .expect("existing SQLite rows should report skipped import");
+        .expect("existing legacy file should report import");
 
-    assert_eq!(report.status, ImportStatus::SkippedExistingTarget);
-    assert_eq!(report.imported_rows, 0);
+    assert_eq!(report.imported_rows, 1);
     assert_eq!(report.skipped_rows, 1);
-    assert_eq!(report.variable_names, vec!["CURRENT"]);
-    assert!(test.store.get("LEGACY").await?.is_none());
+    assert_eq!(report.variable_names, vec!["LEGACY"]);
     assert_eq!(
-        legacy_import_status(&test.pool).await?,
-        Some("skipped_existing_target".to_string())
+        test.store.get("CURRENT").await?.unwrap().value,
+        "sqlite wins"
+    );
+    assert_eq!(
+        test.store.get("LEGACY").await?.unwrap().value,
+        "file imports"
+    );
+    assert!(!source.exists());
+    assert_eq!(
+        fs::read_to_string(&report.backup_path).await?,
+        r#"{
+  "CURRENT": {
+    "value": "file loses",
+    "created_at": "2026-06-30T10:00:00Z",
+    "updated_at": "2026-06-30T10:01:00Z"
+  },
+  "LEGACY": {
+    "value": "file imports",
+    "created_at": "2026-06-30T10:00:00Z",
+    "updated_at": "2026-06-30T10:01:00Z"
+  }
+}"#
     );
 
     Ok(())
@@ -316,6 +339,8 @@ async fn import_invalid_json_or_name_fails_when_sqlite_is_empty() -> anyhow::Res
             .to_string()
             .contains(&invalid_json_source.display().to_string())
     );
+    assert!(invalid_json_source.exists());
+    assert!(legacy_backups(invalid_json.dir.path()).await?.is_empty());
 
     let invalid_name = test_store().await?;
     let invalid_name_source = invalid_name.dir.path().join("variables.json");
@@ -338,20 +363,28 @@ async fn import_invalid_json_or_name_fails_when_sqlite_is_empty() -> anyhow::Res
     assert!(message.contains(&invalid_name_source.display().to_string()));
     assert!(message.contains("BAD-NAME"));
     assert!(!message.contains("secret-ish value"));
+    assert!(invalid_name_source.exists());
+    assert!(legacy_backups(invalid_name.dir.path()).await?.is_empty());
 
     Ok(())
 }
 
-async fn legacy_import_count(pool: &fabro_db::DbPool) -> anyhow::Result<i64> {
-    Ok(sqlx::query_scalar("SELECT COUNT(*) FROM legacy_imports")
-        .fetch_one(pool)
-        .await?)
-}
-
-async fn legacy_import_status(pool: &fabro_db::DbPool) -> anyhow::Result<Option<String>> {
-    Ok(sqlx::query_scalar(
-        "SELECT status FROM legacy_imports WHERE import_name = 'variables-json-v1'",
-    )
-    .fetch_optional(pool)
-    .await?)
+async fn legacy_backups(dir: &Path) -> anyhow::Result<Vec<PathBuf>> {
+    let mut entries = fs::read_dir(dir).await?;
+    let mut backups = Vec::new();
+    while let Some(entry) = entries.next_entry().await? {
+        let path = entry.path();
+        let Some(file_name) = path.file_name().and_then(|name| name.to_str()) else {
+            continue;
+        };
+        if file_name.starts_with("variables.json.imported-")
+            && path
+                .extension()
+                .is_some_and(|extension| extension.eq_ignore_ascii_case("bak"))
+        {
+            backups.push(path);
+        }
+    }
+    backups.sort();
+    Ok(backups)
 }

--- a/lib/crates/fabro-variable/tests/store.rs
+++ b/lib/crates/fabro-variable/tests/store.rs
@@ -9,8 +9,9 @@ struct TestStore {
 
 async fn test_store() -> anyhow::Result<TestStore> {
     let dir = tempfile::tempdir()?;
-    let pool = fabro_db::connect(dir.path().join("fabro.sqlite3")).await?;
-    fabro_db::migrate(&pool).await?;
+    let database = fabro_db::Database::connect(dir.path().join("fabro.sqlite3")).await?;
+    database.migrate().await?;
+    let pool = database.clone_pool();
     let store = VariableStore::new(pool.clone());
     Ok(TestStore { dir, pool, store })
 }


### PR DESCRIPTION
## Summary

This moves workflow-visible variables from JSON file storage into SQLite-backed storage, establishing the first durable SQL table while preserving the existing variable API behavior.

## What Changed

- Added a `fabro-db` crate with bundled SQLite, an embedded migration for the `variables` table, and a `Database` owner for `connect()`, `migrate()`, `health_check()`, and pool access.
- Replaced the `fabro-variable` JSON file store with an async SQLx-backed `VariableStore` that preserves sorted listing, case-sensitive names, empty string values, name validation, and description-preserving upserts.
- Wired server startup to create `<storage>/db/fabro.sqlite3`, run SQLite migrations, import legacy variables when needed, and pass the shared pool into server state.
- Grouped live server stores under `AppStores` so runs, variables, vault, environments, and automations share one state boundary while artifacts remain separate.
- Updated variable handlers, run creation, validation, and test support for async SQLite-backed variable access.
- Added schema, store-level, legacy import, and API-level persistence coverage for variables.

## Legacy JSON Migration

On startup, Fabro looks for `<storage>/variables.json`. If it is missing, startup is a no-op for legacy variables.

If the file exists, Fabro parses and validates the full file before mutating SQLite. Valid entries are inserted with `ON CONFLICT(name) DO NOTHING`, so existing SQLite values remain authoritative and only missing names are imported from the legacy file.

After a successful import transaction, the source file is renamed to a timestamped backup such as `variables.json.imported-<timestamp>.bak`. A later startup naturally skips the import because the original source path no longer exists. Invalid JSON or invalid variable names leave the source file in place for operator repair.

Variable values are not logged during import. Logs include only safe metadata such as source/backup paths, row counts, and variable names.

## Verification

- `cargo nextest run -p fabro-db -p fabro-variable`
- `cargo nextest run -p fabro-server --features test-support variables`
- `cargo +nightly-2026-04-14 fmt --check --all`
- `cargo +nightly-2026-04-14 clippy --workspace --all-targets -- -D warnings`

---

[![Compound Engineering](https://img.shields.io/badge/Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
Generated with GPT-5 via [Codex](https://openai.com/codex)
