### PR TITLE
fix(web): respect workflow's rankdir on run overview graph

### DIFF
--- a/apps/fabro-web/app/components/graph-toolbar.tsx
+++ b/apps/fabro-web/app/components/graph-toolbar.tsx
@@ -11,7 +11,7 @@ export function GraphToolbar({
   zoomIndex,
   setZoomIndex,
 }: {
-  direction: Direction | undefined;
+  direction: Direction;
   setDirection: (d: Direction) => void;
   fitToWindow: () => void;
   zoomIndex: number;

--- a/apps/fabro-web/app/components/graph-toolbar.tsx
+++ b/apps/fabro-web/app/components/graph-toolbar.tsx
@@ -11,7 +11,7 @@ export function GraphToolbar({
   zoomIndex,
   setZoomIndex,
 }: {
-  direction: Direction;
+  direction: Direction | undefined;
   setDirection: (d: Direction) => void;
   fitToWindow: () => void;
   zoomIndex: number;

--- a/apps/fabro-web/app/routes/run-overview.test.tsx
+++ b/apps/fabro-web/app/routes/run-overview.test.tsx
@@ -19,6 +19,7 @@ mock.module("../lib/queries", () => ({
     isLoading: currentGraphLoading,
     mutate:    graphMutateMock,
   }),
+  useRunGraphSource: () => ({ data: undefined }),
   useRunStageEvents: () => ({ data: [] }),
 }));
 

--- a/apps/fabro-web/app/routes/run-overview.tsx
+++ b/apps/fabro-web/app/routes/run-overview.tsx
@@ -26,7 +26,7 @@ type Direction = "LR" | "TB";
 
 const RANKDIR_RE = /rankdir\s*=\s*(\w+)/;
 
-function parseSourceDirection(source: string | null | undefined): Direction | undefined {
+function parseSourceDirection(source: string | undefined): Direction | undefined {
   const value = source?.match(RANKDIR_RE)?.[1];
   return value === "LR" || value === "TB" ? value : undefined;
 }
@@ -35,7 +35,7 @@ export default function RunOverview() {
   const { id } = useParams();
   const [direction, setDirection] = useState<Direction | undefined>(undefined);
   const sourceQuery = useRunGraphSource(id, direction === undefined);
-  const activeDirection = direction ?? parseSourceDirection(sourceQuery.data) ?? "TB";
+  const activeDirection = direction ?? parseSourceDirection(sourceQuery.data ?? undefined) ?? "TB";
   const stagesQuery = useRunStages(id);
   const graphQuery = useRunGraph(id, direction);
   const runQuery = useRun(id);

--- a/apps/fabro-web/app/routes/run-overview.tsx
+++ b/apps/fabro-web/app/routes/run-overview.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useMemo, useRef, useState } from "react";
 import { useNavigate, useParams } from "react-router";
 import { ApiError } from "../lib/api-client";
-import { useRun, useRunGraph, useRunStages } from "../lib/queries";
+import { useRun, useRunGraph, useRunGraphSource, useRunStages } from "../lib/queries";
 import { FloatingTooltip } from "../components/floating-tooltip";
 import { RunSummaryPanel } from "../components/run-summary-panel";
 import { StagePopover } from "../components/stage-popover";
@@ -24,9 +24,18 @@ export const handle = { wide: true };
 
 type Direction = "LR" | "TB";
 
+const RANKDIR_RE = /rankdir\s*=\s*(\w+)/;
+
+function parseSourceDirection(source: string | null | undefined): Direction | undefined {
+  const value = source?.match(RANKDIR_RE)?.[1];
+  return value === "LR" || value === "TB" ? value : undefined;
+}
+
 export default function RunOverview() {
   const { id } = useParams();
   const [direction, setDirection] = useState<Direction | undefined>(undefined);
+  const sourceQuery = useRunGraphSource(id, direction === undefined);
+  const activeDirection = direction ?? parseSourceDirection(sourceQuery.data) ?? "TB";
   const stagesQuery = useRunStages(id);
   const graphQuery = useRunGraph(id, direction);
   const runQuery = useRun(id);
@@ -123,7 +132,7 @@ export default function RunOverview() {
         ) : graphSvg ? (
           <div className="graph-svg relative rounded-md border border-line bg-panel-alt">
             <GraphToolbar
-              direction={direction}
+              direction={activeDirection}
               setDirection={setDirection}
               fitToWindow={fitToWindow}
               zoomIndex={zoomIndex}

--- a/apps/fabro-web/app/routes/run-overview.tsx
+++ b/apps/fabro-web/app/routes/run-overview.tsx
@@ -26,7 +26,7 @@ type Direction = "LR" | "TB";
 
 export default function RunOverview() {
   const { id } = useParams();
-  const [direction, setDirection] = useState<Direction>("LR");
+  const [direction, setDirection] = useState<Direction | undefined>(undefined);
   const stagesQuery = useRunStages(id);
   const graphQuery = useRunGraph(id, direction);
   const runQuery = useRun(id);

--- a/apps/fabro-web/app/routes/run-overview.tsx
+++ b/apps/fabro-web/app/routes/run-overview.tsx
@@ -37,11 +37,7 @@ export default function RunOverview() {
   const { id } = useParams();
   const [direction, setDirection] = useState<Direction | undefined>(undefined);
   const sourceQuery = useRunGraphSource(id, direction === undefined);
-  const sourceDirection = useMemo(
-    () => parseSourceDirection(sourceQuery.data ?? undefined),
-    [sourceQuery.data],
-  );
-  const activeDirection = direction ?? sourceDirection ?? "TB";
+  const activeDirection = direction ?? parseSourceDirection(sourceQuery.data ?? undefined) ?? "TB";
   const stagesQuery = useRunStages(id);
   const graphQuery = useRunGraph(id, direction);
   const runQuery = useRun(id);

--- a/apps/fabro-web/app/routes/run-overview.tsx
+++ b/apps/fabro-web/app/routes/run-overview.tsx
@@ -24,6 +24,8 @@ export const handle = { wide: true };
 
 type Direction = "LR" | "TB";
 
+// Mirrors fabro-graphviz's RANKDIR_RE (lib/crates/fabro-graphviz/src/render.rs) —
+// keep the accepted `rankdir=` syntax in sync with that regex.
 const RANKDIR_RE = /rankdir\s*=\s*(\w+)/;
 
 function parseSourceDirection(source: string | undefined): Direction | undefined {
@@ -35,7 +37,11 @@ export default function RunOverview() {
   const { id } = useParams();
   const [direction, setDirection] = useState<Direction | undefined>(undefined);
   const sourceQuery = useRunGraphSource(id, direction === undefined);
-  const activeDirection = direction ?? parseSourceDirection(sourceQuery.data ?? undefined) ?? "TB";
+  const sourceDirection = useMemo(
+    () => parseSourceDirection(sourceQuery.data ?? undefined),
+    [sourceQuery.data],
+  );
+  const activeDirection = direction ?? sourceDirection ?? "TB";
   const stagesQuery = useRunStages(id);
   const graphQuery = useRunGraph(id, direction);
   const runQuery = useRun(id);


### PR DESCRIPTION
## Summary
Fixes the graph that was always being rendered as `left-to-right` even when the workflow's `rankdir` is `top-to-bottom`

## Test plan
- [x] `bun run typecheck` (fabro-web)
- [x] `bun test` (fabro-web, full suite — 625 pass)
- [x] Manually load a run whose workflow declares `rankdir TB` and confirm the graph renders top-to-bottom on first load, with the toolbar's LR/TB buttons still working as manual overrides

🤖 Generated with [Claude Code](https://claude.com/claude-code)