### PR TITLE
feat(web): trackpad pan + ⌘-scroll zoom on the run graph

### DIFF
--- a/apps/fabro-web/app/components/graph-toolbar-constants.ts
+++ b/apps/fabro-web/app/components/graph-toolbar-constants.ts
@@ -1,2 +1,0 @@
-export const GRAPH_ZOOM_STEPS = [25, 50, 75, 100, 150, 200];
-export const GRAPH_DEFAULT_ZOOM_INDEX = 2;

--- a/apps/fabro-web/app/components/graph-toolbar.tsx
+++ b/apps/fabro-web/app/components/graph-toolbar.tsx
@@ -1,21 +1,23 @@
 import { ArrowDownIcon, ArrowRightIcon, MinusIcon, PlusIcon } from "@heroicons/react/20/solid";
 
-import { GRAPH_ZOOM_STEPS } from "./graph-toolbar-constants";
-
 type Direction = "LR" | "TB";
 
 export function GraphToolbar({
   direction,
   setDirection,
   fitToWindow,
-  zoomIndex,
-  setZoomIndex,
+  onZoomIn,
+  onZoomOut,
+  canZoomIn,
+  canZoomOut,
 }: {
   direction: Direction;
   setDirection: (d: Direction) => void;
   fitToWindow: () => void;
-  zoomIndex: number;
-  setZoomIndex: (updater: (i: number) => number) => void;
+  onZoomIn: () => void;
+  onZoomOut: () => void;
+  canZoomIn: boolean;
+  canZoomOut: boolean;
 }) {
   const group =
     "flex items-center gap-0.5 px-0.5 [&:not(:first-child)]:border-l [&:not(:first-child)]:border-line-strong [&:not(:first-child)]:pl-1 [&:not(:first-child)]:ml-1";
@@ -68,8 +70,8 @@ export function GraphToolbar({
         <button
           type="button"
           title="Zoom out"
-          onClick={() => setZoomIndex((i) => Math.max(0, i - 1))}
-          disabled={zoomIndex === 0}
+          onClick={onZoomOut}
+          disabled={!canZoomOut}
           className={`${btn} ${btnDisabled}`}
         >
           <MinusIcon className="size-4" aria-hidden="true" />
@@ -77,8 +79,8 @@ export function GraphToolbar({
         <button
           type="button"
           title="Zoom in"
-          onClick={() => setZoomIndex((i) => Math.min(GRAPH_ZOOM_STEPS.length - 1, i + 1))}
-          disabled={zoomIndex === GRAPH_ZOOM_STEPS.length - 1}
+          onClick={onZoomIn}
+          disabled={!canZoomIn}
           className={`${btn} ${btnDisabled}`}
         >
           <PlusIcon className="size-4" aria-hidden="true" />

--- a/apps/fabro-web/app/hooks/effects.ts
+++ b/apps/fabro-web/app/hooks/effects.ts
@@ -118,6 +118,33 @@ export function useDocumentEvent<K extends keyof DocumentEventMap>(
 }
 
 /**
+ * Synchronizes React with an event listener on a ref'd element. The listener is
+ * removed before resubscribe and on unmount; the handler sees the latest render.
+ * Unlike a JSX event prop, this can pass `{ passive: false }` so the handler may
+ * `preventDefault()` (e.g. to own wheel/⌘-scroll instead of the browser).
+ */
+export function useElementEvent<K extends keyof HTMLElementEventMap>(
+  ref: RefObject<HTMLElement | null>,
+  type: K,
+  handler: (event: HTMLElementEventMap[K]) => void,
+  options?: AddEventListenerOptions | boolean,
+  active = true,
+): void {
+  const handlerRef = useRef(handler);
+  handlerRef.current = handler;
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!active || !el) return undefined;
+    const listener = (event: HTMLElementEventMap[K]) => handlerRef.current(event);
+    el.addEventListener(type, listener as EventListener, options);
+    return () => {
+      el.removeEventListener(type, listener as EventListener, options);
+    };
+  }, [active, options, ref, type]);
+}
+
+/**
  * Synchronizes React with `document.title`. The previous title is restored when
  * the title changes or the component unmounts.
  */

--- a/apps/fabro-web/app/lib/graph-viewport.test.ts
+++ b/apps/fabro-web/app/lib/graph-viewport.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  GRAPH_MAX_ZOOM,
+  GRAPH_MIN_ZOOM,
+  GRAPH_ZOOM_BUTTON_FACTOR,
+  clampZoom,
+  zoomAtPoint,
+  type GraphView,
+} from "./graph-viewport";
+
+// Screen offset (from container center) of a content point at pre-transform offset q.
+const screenOffset = (view: GraphView, q: { x: number; y: number }) => ({
+  x: view.pan.x + (view.zoom / 100) * q.x,
+  y: view.pan.y + (view.zoom / 100) * q.y,
+});
+
+describe("zoomAtPoint", () => {
+  test("keeps the point under the cursor anchored on screen", () => {
+    const view: GraphView = { zoom: 100, pan: { x: 30, y: -20 } };
+    const cursor = { x: 50, y: 40 };
+    // Content point currently under the cursor, in pre-transform coords.
+    const q = {
+      x: (cursor.x - view.pan.x) / (view.zoom / 100),
+      y: (cursor.y - view.pan.y) / (view.zoom / 100),
+    };
+
+    const after = zoomAtPoint(view, 1.5, cursor);
+    const anchored = screenOffset(after, q);
+
+    expect(after.zoom).toBeCloseTo(150);
+    expect(anchored.x).toBeCloseTo(cursor.x);
+    expect(anchored.y).toBeCloseTo(cursor.y);
+  });
+
+  test("clamps zoom and applies the clamped ratio to pan", () => {
+    const view: GraphView = { zoom: GRAPH_MAX_ZOOM, pan: { x: 10, y: 10 } };
+    const after = zoomAtPoint(view, 4, { x: 0, y: 0 }); // wants 800%, must clamp to max
+    expect(after.zoom).toBe(GRAPH_MAX_ZOOM);
+    expect(after.pan).toEqual({ x: 10, y: 10 }); // k == 1, pan unchanged toward center
+  });
+
+  test("center-anchored zoom in then out is a round trip", () => {
+    const start: GraphView = { zoom: 80, pan: { x: 12, y: -6 } };
+    const zoomedIn = zoomAtPoint(start, GRAPH_ZOOM_BUTTON_FACTOR, { x: 0, y: 0 });
+    const roundTrip = zoomAtPoint(zoomedIn, 1 / GRAPH_ZOOM_BUTTON_FACTOR, { x: 0, y: 0 });
+    expect(roundTrip.zoom).toBeCloseTo(start.zoom);
+    expect(roundTrip.pan.x).toBeCloseTo(start.pan.x);
+    expect(roundTrip.pan.y).toBeCloseTo(start.pan.y);
+  });
+});
+
+test("clampZoom respects bounds", () => {
+  expect(clampZoom(10)).toBe(GRAPH_MIN_ZOOM);
+  expect(clampZoom(500)).toBe(GRAPH_MAX_ZOOM);
+  expect(clampZoom(75)).toBe(75);
+});

--- a/apps/fabro-web/app/lib/graph-viewport.test.ts
+++ b/apps/fabro-web/app/lib/graph-viewport.test.ts
@@ -3,7 +3,6 @@ import { describe, expect, test } from "bun:test";
 import {
   GRAPH_MAX_ZOOM,
   GRAPH_MIN_ZOOM,
-  GRAPH_ZOOM_BUTTON_FACTOR,
   clampZoom,
   zoomAtPoint,
   type GraphView,
@@ -42,8 +41,9 @@ describe("zoomAtPoint", () => {
 
   test("center-anchored zoom in then out is a round trip", () => {
     const start: GraphView = { zoom: 80, pan: { x: 12, y: -6 } };
-    const zoomedIn = zoomAtPoint(start, GRAPH_ZOOM_BUTTON_FACTOR, { x: 0, y: 0 });
-    const roundTrip = zoomAtPoint(zoomedIn, 1 / GRAPH_ZOOM_BUTTON_FACTOR, { x: 0, y: 0 });
+    const factor = 1.25;
+    const zoomedIn = zoomAtPoint(start, factor, { x: 0, y: 0 });
+    const roundTrip = zoomAtPoint(zoomedIn, 1 / factor, { x: 0, y: 0 });
     expect(roundTrip.zoom).toBeCloseTo(start.zoom);
     expect(roundTrip.pan.x).toBeCloseTo(start.pan.x);
     expect(roundTrip.pan.y).toBeCloseTo(start.pan.y);

--- a/apps/fabro-web/app/lib/graph-viewport.ts
+++ b/apps/fabro-web/app/lib/graph-viewport.ts
@@ -1,0 +1,47 @@
+// Pan/zoom viewport math for the run graph. There's no React in here, so it can be
+// unit-tested on its own. Zoom is a continuous percentage rather than a discrete step
+// index, which is what keeps cursor-anchored ⌘-scroll zoom smooth.
+//
+// The playground canvas (components/playground/canvas) has the same hand-rolled
+// pan/zoom but still uses a discrete step index. If it ever wants cursor-anchored
+// zoom, it can import this module.
+
+export const GRAPH_MIN_ZOOM = 25; // percent; the clamp bounds. Widen if you want more range.
+export const GRAPH_MAX_ZOOM = 200;
+// Initial zoom shown when the graph first loads, in percent.
+export const GRAPH_DEFAULT_ZOOM = 75;
+// Toolbar +/- step. Using 1/1.25 for zoom-out keeps it symmetric with zoom-in.
+export const GRAPH_ZOOM_BUTTON_FACTOR = 1.25;
+// How fast ⌘-scroll zooms; tune to taste. exp() keeps it symmetric and always above 0.
+export const GRAPH_ZOOM_WHEEL_SENSITIVITY = 0.002;
+
+export type GraphView = { zoom: number; pan: { x: number; y: number } };
+
+export const clampZoom = (zoom: number): number =>
+  Math.min(GRAPH_MAX_ZOOM, Math.max(GRAPH_MIN_ZOOM, zoom));
+
+/**
+ * Scale `view.zoom` by `factor`, keeping the content point under `cursor` fixed on
+ * screen. `cursor` is measured from the container CENTER (matching the graph's
+ * `transform-origin: center center`); pass {x:0,y:0} to zoom toward the center, which
+ * is what the toolbar +/- buttons want.
+ *
+ * Derivation: with `translate(pan) scale(s)` about the center, a content point at
+ * pre-transform offset q sits at screen offset `pan + s*q`. Holding the point under
+ * the cursor (offset c) fixed while s -> s' gives `pan' = c*(1-k) + k*pan`, k = s'/s.
+ */
+export function zoomAtPoint(
+  view: GraphView,
+  factor: number,
+  cursor: { x: number; y: number },
+): GraphView {
+  const zoom = clampZoom(view.zoom * factor);
+  const k = zoom / view.zoom; // applied ratio after clamping
+  return {
+    zoom,
+    pan: {
+      x: cursor.x * (1 - k) + k * view.pan.x,
+      y: cursor.y * (1 - k) + k * view.pan.y,
+    },
+  };
+}

--- a/apps/fabro-web/app/lib/graph-viewport.ts
+++ b/apps/fabro-web/app/lib/graph-viewport.ts
@@ -8,12 +8,6 @@
 
 export const GRAPH_MIN_ZOOM = 25; // percent; the clamp bounds. Widen if you want more range.
 export const GRAPH_MAX_ZOOM = 200;
-// Initial zoom shown when the graph first loads, in percent.
-export const GRAPH_DEFAULT_ZOOM = 75;
-// Toolbar +/- step. Using 1/1.25 for zoom-out keeps it symmetric with zoom-in.
-export const GRAPH_ZOOM_BUTTON_FACTOR = 1.25;
-// How fast ⌘-scroll zooms; tune to taste. exp() keeps it symmetric and always above 0.
-export const GRAPH_ZOOM_WHEEL_SENSITIVITY = 0.002;
 
 export type GraphView = { zoom: number; pan: { x: number; y: number } };
 

--- a/apps/fabro-web/app/routes/run-overview.tsx
+++ b/apps/fabro-web/app/routes/run-overview.tsx
@@ -7,9 +7,16 @@ import { RunSummaryPanel } from "../components/run-summary-panel";
 import { StagePopover } from "../components/stage-popover";
 import { StageSidebar } from "../components/stage-sidebar";
 import {
-  GRAPH_DEFAULT_ZOOM_INDEX,
-  GRAPH_ZOOM_STEPS,
-} from "../components/graph-toolbar-constants";
+  GRAPH_DEFAULT_ZOOM,
+  GRAPH_MAX_ZOOM,
+  GRAPH_MIN_ZOOM,
+  GRAPH_ZOOM_BUTTON_FACTOR,
+  GRAPH_ZOOM_WHEEL_SENSITIVITY,
+  clampZoom,
+  zoomAtPoint,
+  type GraphView,
+} from "../lib/graph-viewport";
+import { useElementEvent } from "../hooks/effects";
 import { GraphToolbar } from "../components/graph-toolbar";
 import { EmptyState, ErrorState } from "../components/state";
 import {
@@ -32,6 +39,13 @@ function parseSourceDirection(source: string | undefined): Direction | undefined
   const value = source?.match(RANKDIR_RE)?.[1];
   return value === "LR" || value === "TB" ? value : undefined;
 }
+
+// Zoom toward the container center. The toolbar +/- buttons anchor here, not the cursor.
+const CENTER = { x: 0, y: 0 };
+// Non-passive so the wheel handler can call preventDefault on the browser's own ⌘-zoom.
+// Kept at module scope for a stable identity, since the effect resubscribes when its
+// options object changes.
+const WHEEL_LISTENER_OPTS: AddEventListenerOptions = { passive: false };
 
 export default function RunOverview() {
   const { id } = useParams();
@@ -63,10 +77,8 @@ export default function RunOverview() {
   const innerRef = useRef<HTMLDivElement>(null);
   const svgRef = useRef<SVGSVGElement | null>(null);
   const navigate = useNavigate();
-  const [zoomIndex, setZoomIndex] = useState(GRAPH_DEFAULT_ZOOM_INDEX);
-  const [pan, setPan] = useState({ x: 0, y: 0 });
+  const [view, setView] = useState<GraphView>({ zoom: GRAPH_DEFAULT_ZOOM, pan: { x: 0, y: 0 } });
   const dragState = useRef<{ startX: number; startY: number; startPanX: number; startPanY: number } | null>(null);
-  const zoom = GRAPH_ZOOM_STEPS[zoomIndex];
   const [hoveredNode, setHoveredNode] = useState<RunGraphNodeHover | null>(null);
 
   const openStage = useCallback(
@@ -87,21 +99,43 @@ export default function RunOverview() {
     if ((e.target as HTMLElement).closest("button")) return;
     if ((e.target as HTMLElement).closest(".node")) return;
     e.currentTarget.setPointerCapture(e.pointerId);
-    dragState.current = { startX: e.clientX, startY: e.clientY, startPanX: pan.x, startPanY: pan.y };
-  }, [pan]);
+    dragState.current = { startX: e.clientX, startY: e.clientY, startPanX: view.pan.x, startPanY: view.pan.y };
+  }, [view.pan]);
 
   const onPointerMove = useCallback((e: React.PointerEvent) => {
     const drag = dragState.current;
     if (!drag) return;
-    setPan({
-      x: drag.startPanX + e.clientX - drag.startX,
-      y: drag.startPanY + e.clientY - drag.startY,
-    });
+    setView((v) => ({
+      ...v,
+      pan: {
+        x: drag.startPanX + e.clientX - drag.startX,
+        y: drag.startPanY + e.clientY - drag.startY,
+      },
+    }));
   }, []);
 
   const onPointerUp = useCallback(() => {
     dragState.current = null;
   }, []);
+
+  // Two-finger scroll pans; ⌘/Ctrl + scroll (and trackpad pinch, which arrives as
+  // ctrl+wheel) zooms anchored at the cursor. Native listener so preventDefault sticks.
+  const onWheel = useCallback((e: WheelEvent) => {
+    const el = containerRef.current;
+    if (!el) return;
+    if ((e.target as HTMLElement).closest('[role="toolbar"]')) return;
+    e.preventDefault();
+    if (e.ctrlKey || e.metaKey) {
+      const r = el.getBoundingClientRect();
+      const cursor = { x: e.clientX - (r.left + r.width / 2), y: e.clientY - (r.top + r.height / 2) };
+      setView((v) => zoomAtPoint(v, Math.exp(-e.deltaY * GRAPH_ZOOM_WHEEL_SENSITIVITY), cursor));
+    } else {
+      setView((v) => ({ ...v, pan: { x: v.pan.x - e.deltaX, y: v.pan.y - e.deltaY } }));
+    }
+  }, []);
+  // The container only exists once the graph has loaded, so gate the listener on
+  // graphSvg. The effect then re-runs and binds once the container is on the page.
+  useElementEvent(containerRef, "wheel", onWheel, WHEEL_LISTENER_OPTS, Boolean(graphSvg));
 
   const fitToWindow = useCallback(() => {
     const svg = svgRef.current;
@@ -115,12 +149,7 @@ export default function RunOverview() {
     const containerH = container.clientHeight - padPx;
 
     const fitPct = Math.min(containerW / svgW, containerH / svgH) * 100;
-    let best = 0;
-    for (let i = GRAPH_ZOOM_STEPS.length - 1; i >= 0; i--) {
-      if (GRAPH_ZOOM_STEPS[i] <= fitPct) { best = i; break; }
-    }
-    setZoomIndex(best);
-    setPan({ x: 0, y: 0 });
+    setView({ zoom: clampZoom(fitPct), pan: { x: 0, y: 0 } });
   }, []);
 
   return (
@@ -141,13 +170,15 @@ export default function RunOverview() {
               direction={activeDirection}
               setDirection={setDirection}
               fitToWindow={fitToWindow}
-              zoomIndex={zoomIndex}
-              setZoomIndex={setZoomIndex}
+              onZoomIn={() => setView((v) => zoomAtPoint(v, GRAPH_ZOOM_BUTTON_FACTOR, CENTER))}
+              onZoomOut={() => setView((v) => zoomAtPoint(v, 1 / GRAPH_ZOOM_BUTTON_FACTOR, CENTER))}
+              canZoomIn={view.zoom < GRAPH_MAX_ZOOM}
+              canZoomOut={view.zoom > GRAPH_MIN_ZOOM}
             />
 
             <div
               ref={containerRef}
-              className="min-h-0 flex-1 overflow-hidden p-6"
+              className="min-h-0 flex-1 touch-none overflow-hidden overscroll-contain p-6"
               style={{ cursor: dragState.current ? "grabbing" : "grab" }}
               onPointerDown={onPointerDown}
               onPointerMove={onPointerMove}
@@ -157,7 +188,7 @@ export default function RunOverview() {
               <div
                 ref={innerRef}
                 className="flex h-full items-center justify-center [&_svg]:mx-auto [&_svg]:block"
-                style={{ transform: `translate(${pan.x}px, ${pan.y}px) scale(${zoom / 100})`, transformOrigin: "center center" }}
+                style={{ transform: `translate(${view.pan.x}px, ${view.pan.y}px) scale(${view.zoom / 100})`, transformOrigin: "center center" }}
               />
             </div>
           </div>

--- a/apps/fabro-web/app/routes/run-overview.tsx
+++ b/apps/fabro-web/app/routes/run-overview.tsx
@@ -7,11 +7,8 @@ import { RunSummaryPanel } from "../components/run-summary-panel";
 import { StagePopover } from "../components/stage-popover";
 import { StageSidebar } from "../components/stage-sidebar";
 import {
-  GRAPH_DEFAULT_ZOOM,
   GRAPH_MAX_ZOOM,
   GRAPH_MIN_ZOOM,
-  GRAPH_ZOOM_BUTTON_FACTOR,
-  GRAPH_ZOOM_WHEEL_SENSITIVITY,
   clampZoom,
   zoomAtPoint,
   type GraphView,
@@ -40,6 +37,12 @@ function parseSourceDirection(source: string | undefined): Direction | undefined
   return value === "LR" || value === "TB" ? value : undefined;
 }
 
+// Initial zoom shown when the graph first loads, in percent.
+const GRAPH_DEFAULT_ZOOM = 75;
+// Toolbar +/- step. Using 1/1.25 for zoom-out keeps it symmetric with zoom-in.
+const GRAPH_ZOOM_BUTTON_FACTOR = 1.25;
+// How fast ⌘-scroll zooms; tune to taste. exp() keeps it symmetric and always above 0.
+const GRAPH_ZOOM_WHEEL_SENSITIVITY = 0.002;
 // Zoom toward the container center. The toolbar +/- buttons anchor here, not the cursor.
 const CENTER = { x: 0, y: 0 };
 // Non-passive so the wheel handler can call preventDefault on the browser's own ⌘-zoom.


### PR DESCRIPTION
## What

On **Runs → Overview**, the workflow graph now supports the standard Figma/Excalidraw canvas interactions:

- **Two-finger scroll → pan**
- **⌘/Ctrl + scroll → zoom**, anchored under the cursor (mac trackpad pinch works too — the browser delivers it as `ctrl+wheel`)

The graph already had drag-to-pan, stepped zoom (toolbar +/−), and fit-to-window. This adds the missing wheel/trackpad input on top of that existing transform state.


https://github.com/user-attachments/assets/15eac98b-2603-44c9-b438-7ee27034ccd7


## How

- **`app/lib/graph-viewport.ts`** (new) — pure, framework-free zoom math: `zoomAtPoint` keeps the point under the cursor fixed while scaling; `clampZoom` + zoom constants. Zoom becomes a continuous float (was a discrete step index) so ⌘-scroll is smooth instead of jumping between steps. Unit-tested (`graph-viewport.test.ts`), including the cursor-anchor invariant.
- **`useElementEvent` in `hooks/effects.ts`** (new) — element-scoped, non-passive listener, a sibling to the existing `useWindowEvent`/`useDocumentEvent`. Non-passive is required so the handler can `preventDefault()` the browser's own ⌘-zoom; a JSX `onWheel` can't.
- **`routes/run-overview.tsx`** — coalesces zoom+pan into one `view` state (atomic cursor-anchored updates), adds the wheel handler (plain scroll → pan, ⌘/Ctrl → zoom), and `touch-none overscroll-contain` so a horizontal swipe can't trigger browser back-nav.
- **`components/graph-toolbar.tsx`** — presentational continuous interface; +/− buttons reuse `zoomAtPoint` (center-anchored). Deletes the now-dead `graph-toolbar-constants.ts`.

## Testing

- `bun run typecheck` clean; `bun test` green (incl. 4 new viewport tests).
- Verified live against a real 10-node run graph via Chrome DevTools: two-finger pan tracks the scroll delta; ⌘+wheel zoom is cursor-anchored (confirmed even with the cursor over a node); toolbar +/− step ×1.25 and clamp/disable at 200%; fit-to-window sets a continuous scale; node click/hover unaffected.

## Non-goals

- **Playground canvas** (`components/playground/canvas`) shares the same hand-rolled pan/zoom pattern and also lacks wheel support — deliberately out of scope; `graph-viewport.ts` is the seam to adopt it later.
- **No persistence** — zoom/pan stays ephemeral per visit, as it was before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)