### PR TITLE
fix: grant organization_projects to auto-created GitHub Apps for Projects V2

### DIFF
--- a/lib/crates/fabro-cli/src/commands/install.rs
+++ b/lib/crates/fabro-cli/src/commands/install.rs
@@ -949,7 +949,8 @@ fn build_github_app_manifest(app_name: &str, port: u16, web_url: &str) -> serde_
             "checks": "write",
             "issues": "write",
             "emails": "read",
-            "vulnerability_alerts": "write"
+            "vulnerability_alerts": "write",
+            "organization_projects": "write"
         },
         "default_events": []
     })
@@ -2665,6 +2666,10 @@ client_id = "client-id"
         );
         assert_eq!(
             manifest["default_permissions"]["vulnerability_alerts"],
+            serde_json::json!("write"),
+        );
+        assert_eq!(
+            manifest["default_permissions"]["organization_projects"],
             serde_json::json!("write"),
         );
     }

--- a/lib/crates/fabro-server/src/install.rs
+++ b/lib/crates/fabro-server/src/install.rs
@@ -2054,7 +2054,8 @@ fn build_github_app_manifest(
             "checks": "write",
             "issues": "write",
             "emails": "read",
-            "vulnerability_alerts": "write"
+            "vulnerability_alerts": "write",
+            "organization_projects": "write"
         },
         "default_events": []
     })


### PR DESCRIPTION
## What

Adds the `organization_projects: write` permission to the GitHub App manifest used when Fabro auto-creates a GitHub App, in **both** install flows:

- `lib/crates/fabro-server/src/install.rs` (web-UI install)
- `lib/crates/fabro-cli/src/commands/install.rs` (CLI install)

A test assertion in the CLI install tests guards the new permission.

## Why

The GitHub Projects V2 tracker mints a scoped installation token requesting `{ "issues": "write", "organization_projects": "write" }` (`create_installation_access_token_for_projects`, `fabro-github/src/lib.rs`). GitHub only lets an installation token request a **subset** of the permissions the app was granted at install time — and `organization_projects` was never in the manifest. So on any auto-created Fabro app, the token request comes back **422** and the tracker fails before it can make a single GraphQL call.

`issues: write` (also requested by that helper) is already covered by the manifest; `organization_projects` was the missing piece.

## Note on rollout

Manifest `default_permissions` are applied at **app-creation time**, so this only affects **newly** auto-created apps. Existing apps need the permission added manually in their settings, and each installation must approve it.

## Follow-up (not in this PR)

The `422` branch in `mint_installation_token_with_jwt` reports "GitHub App does not have access to repository {repo}" — which misattributes a missing-permission failure to repository access. Worth softening the message to mention permissions too; left out here to keep this PR focused on the scope change.

## Test

- `cargo nextest run -p fabro-cli -- manifest_includes_callback_urls_and_setup_url` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)