### PR TITLE
feat: grant Dependabot alerts read/write to auto-created GitHub Apps

### DIFF
--- a/lib/crates/fabro-cli/src/commands/install.rs
+++ b/lib/crates/fabro-cli/src/commands/install.rs
@@ -948,7 +948,8 @@ fn build_github_app_manifest(app_name: &str, port: u16, web_url: &str) -> serde_
             "pull_requests": "write",
             "checks": "write",
             "issues": "write",
-            "emails": "read"
+            "emails": "read",
+            "vulnerability_alerts": "write"
         },
         "default_events": []
     })
@@ -2661,6 +2662,10 @@ client_id = "client-id"
         assert_eq!(
             manifest["setup_url"],
             serde_json::json!("https://app.example.com/setup"),
+        );
+        assert_eq!(
+            manifest["default_permissions"]["vulnerability_alerts"],
+            serde_json::json!("write"),
         );
     }
 

--- a/lib/crates/fabro-server/src/install.rs
+++ b/lib/crates/fabro-server/src/install.rs
@@ -2053,7 +2053,8 @@ fn build_github_app_manifest(
             "pull_requests": "write",
             "checks": "write",
             "issues": "write",
-            "emails": "read"
+            "emails": "read",
+            "vulnerability_alerts": "write"
         },
         "default_events": []
     })


### PR DESCRIPTION
## What

Adds the `vulnerability_alerts: write` fine-grained permission to the GitHub App manifest used when Fabro auto-creates a GitHub App, in **both** install flows:

- `lib/crates/fabro-server/src/install.rs` (web-UI install)
- `lib/crates/fabro-cli/src/commands/install.rs` (CLI install)

`write` on `vulnerability_alerts` grants both read and write of Dependabot alerts (write implies read for fine-grained permissions).

The two manifest builders are byte-for-byte identical by design, so both are updated together. A test assertion in the CLI install tests guards the new permission.

## Why

We need auto-created Fabro apps to be able to read and manage Dependabot alerts.

## Note on rollout

Manifest `default_permissions` are applied at **app-creation time**, so this only affects **newly** auto-created apps. Any app already created won't pick this up automatically — the owner must add the permission in the app's settings, and each existing installation must approve the new permission request.

## Test

- `cargo nextest run -p fabro-cli -- manifest_includes_callback_urls_and_setup_url` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)