### PR TITLE
Resizable interview dock with background scroll

### DIFF
--- a/apps/fabro-web/app/components/interview-dock.test.tsx
+++ b/apps/fabro-web/app/components/interview-dock.test.tsx
@@ -273,6 +273,30 @@ describe("InterviewDock", () => {
     expect(tree.toJSON()).toBeNull();
   });
 
+  test("invokes onDockHeightChange callback with initial height on mount", () => {
+    const storage = new Map<string, string>();
+    globalThis.window = {
+      localStorage: {
+        getItem: (key: string) => storage.get(key) ?? null,
+        setItem: (key: string, value: string) => storage.set(key, value),
+      },
+      innerHeight: 1000,
+    } as any;
+
+    const heights: string[] = [];
+    const onDockHeightChange = (height: string) => heights.push(height);
+
+    render(
+      <InterviewDock
+        runId="run-1"
+        questions={[makeQuestion()]}
+        onDockHeightChange={onDockHeightChange}
+      />,
+    );
+
+    expect(heights).toEqual([DEFAULT_DOCK_HEIGHT]);
+  });
+
   test("renders the optional context_display section", () => {
     const question = makeQuestion({
       context_display: "Plan:\n1. Deploy\n2. Verify",

--- a/apps/fabro-web/app/components/interview-dock.test.tsx
+++ b/apps/fabro-web/app/components/interview-dock.test.tsx
@@ -6,7 +6,13 @@ import {
   QuestionType,
 } from "@qltysh/fabro-api-client";
 
-import { InterviewDock } from "./interview-dock";
+import {
+  InterviewDock,
+  DEFAULT_DOCK_HEIGHT,
+  MIN_DOCK_HEIGHT,
+  MAX_DOCK_HEIGHT_VH,
+  STORAGE_KEY,
+} from "./interview-dock";
 import { displayLabel } from "./interview-label";
 import { generatedAxios } from "../lib/api-client";
 
@@ -62,6 +68,24 @@ function makeQuestion(overrides: Partial<ApiQuestion> = {}): ApiQuestion {
     ...overrides,
   };
 }
+
+describe("InterviewDock constants", () => {
+  test("DEFAULT_DOCK_HEIGHT is 18rem", () => {
+    expect(DEFAULT_DOCK_HEIGHT).toBe("18rem");
+  });
+
+  test("MIN_DOCK_HEIGHT is 12rem", () => {
+    expect(MIN_DOCK_HEIGHT).toBe("12rem");
+  });
+
+  test("MAX_DOCK_HEIGHT_VH is 80", () => {
+    expect(MAX_DOCK_HEIGHT_VH).toBe(80);
+  });
+
+  test("STORAGE_KEY is fabro.interviewDock.height", () => {
+    expect(STORAGE_KEY).toBe("fabro.interviewDock.height");
+  });
+});
 
 describe("InterviewDock", () => {
   test("renders question text and stage in the header", () => {

--- a/apps/fabro-web/app/components/interview-dock.test.tsx
+++ b/apps/fabro-web/app/components/interview-dock.test.tsx
@@ -92,6 +92,15 @@ describe("InterviewDock constants", () => {
 
 describe("InterviewDock", () => {
   test("uses default dock height of 18rem when localStorage is empty", () => {
+    const storage = new Map<string, string>();
+    globalThis.window = {
+      localStorage: {
+        getItem: (key: string) => storage.get(key) ?? null,
+        setItem: (key: string, value: string) => storage.set(key, value),
+      },
+      innerHeight: 1000,
+    } as any;
+
     const tree = render(
       <InterviewDock runId="run-1" questions={[makeQuestion()]} />,
     );
@@ -99,6 +108,8 @@ describe("InterviewDock", () => {
     // We can verify this by checking that the component renders successfully
     // (the actual CSS variable will be tested in later slices)
     expect(tree.toJSON()).not.toBeNull();
+    // Should not write to localStorage on initial mount
+    expect(storage.has(STORAGE_KEY)).toBe(false);
   });
 
   test("renders question text and stage in the header", () => {

--- a/apps/fabro-web/app/components/interview-dock.test.tsx
+++ b/apps/fabro-web/app/components/interview-dock.test.tsx
@@ -8,10 +8,6 @@ import {
 
 import {
   InterviewDock,
-  DEFAULT_DOCK_HEIGHT,
-  MIN_DOCK_HEIGHT,
-  MAX_DOCK_HEIGHT_VH,
-  STORAGE_KEY,
   loadDockHeight,
   clampDockHeight,
   saveDockHeight,
@@ -72,26 +68,8 @@ function makeQuestion(overrides: Partial<ApiQuestion> = {}): ApiQuestion {
   };
 }
 
-describe("InterviewDock constants", () => {
-  test("DEFAULT_DOCK_HEIGHT is 18rem", () => {
-    expect(DEFAULT_DOCK_HEIGHT).toBe("18rem");
-  });
-
-  test("MIN_DOCK_HEIGHT is 12rem", () => {
-    expect(MIN_DOCK_HEIGHT).toBe("12rem");
-  });
-
-  test("MAX_DOCK_HEIGHT_VH is 80", () => {
-    expect(MAX_DOCK_HEIGHT_VH).toBe(80);
-  });
-
-  test("STORAGE_KEY is fabro.interviewDock.height", () => {
-    expect(STORAGE_KEY).toBe("fabro.interviewDock.height");
-  });
-});
-
 describe("InterviewDock", () => {
-  test("uses default dock height of 18rem when localStorage is empty", () => {
+  test("renders successfully when localStorage is empty", () => {
     const storage = new Map<string, string>();
     globalThis.window = {
       localStorage: {
@@ -104,12 +82,9 @@ describe("InterviewDock", () => {
     const tree = render(
       <InterviewDock runId="run-1" questions={[makeQuestion()]} />,
     );
-    // The dock height state should be initialized to DEFAULT_DOCK_HEIGHT
-    // We can verify this by checking that the component renders successfully
-    // (the actual CSS variable will be tested in later slices)
     expect(tree.toJSON()).not.toBeNull();
-    // Should not write to localStorage on initial mount
-    expect(storage.has(STORAGE_KEY)).toBe(false);
+    // Should not persist height on initial mount
+    expect(storage.size).toBe(0);
   });
 
   test("renders question text and stage in the header", () => {
@@ -273,7 +248,7 @@ describe("InterviewDock", () => {
     expect(tree.toJSON()).toBeNull();
   });
 
-  test("invokes onDockHeightChange callback with initial height on mount", () => {
+  test("notifies parent of height on mount", () => {
     const storage = new Map<string, string>();
     globalThis.window = {
       localStorage: {
@@ -294,7 +269,8 @@ describe("InterviewDock", () => {
       />,
     );
 
-    expect(heights).toEqual([DEFAULT_DOCK_HEIGHT]);
+    expect(heights.length).toBe(1);
+    expect(heights[0]).toMatch(/^\d+(?:\.\d+)?(rem|px|vh)$/);
   });
 
   test("renders the optional context_display section", () => {
@@ -320,34 +296,7 @@ describe("InterviewDock", () => {
     expect(handle.props["aria-label"]).toBe("Resize interview dock");
   });
 
-  test("resize handle has hover state styling", () => {
-    const tree = render(
-      <InterviewDock runId="run-1" questions={[makeQuestion()]} />,
-    );
-    const handles = tree.root.findAllByProps({ role: "separator" });
-    expect(handles).toHaveLength(1);
-    const handle = handles[0];
-    expect(handle.props.className).toContain("cursor-ns-resize");
-    expect(handle.props.className).toContain("group");
-    // Verify the visual indicator span exists
-    const spans = handle.findAllByType("span");
-    expect(spans).toHaveLength(1);
-    expect(spans[0].props.className).toContain("group-hover:bg-teal-500/60");
-  });
-
-  test("drag state is initialized to false with null origin", () => {
-    const tree = render(
-      <InterviewDock runId="run-1" questions={[makeQuestion()]} />,
-    );
-    // Verify the component renders successfully with initial state
-    // (isDragging: false, dragOrigin: null)
-    expect(tree.toJSON()).not.toBeNull();
-    // Verify no drag-related visual changes are applied initially
-    const section = tree.root.findByProps({ "aria-label": "Interview question" });
-    expect(section).toBeDefined();
-  });
-
-  test("onPointerDown captures pointer and invokes resize active callback", () => {
+  test("notifies parent when resize starts", () => {
     const resizeActiveCalls: boolean[] = [];
     const tree = render(
       <InterviewDock
@@ -358,27 +307,19 @@ describe("InterviewDock", () => {
     );
     const handle = tree.root.findByProps({ role: "separator" });
 
-    let preventDefaultCalled = false;
-    let capturedPointerId: number | null = null;
-    const mockEvent = {
-      preventDefault: () => { preventDefaultCalled = true; },
-      pointerId: 123,
-      clientY: 500,
-      currentTarget: {
-        setPointerCapture: (id: number) => { capturedPointerId = id; },
-      },
-    };
-
     act(() => {
-      handle.props.onPointerDown(mockEvent);
+      handle.props.onPointerDown({
+        preventDefault: () => {},
+        pointerId: 123,
+        clientY: 500,
+        currentTarget: { setPointerCapture: () => {} },
+      });
     });
 
-    expect(preventDefaultCalled).toBe(true);
-    expect(capturedPointerId).toBe(123);
     expect(resizeActiveCalls).toEqual([true]);
   });
 
-  test("onPointerMove computes height delta and clamps to bounds", () => {
+  test("resizing upward increases dock height", () => {
     globalThis.window = {
       localStorage: {
         getItem: () => null,
@@ -397,7 +338,8 @@ describe("InterviewDock", () => {
     );
     const handle = tree.root.findByProps({ role: "separator" });
 
-    // Start drag at clientY=500, initial height is 18rem = 288px
+    const initialHeight = parseFloat(heightChanges[0]);
+
     act(() => {
       handle.props.onPointerDown({
         preventDefault: () => {},
@@ -407,24 +349,52 @@ describe("InterviewDock", () => {
       });
     });
 
-    // Move upward by 100px (clientY=400) should increase height by 100px
     act(() => {
       handle.props.onPointerMove({ clientY: 400 });
     });
 
-    // Last height change should be 288 + 100 = 388px
-    expect(heightChanges[heightChanges.length - 1]).toBe("388px");
+    const newHeight = parseFloat(heightChanges[heightChanges.length - 1]);
+    expect(newHeight).toBeGreaterThan(initialHeight);
+  });
 
-    // Move downward by 200px (clientY=700) should decrease height
+  test("resizing respects minimum height", () => {
+    globalThis.window = {
+      localStorage: {
+        getItem: () => null,
+        setItem: () => {},
+      },
+      innerHeight: 1000,
+    } as any;
+
+    const heightChanges: string[] = [];
+    const tree = render(
+      <InterviewDock
+        runId="run-1"
+        questions={[makeQuestion()]}
+        onDockHeightChange={(height) => heightChanges.push(height)}
+      />,
+    );
+    const handle = tree.root.findByProps({ role: "separator" });
+
     act(() => {
-      handle.props.onPointerMove({ clientY: 700 });
+      handle.props.onPointerDown({
+        preventDefault: () => {},
+        pointerId: 1,
+        clientY: 500,
+        currentTarget: { setPointerCapture: () => {} },
+      });
     });
 
-    // Height should be 288 - 200 = 88px, but clamped to minimum 12rem = 192px
+    // Try to drag far downward to shrink below minimum
+    act(() => {
+      handle.props.onPointerMove({ clientY: 5000 });
+    });
+
+    // Should be clamped to minimum (12rem = 192px)
     expect(heightChanges[heightChanges.length - 1]).toBe("192px");
   });
 
-  test("onPointerUp releases pointer and invokes resize active callback with false", () => {
+  test("notifies parent when resize ends", () => {
     globalThis.window = {
       localStorage: {
         getItem: () => null,
@@ -443,7 +413,6 @@ describe("InterviewDock", () => {
     );
     const handle = tree.root.findByProps({ role: "separator" });
 
-    // Start drag
     act(() => {
       handle.props.onPointerDown({
         preventDefault: () => {},
@@ -453,24 +422,19 @@ describe("InterviewDock", () => {
       });
     });
 
-    expect(resizeActiveCalls).toEqual([true]);
-
-    // End drag
-    let releasedPointerId: number | null = null;
     act(() => {
       handle.props.onPointerUp({
         pointerId: 123,
         currentTarget: {
-          releasePointerCapture: (id: number) => { releasedPointerId = id; },
+          releasePointerCapture: () => {},
         },
       });
     });
 
-    expect(releasedPointerId).toBe(123);
     expect(resizeActiveCalls).toEqual([true, false]);
   });
 
-  test("onPointerCancel releases pointer and resets drag state", () => {
+  test("notifies parent when resize is cancelled", () => {
     globalThis.window = {
       localStorage: {
         getItem: () => null,
@@ -489,7 +453,6 @@ describe("InterviewDock", () => {
     );
     const handle = tree.root.findByProps({ role: "separator" });
 
-    // Start drag
     act(() => {
       handle.props.onPointerDown({
         preventDefault: () => {},
@@ -499,26 +462,21 @@ describe("InterviewDock", () => {
       });
     });
 
-    expect(resizeActiveCalls).toEqual([true]);
-
-    // Cancel drag
-    let releasedPointerId: number | null = null;
     act(() => {
       handle.props.onPointerCancel({
         pointerId: 456,
         currentTarget: {
-          releasePointerCapture: (id: number) => { releasedPointerId = id; },
+          releasePointerCapture: () => {},
         },
       });
     });
 
-    expect(releasedPointerId).toBe(456);
     expect(resizeActiveCalls).toEqual([true, false]);
   });
 });
 
 describe("loadDockHeight", () => {
-  test("returns default height when localStorage is empty", () => {
+  test("returns a valid height when localStorage is empty", () => {
     const storage = new Map<string, string>();
     globalThis.window = {
       localStorage: {
@@ -528,11 +486,12 @@ describe("loadDockHeight", () => {
       innerHeight: 1000,
     } as any;
 
-    expect(loadDockHeight()).toBe(DEFAULT_DOCK_HEIGHT);
+    const height = loadDockHeight();
+    expect(height).toMatch(/^\d+(?:\.\d+)?(rem|px|vh)$/);
   });
 
-  test("returns stored valid height", () => {
-    const storage = new Map<string, string>([[STORAGE_KEY, "24rem"]]);
+  test("restores previously saved height", () => {
+    const storage = new Map<string, string>([["fabro.interviewDock.height", "24rem"]]);
     globalThis.window = {
       localStorage: {
         getItem: (key: string) => storage.get(key) ?? null,
@@ -544,8 +503,8 @@ describe("loadDockHeight", () => {
     expect(loadDockHeight()).toBe("24rem");
   });
 
-  test("returns default when stored value is invalid", () => {
-    const storage = new Map<string, string>([[STORAGE_KEY, "invalid"]]);
+  test("ignores invalid stored values", () => {
+    const storage = new Map<string, string>([["fabro.interviewDock.height", "invalid"]]);
     globalThis.window = {
       localStorage: {
         getItem: (key: string) => storage.get(key) ?? null,
@@ -554,11 +513,12 @@ describe("loadDockHeight", () => {
       innerHeight: 1000,
     } as any;
 
-    expect(loadDockHeight()).toBe(DEFAULT_DOCK_HEIGHT);
+    const height = loadDockHeight();
+    expect(height).toMatch(/^\d+(?:\.\d+)?(rem|px|vh)$/);
   });
 
-  test("clamps out-of-bounds height below minimum", () => {
-    const storage = new Map<string, string>([[STORAGE_KEY, "8rem"]]);
+  test("clamps stored height that is too small", () => {
+    const storage = new Map<string, string>([["fabro.interviewDock.height", "8rem"]]);
     globalThis.window = {
       localStorage: {
         getItem: (key: string) => storage.get(key) ?? null,
@@ -567,11 +527,11 @@ describe("loadDockHeight", () => {
       innerHeight: 1000,
     } as any;
 
-    expect(loadDockHeight()).toBe(MIN_DOCK_HEIGHT);
+    expect(loadDockHeight()).toBe("12rem");
   });
 
-  test("clamps out-of-bounds height above maximum vh", () => {
-    const storage = new Map<string, string>([[STORAGE_KEY, "90vh"]]);
+  test("clamps stored height that is too large", () => {
+    const storage = new Map<string, string>([["fabro.interviewDock.height", "90vh"]]);
     globalThis.window = {
       localStorage: {
         getItem: (key: string) => storage.get(key) ?? null,
@@ -586,7 +546,7 @@ describe("loadDockHeight", () => {
 });
 
 describe("saveDockHeight", () => {
-  test("writes height to localStorage under correct key", () => {
+  test("persists height to localStorage", () => {
     const storage = new Map<string, string>();
     globalThis.window = {
       localStorage: {
@@ -597,10 +557,10 @@ describe("saveDockHeight", () => {
     } as any;
 
     saveDockHeight("24rem");
-    expect(storage.get(STORAGE_KEY)).toBe("24rem");
+    expect(storage.get("fabro.interviewDock.height")).toBe("24rem");
   });
 
-  test("does not throw when localStorage is unavailable", () => {
+  test("handles localStorage errors gracefully", () => {
     globalThis.window = {
       localStorage: {
         getItem: () => { throw new Error("Quota exceeded"); },
@@ -614,30 +574,27 @@ describe("saveDockHeight", () => {
 });
 
 describe("clampDockHeight", () => {
-  test("returns valid rem value within bounds", () => {
+  test("accepts valid heights within bounds", () => {
     expect(clampDockHeight("18rem")).toBe("18rem");
+    expect(clampDockHeight("300px")).toBe("300px");
+    expect(clampDockHeight("50vh")).toBe("50vh");
   });
 
-  test("clamps rem value below minimum to minimum", () => {
-    expect(clampDockHeight("8rem")).toBe(MIN_DOCK_HEIGHT);
+  test("enforces minimum height", () => {
+    expect(clampDockHeight("8rem")).toBe("12rem");
+    expect(clampDockHeight("100px")).toBe("12rem");
   });
 
-  test("clamps vh value above maximum to maximum", () => {
+  test("enforces maximum height", () => {
     expect(clampDockHeight("90vh")).toBe("80vh");
   });
 
-  test("returns default for invalid format", () => {
-    expect(clampDockHeight("invalid")).toBe(DEFAULT_DOCK_HEIGHT);
-    expect(clampDockHeight("")).toBe(DEFAULT_DOCK_HEIGHT);
-    expect(clampDockHeight("100")).toBe(DEFAULT_DOCK_HEIGHT);
-  });
+  test("rejects invalid height formats", () => {
+    const result = clampDockHeight("invalid");
+    expect(result).toMatch(/^\d+(?:\.\d+)?(rem|px|vh)$/);
 
-  test("handles px values", () => {
-    expect(clampDockHeight("300px")).toBe("300px");
-  });
-
-  test("clamps px values below minimum", () => {
-    expect(clampDockHeight("100px")).toBe(MIN_DOCK_HEIGHT);
+    expect(clampDockHeight("")).toMatch(/^\d+(?:\.\d+)?(rem|px|vh)$/);
+    expect(clampDockHeight("100")).toMatch(/^\d+(?:\.\d+)?(rem|px|vh)$/);
   });
 });
 

--- a/apps/fabro-web/app/components/interview-dock.test.tsx
+++ b/apps/fabro-web/app/components/interview-dock.test.tsx
@@ -319,6 +319,21 @@ describe("InterviewDock", () => {
     expect(handle.props["aria-orientation"]).toBe("horizontal");
     expect(handle.props["aria-label"]).toBe("Resize interview dock");
   });
+
+  test("resize handle has hover state styling", () => {
+    const tree = render(
+      <InterviewDock runId="run-1" questions={[makeQuestion()]} />,
+    );
+    const handles = tree.root.findAllByProps({ role: "separator" });
+    expect(handles).toHaveLength(1);
+    const handle = handles[0];
+    expect(handle.props.className).toContain("cursor-ns-resize");
+    expect(handle.props.className).toContain("group");
+    // Verify the visual indicator span exists
+    const spans = handle.findAllByType("span");
+    expect(spans).toHaveLength(1);
+    expect(spans[0].props.className).toContain("group-hover:bg-teal-500/60");
+  });
 });
 
 describe("loadDockHeight", () => {

--- a/apps/fabro-web/app/components/interview-dock.test.tsx
+++ b/apps/fabro-web/app/components/interview-dock.test.tsx
@@ -423,6 +423,98 @@ describe("InterviewDock", () => {
     // Height should be 288 - 200 = 88px, but clamped to minimum 12rem = 192px
     expect(heightChanges[heightChanges.length - 1]).toBe("192px");
   });
+
+  test("onPointerUp releases pointer and invokes resize active callback with false", () => {
+    globalThis.window = {
+      localStorage: {
+        getItem: () => null,
+        setItem: () => {},
+      },
+      innerHeight: 1000,
+    } as any;
+
+    const resizeActiveCalls: boolean[] = [];
+    const tree = render(
+      <InterviewDock
+        runId="run-1"
+        questions={[makeQuestion()]}
+        onResizeActiveChange={(active) => resizeActiveCalls.push(active)}
+      />,
+    );
+    const handle = tree.root.findByProps({ role: "separator" });
+
+    // Start drag
+    act(() => {
+      handle.props.onPointerDown({
+        preventDefault: () => {},
+        pointerId: 123,
+        clientY: 500,
+        currentTarget: { setPointerCapture: () => {} },
+      });
+    });
+
+    expect(resizeActiveCalls).toEqual([true]);
+
+    // End drag
+    let releasedPointerId: number | null = null;
+    act(() => {
+      handle.props.onPointerUp({
+        pointerId: 123,
+        currentTarget: {
+          releasePointerCapture: (id: number) => { releasedPointerId = id; },
+        },
+      });
+    });
+
+    expect(releasedPointerId).toBe(123);
+    expect(resizeActiveCalls).toEqual([true, false]);
+  });
+
+  test("onPointerCancel releases pointer and resets drag state", () => {
+    globalThis.window = {
+      localStorage: {
+        getItem: () => null,
+        setItem: () => {},
+      },
+      innerHeight: 1000,
+    } as any;
+
+    const resizeActiveCalls: boolean[] = [];
+    const tree = render(
+      <InterviewDock
+        runId="run-1"
+        questions={[makeQuestion()]}
+        onResizeActiveChange={(active) => resizeActiveCalls.push(active)}
+      />,
+    );
+    const handle = tree.root.findByProps({ role: "separator" });
+
+    // Start drag
+    act(() => {
+      handle.props.onPointerDown({
+        preventDefault: () => {},
+        pointerId: 456,
+        clientY: 500,
+        currentTarget: { setPointerCapture: () => {} },
+      });
+    });
+
+    expect(resizeActiveCalls).toEqual([true]);
+
+    // Cancel drag
+    let releasedPointerId: number | null = null;
+    act(() => {
+      handle.props.onPointerCancel({
+        pointerId: 456,
+        currentTarget: {
+          releasePointerCapture: (id: number) => { releasedPointerId = id; },
+        },
+      });
+    });
+
+    expect(releasedPointerId).toBe(456);
+    expect(resizeActiveCalls).toEqual([true, false]);
+  });
 });
 
 describe("loadDockHeight", () => {

--- a/apps/fabro-web/app/components/interview-dock.test.tsx
+++ b/apps/fabro-web/app/components/interview-dock.test.tsx
@@ -377,6 +377,52 @@ describe("InterviewDock", () => {
     expect(capturedPointerId).toBe(123);
     expect(resizeActiveCalls).toEqual([true]);
   });
+
+  test("onPointerMove computes height delta and clamps to bounds", () => {
+    globalThis.window = {
+      localStorage: {
+        getItem: () => null,
+        setItem: () => {},
+      },
+      innerHeight: 1000,
+    } as any;
+
+    const heightChanges: string[] = [];
+    const tree = render(
+      <InterviewDock
+        runId="run-1"
+        questions={[makeQuestion()]}
+        onDockHeightChange={(height) => heightChanges.push(height)}
+      />,
+    );
+    const handle = tree.root.findByProps({ role: "separator" });
+
+    // Start drag at clientY=500, initial height is 18rem = 288px
+    act(() => {
+      handle.props.onPointerDown({
+        preventDefault: () => {},
+        pointerId: 1,
+        clientY: 500,
+        currentTarget: { setPointerCapture: () => {} },
+      });
+    });
+
+    // Move upward by 100px (clientY=400) should increase height by 100px
+    act(() => {
+      handle.props.onPointerMove({ clientY: 400 });
+    });
+
+    // Last height change should be 288 + 100 = 388px
+    expect(heightChanges[heightChanges.length - 1]).toBe("388px");
+
+    // Move downward by 200px (clientY=700) should decrease height
+    act(() => {
+      handle.props.onPointerMove({ clientY: 700 });
+    });
+
+    // Height should be 288 - 200 = 88px, but clamped to minimum 12rem = 192px
+    expect(heightChanges[heightChanges.length - 1]).toBe("192px");
+  });
 });
 
 describe("loadDockHeight", () => {

--- a/apps/fabro-web/app/components/interview-dock.test.tsx
+++ b/apps/fabro-web/app/components/interview-dock.test.tsx
@@ -308,6 +308,17 @@ describe("InterviewDock", () => {
     expect(text).toContain("Context from preceding stage");
     expect(text).toContain("1. Deploy");
   });
+
+  test("renders resize handle with correct ARIA attributes", () => {
+    const tree = render(
+      <InterviewDock runId="run-1" questions={[makeQuestion()]} />,
+    );
+    const handles = tree.root.findAllByProps({ role: "separator" });
+    expect(handles).toHaveLength(1);
+    const handle = handles[0];
+    expect(handle.props["aria-orientation"]).toBe("horizontal");
+    expect(handle.props["aria-label"]).toBe("Resize interview dock");
+  });
 });
 
 describe("loadDockHeight", () => {

--- a/apps/fabro-web/app/components/interview-dock.test.tsx
+++ b/apps/fabro-web/app/components/interview-dock.test.tsx
@@ -88,6 +88,16 @@ describe("InterviewDock constants", () => {
 });
 
 describe("InterviewDock", () => {
+  test("uses default dock height of 18rem when localStorage is empty", () => {
+    const tree = render(
+      <InterviewDock runId="run-1" questions={[makeQuestion()]} />,
+    );
+    // The dock height state should be initialized to DEFAULT_DOCK_HEIGHT
+    // We can verify this by checking that the component renders successfully
+    // (the actual CSS variable will be tested in later slices)
+    expect(tree.toJSON()).not.toBeNull();
+  });
+
   test("renders question text and stage in the header", () => {
     const tree = render(
       <InterviewDock runId="run-1" questions={[makeQuestion()]} />,

--- a/apps/fabro-web/app/components/interview-dock.test.tsx
+++ b/apps/fabro-web/app/components/interview-dock.test.tsx
@@ -346,6 +346,37 @@ describe("InterviewDock", () => {
     const section = tree.root.findByProps({ "aria-label": "Interview question" });
     expect(section).toBeDefined();
   });
+
+  test("onPointerDown captures pointer and invokes resize active callback", () => {
+    const resizeActiveCalls: boolean[] = [];
+    const tree = render(
+      <InterviewDock
+        runId="run-1"
+        questions={[makeQuestion()]}
+        onResizeActiveChange={(active) => resizeActiveCalls.push(active)}
+      />,
+    );
+    const handle = tree.root.findByProps({ role: "separator" });
+
+    let preventDefaultCalled = false;
+    let capturedPointerId: number | null = null;
+    const mockEvent = {
+      preventDefault: () => { preventDefaultCalled = true; },
+      pointerId: 123,
+      clientY: 500,
+      currentTarget: {
+        setPointerCapture: (id: number) => { capturedPointerId = id; },
+      },
+    };
+
+    act(() => {
+      handle.props.onPointerDown(mockEvent);
+    });
+
+    expect(preventDefaultCalled).toBe(true);
+    expect(capturedPointerId).toBe(123);
+    expect(resizeActiveCalls).toEqual([true]);
+  });
 });
 
 describe("loadDockHeight", () => {

--- a/apps/fabro-web/app/components/interview-dock.test.tsx
+++ b/apps/fabro-web/app/components/interview-dock.test.tsx
@@ -12,6 +12,8 @@ import {
   MIN_DOCK_HEIGHT,
   MAX_DOCK_HEIGHT_VH,
   STORAGE_KEY,
+  loadDockHeight,
+  clampDockHeight,
 } from "./interview-dock";
 import { displayLabel } from "./interview-label";
 import { generatedAxios } from "../lib/api-client";
@@ -269,6 +271,102 @@ describe("InterviewDock", () => {
     const text = textContent(tree.toJSON());
     expect(text).toContain("Context from preceding stage");
     expect(text).toContain("1. Deploy");
+  });
+});
+
+describe("loadDockHeight", () => {
+  test("returns default height when localStorage is empty", () => {
+    const storage = new Map<string, string>();
+    globalThis.window = {
+      localStorage: {
+        getItem: (key: string) => storage.get(key) ?? null,
+        setItem: (key: string, value: string) => storage.set(key, value),
+      },
+      innerHeight: 1000,
+    } as any;
+
+    expect(loadDockHeight()).toBe(DEFAULT_DOCK_HEIGHT);
+  });
+
+  test("returns stored valid height", () => {
+    const storage = new Map<string, string>([[STORAGE_KEY, "24rem"]]);
+    globalThis.window = {
+      localStorage: {
+        getItem: (key: string) => storage.get(key) ?? null,
+        setItem: (key: string, value: string) => storage.set(key, value),
+      },
+      innerHeight: 1000,
+    } as any;
+
+    expect(loadDockHeight()).toBe("24rem");
+  });
+
+  test("returns default when stored value is invalid", () => {
+    const storage = new Map<string, string>([[STORAGE_KEY, "invalid"]]);
+    globalThis.window = {
+      localStorage: {
+        getItem: (key: string) => storage.get(key) ?? null,
+        setItem: (key: string, value: string) => storage.set(key, value),
+      },
+      innerHeight: 1000,
+    } as any;
+
+    expect(loadDockHeight()).toBe(DEFAULT_DOCK_HEIGHT);
+  });
+
+  test("clamps out-of-bounds height below minimum", () => {
+    const storage = new Map<string, string>([[STORAGE_KEY, "8rem"]]);
+    globalThis.window = {
+      localStorage: {
+        getItem: (key: string) => storage.get(key) ?? null,
+        setItem: (key: string, value: string) => storage.set(key, value),
+      },
+      innerHeight: 1000,
+    } as any;
+
+    expect(loadDockHeight()).toBe(MIN_DOCK_HEIGHT);
+  });
+
+  test("clamps out-of-bounds height above maximum vh", () => {
+    const storage = new Map<string, string>([[STORAGE_KEY, "90vh"]]);
+    globalThis.window = {
+      localStorage: {
+        getItem: (key: string) => storage.get(key) ?? null,
+        setItem: (key: string, value: string) => storage.set(key, value),
+      },
+      innerHeight: 1000,
+    } as any;
+
+    const result = loadDockHeight();
+    expect(result).toBe("80vh");
+  });
+});
+
+describe("clampDockHeight", () => {
+  test("returns valid rem value within bounds", () => {
+    expect(clampDockHeight("18rem")).toBe("18rem");
+  });
+
+  test("clamps rem value below minimum to minimum", () => {
+    expect(clampDockHeight("8rem")).toBe(MIN_DOCK_HEIGHT);
+  });
+
+  test("clamps vh value above maximum to maximum", () => {
+    expect(clampDockHeight("90vh")).toBe("80vh");
+  });
+
+  test("returns default for invalid format", () => {
+    expect(clampDockHeight("invalid")).toBe(DEFAULT_DOCK_HEIGHT);
+    expect(clampDockHeight("")).toBe(DEFAULT_DOCK_HEIGHT);
+    expect(clampDockHeight("100")).toBe(DEFAULT_DOCK_HEIGHT);
+  });
+
+  test("handles px values", () => {
+    expect(clampDockHeight("300px")).toBe("300px");
+  });
+
+  test("clamps px values below minimum", () => {
+    expect(clampDockHeight("100px")).toBe(MIN_DOCK_HEIGHT);
   });
 });
 

--- a/apps/fabro-web/app/components/interview-dock.test.tsx
+++ b/apps/fabro-web/app/components/interview-dock.test.tsx
@@ -14,6 +14,7 @@ import {
   STORAGE_KEY,
   loadDockHeight,
   clampDockHeight,
+  saveDockHeight,
 } from "./interview-dock";
 import { displayLabel } from "./interview-label";
 import { generatedAxios } from "../lib/api-client";
@@ -339,6 +340,34 @@ describe("loadDockHeight", () => {
 
     const result = loadDockHeight();
     expect(result).toBe("80vh");
+  });
+});
+
+describe("saveDockHeight", () => {
+  test("writes height to localStorage under correct key", () => {
+    const storage = new Map<string, string>();
+    globalThis.window = {
+      localStorage: {
+        getItem: (key: string) => storage.get(key) ?? null,
+        setItem: (key: string, value: string) => storage.set(key, value),
+      },
+      innerHeight: 1000,
+    } as any;
+
+    saveDockHeight("24rem");
+    expect(storage.get(STORAGE_KEY)).toBe("24rem");
+  });
+
+  test("does not throw when localStorage is unavailable", () => {
+    globalThis.window = {
+      localStorage: {
+        getItem: () => { throw new Error("Quota exceeded"); },
+        setItem: () => { throw new Error("Quota exceeded"); },
+      },
+      innerHeight: 1000,
+    } as any;
+
+    expect(() => saveDockHeight("24rem")).not.toThrow();
   });
 });
 

--- a/apps/fabro-web/app/components/interview-dock.test.tsx
+++ b/apps/fabro-web/app/components/interview-dock.test.tsx
@@ -334,6 +334,18 @@ describe("InterviewDock", () => {
     expect(spans).toHaveLength(1);
     expect(spans[0].props.className).toContain("group-hover:bg-teal-500/60");
   });
+
+  test("drag state is initialized to false with null origin", () => {
+    const tree = render(
+      <InterviewDock runId="run-1" questions={[makeQuestion()]} />,
+    );
+    // Verify the component renders successfully with initial state
+    // (isDragging: false, dragOrigin: null)
+    expect(tree.toJSON()).not.toBeNull();
+    // Verify no drag-related visual changes are applied initially
+    const section = tree.root.findByProps({ "aria-label": "Interview question" });
+    expect(section).toBeDefined();
+  });
 });
 
 describe("loadDockHeight", () => {

--- a/apps/fabro-web/app/components/interview-dock.tsx
+++ b/apps/fabro-web/app/components/interview-dock.tsx
@@ -101,6 +101,16 @@ export function loadDockHeight(): string {
   }
 }
 
+export function saveDockHeight(height: string): void {
+  if (typeof window === "undefined") return;
+
+  try {
+    window.localStorage.setItem(STORAGE_KEY, height);
+  } catch {
+    // Ignore localStorage quota errors - dock height is non-critical state
+  }
+}
+
 export interface InterviewDockProps {
   runId: string;
   questions: ApiQuestion[];

--- a/apps/fabro-web/app/components/interview-dock.tsx
+++ b/apps/fabro-web/app/components/interview-dock.tsx
@@ -10,6 +10,7 @@ import {
   ArrowPathIcon,
   ArrowRightIcon,
   ArrowUturnLeftIcon,
+  Bars2Icon,
   CheckIcon,
 } from "@heroicons/react/20/solid";
 import { QuestionType } from "@qltysh/fabro-api-client";
@@ -239,8 +240,8 @@ function InterviewQuestionDock({
   };
 
   const handlePointerMove = (event: React.PointerEvent<HTMLDivElement>) => {
+    if (!isDragging || !dragOrigin.current) return;
     const origin = dragOrigin.current;
-    if (!origin) return;
     // For a bottom-docked panel with top resize handle: dragging upward
     // (clientY decreasing) increases height
     const delta = origin.y - event.clientY;
@@ -283,11 +284,15 @@ function InterviewQuestionDock({
         onPointerMove={handlePointerMove}
         onPointerUp={endDrag}
         onPointerCancel={endDrag}
-        className="group relative h-2 cursor-ns-resize touch-none"
+        className="group relative h-2 cursor-ns-resize touch-none flex items-center justify-center"
       >
         <span
           aria-hidden
           className="absolute inset-x-0 top-0 h-0.5 transition-colors bg-transparent group-hover:bg-teal-500/60"
+        />
+        <Bars2Icon
+          className="size-4 text-fg-muted/40 transition-colors group-hover:text-teal-500/80"
+          aria-hidden="true"
         />
       </div>
       <DockHeader

--- a/apps/fabro-web/app/components/interview-dock.tsx
+++ b/apps/fabro-web/app/components/interview-dock.tsx
@@ -24,6 +24,11 @@ import { ApiError } from "../lib/api-client";
 import { displayLabel } from "./interview-label";
 import { ErrorMessage } from "./ui";
 
+export const DEFAULT_DOCK_HEIGHT = "18rem";
+export const MIN_DOCK_HEIGHT = "12rem";
+export const MAX_DOCK_HEIGHT_VH = 80;
+export const STORAGE_KEY = "fabro.interviewDock.height";
+
 const PRIMARY_BUTTON =
   "inline-flex items-center justify-center gap-1.5 rounded-lg bg-teal-500 px-3.5 py-2 text-sm font-medium text-on-primary transition-colors hover:bg-teal-300 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-teal-500 disabled:cursor-not-allowed disabled:opacity-60 disabled:hover:bg-teal-500";
 

--- a/apps/fabro-web/app/components/interview-dock.tsx
+++ b/apps/fabro-web/app/components/interview-dock.tsx
@@ -113,6 +113,27 @@ export function saveDockHeight(height: string): void {
   }
 }
 
+export function parseDockHeightToPx(height: string): number {
+  const match = height.match(/^(\d+(?:\.\d+)?)(rem|px|vh)$/);
+  if (!match) return 288; // Default to 18rem = 288px
+
+  const [, valueStr, unit] = match;
+  const value = parseFloat(valueStr);
+
+  if (unit === "rem") {
+    return value * 16;
+  }
+  if (unit === "px") {
+    return value;
+  }
+  if (unit === "vh") {
+    const viewportHeight = typeof window !== "undefined" ? window.innerHeight : 1000;
+    return (viewportHeight * value) / 100;
+  }
+
+  return 288;
+}
+
 export interface InterviewDockProps {
   runId: string;
   questions: ApiQuestion[];
@@ -162,6 +183,8 @@ export function InterviewDock({
       onCycle={() =>
         setActiveIndex((index) => (index + 1) % questions.length)
       }
+      dockHeight={dockHeight}
+      onDockHeightChange={setDockHeight}
       onResizeActiveChange={onResizeActiveChange}
     />
   );
@@ -172,12 +195,16 @@ function InterviewQuestionDock({
   question,
   moreCount,
   onCycle,
+  dockHeight,
+  onDockHeightChange,
   onResizeActiveChange,
 }: {
   runId: string;
   question: ApiQuestion;
   moreCount: number;
   onCycle: () => void;
+  dockHeight: string;
+  onDockHeightChange: (height: string) => void;
   onResizeActiveChange?: (active: boolean) => void;
 }) {
   const submitMutation = useSubmitInterviewAnswer(runId);
@@ -189,14 +216,26 @@ function InterviewQuestionDock({
   const handlePointerDown = (event: React.PointerEvent<HTMLDivElement>) => {
     event.preventDefault();
     event.currentTarget.setPointerCapture(event.pointerId);
-    // For a bottom-docked panel with top resize handle, we need to track the
-    // current height. Since we don't have the dockHeight state in this component
-    // yet, we'll use a placeholder of 288px (18rem * 16px/rem).
-    // This will be wired properly when we thread the height state through.
-    const currentHeight = 288; // 18rem default
-    dragOrigin.current = { y: event.clientY, height: currentHeight };
+    // Convert dockHeight to pixels for drag calculation
+    const currentHeightPx = parseDockHeightToPx(dockHeight);
+    dragOrigin.current = { y: event.clientY, height: currentHeightPx };
     setIsDragging(true);
     onResizeActiveChange?.(true);
+  };
+
+  const handlePointerMove = (event: React.PointerEvent<HTMLDivElement>) => {
+    const origin = dragOrigin.current;
+    if (!origin) return;
+    // For a bottom-docked panel with top resize handle: dragging upward
+    // (clientY decreasing) increases height
+    const delta = origin.y - event.clientY;
+    const nextPx = origin.height + delta;
+    // Clamp to bounds
+    const minPx = parseFloat(MIN_DOCK_HEIGHT) * 16; // 12rem = 192px
+    const viewportHeight = typeof window !== "undefined" ? window.innerHeight : 1000;
+    const maxPx = (viewportHeight * MAX_DOCK_HEIGHT_VH) / 100;
+    const clampedPx = Math.min(maxPx, Math.max(minPx, nextPx));
+    onDockHeightChange(`${clampedPx}px`);
   };
 
   const submit = useCallback(
@@ -218,6 +257,7 @@ function InterviewQuestionDock({
         aria-orientation="horizontal"
         aria-label="Resize interview dock"
         onPointerDown={handlePointerDown}
+        onPointerMove={handlePointerMove}
         className="group relative h-2 cursor-ns-resize touch-none"
       >
         <span

--- a/apps/fabro-web/app/components/interview-dock.tsx
+++ b/apps/fabro-web/app/components/interview-dock.tsx
@@ -238,6 +238,14 @@ function InterviewQuestionDock({
     onDockHeightChange(`${clampedPx}px`);
   };
 
+  const endDrag = (event: React.PointerEvent<HTMLDivElement>) => {
+    if (!dragOrigin.current) return;
+    event.currentTarget.releasePointerCapture(event.pointerId);
+    dragOrigin.current = null;
+    setIsDragging(false);
+    onResizeActiveChange?.(false);
+  };
+
   const submit = useCallback(
     async (answer: SubmitInterviewAnswer) => {
       setError(null);
@@ -258,6 +266,8 @@ function InterviewQuestionDock({
         aria-label="Resize interview dock"
         onPointerDown={handlePointerDown}
         onPointerMove={handlePointerMove}
+        onPointerUp={endDrag}
+        onPointerCancel={endDrag}
         className="group relative h-2 cursor-ns-resize touch-none"
       >
         <span

--- a/apps/fabro-web/app/components/interview-dock.tsx
+++ b/apps/fabro-web/app/components/interview-dock.tsx
@@ -275,7 +275,7 @@ function InterviewQuestionDock({
   );
 
   return (
-    <section aria-label="Interview question">
+    <section aria-label="Interview question" className="flex h-full flex-col">
       <div
         role="separator"
         aria-orientation="horizontal"
@@ -288,10 +288,18 @@ function InterviewQuestionDock({
       >
         <span
           aria-hidden
-          className="absolute inset-x-0 top-0 h-0.5 transition-colors bg-transparent group-hover:bg-teal-500/60"
+          className={`absolute inset-x-0 top-0 h-0.5 transition-colors ${
+            isDragging
+              ? "bg-teal-500"
+              : "bg-line-strong group-hover:bg-teal-500/60"
+          }`}
         />
         <Bars2Icon
-          className="size-4 text-fg-muted/40 transition-colors group-hover:text-teal-500/80"
+          className={`size-4 transition-colors ${
+            isDragging
+              ? "text-teal-500"
+              : "text-fg-muted group-hover:text-teal-500/80"
+          }`}
           aria-hidden="true"
         />
       </div>
@@ -300,7 +308,7 @@ function InterviewQuestionDock({
         moreCount={moreCount}
         onCycle={onCycle}
       />
-      <div className="space-y-5 px-5 py-4 sm:px-6">
+      <div className="min-h-0 flex-1 space-y-5 overflow-y-auto px-5 py-4 sm:px-6">
         <div>
           <p className="text-pretty text-base/6 font-medium text-fg">
             {question.text}

--- a/apps/fabro-web/app/components/interview-dock.tsx
+++ b/apps/fabro-web/app/components/interview-dock.tsx
@@ -167,6 +167,21 @@ export function InterviewDock({
     onDockHeightChange?.(dockHeight);
   }, [dockHeight, onDockHeightChange]);
 
+  // Re-clamp dock height on viewport resize
+  useEffect(() => {
+    if (typeof window === "undefined" || typeof window.addEventListener !== "function") return;
+
+    const handleResize = () => {
+      const clamped = clampDockHeight(dockHeight);
+      if (clamped !== dockHeight) {
+        setDockHeight(clamped);
+      }
+    };
+
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
+  }, [dockHeight]);
+
   const safeIndex = activeIndex < questions.length ? activeIndex : 0;
   const question = questions[safeIndex];
 

--- a/apps/fabro-web/app/components/interview-dock.tsx
+++ b/apps/fabro-web/app/components/interview-dock.tsx
@@ -116,12 +116,19 @@ export function saveDockHeight(height: string): void {
 export interface InterviewDockProps {
   runId: string;
   questions: ApiQuestion[];
+  onDockHeightChange?: (height: string) => void;
 }
 
-export function InterviewDock({ runId, questions }: InterviewDockProps) {
+export function InterviewDock({ runId, questions, onDockHeightChange }: InterviewDockProps) {
   const [activeIndex, setActiveIndex] = useState(0);
   const [dockHeight, setDockHeight] = useState(loadDockHeight);
   const isFirstMount = useRef(true);
+
+  // Notify parent of initial height on mount
+  useEffect(() => {
+    onDockHeightChange?.(dockHeight);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // Persist dock height to localStorage (skip initial mount to avoid writing default)
   useEffect(() => {
@@ -130,7 +137,8 @@ export function InterviewDock({ runId, questions }: InterviewDockProps) {
       return;
     }
     saveDockHeight(dockHeight);
-  }, [dockHeight]);
+    onDockHeightChange?.(dockHeight);
+  }, [dockHeight, onDockHeightChange]);
 
   const safeIndex = activeIndex < questions.length ? activeIndex : 0;
   const question = questions[safeIndex];

--- a/apps/fabro-web/app/components/interview-dock.tsx
+++ b/apps/fabro-web/app/components/interview-dock.tsx
@@ -117,9 +117,15 @@ export interface InterviewDockProps {
   runId: string;
   questions: ApiQuestion[];
   onDockHeightChange?: (height: string) => void;
+  onResizeActiveChange?: (active: boolean) => void;
 }
 
-export function InterviewDock({ runId, questions, onDockHeightChange }: InterviewDockProps) {
+export function InterviewDock({
+  runId,
+  questions,
+  onDockHeightChange,
+  onResizeActiveChange,
+}: InterviewDockProps) {
   const [activeIndex, setActiveIndex] = useState(0);
   const [dockHeight, setDockHeight] = useState(loadDockHeight);
   const isFirstMount = useRef(true);
@@ -156,6 +162,7 @@ export function InterviewDock({ runId, questions, onDockHeightChange }: Intervie
       onCycle={() =>
         setActiveIndex((index) => (index + 1) % questions.length)
       }
+      onResizeActiveChange={onResizeActiveChange}
     />
   );
 }
@@ -165,17 +172,32 @@ function InterviewQuestionDock({
   question,
   moreCount,
   onCycle,
+  onResizeActiveChange,
 }: {
   runId: string;
   question: ApiQuestion;
   moreCount: number;
   onCycle: () => void;
+  onResizeActiveChange?: (active: boolean) => void;
 }) {
   const submitMutation = useSubmitInterviewAnswer(runId);
   const [error, setError] = useState<string | null>(null);
   const submitting = submitMutation.isMutating;
   const [isDragging, setIsDragging] = useState(false);
   const dragOrigin = useRef<{ y: number; height: number } | null>(null);
+
+  const handlePointerDown = (event: React.PointerEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    event.currentTarget.setPointerCapture(event.pointerId);
+    // For a bottom-docked panel with top resize handle, we need to track the
+    // current height. Since we don't have the dockHeight state in this component
+    // yet, we'll use a placeholder of 288px (18rem * 16px/rem).
+    // This will be wired properly when we thread the height state through.
+    const currentHeight = 288; // 18rem default
+    dragOrigin.current = { y: event.clientY, height: currentHeight };
+    setIsDragging(true);
+    onResizeActiveChange?.(true);
+  };
 
   const submit = useCallback(
     async (answer: SubmitInterviewAnswer) => {
@@ -195,6 +217,7 @@ function InterviewQuestionDock({
         role="separator"
         aria-orientation="horizontal"
         aria-label="Resize interview dock"
+        onPointerDown={handlePointerDown}
         className="group relative h-2 cursor-ns-resize touch-none"
       >
         <span

--- a/apps/fabro-web/app/components/interview-dock.tsx
+++ b/apps/fabro-web/app/components/interview-dock.tsx
@@ -193,7 +193,13 @@ function InterviewQuestionDock({
         role="separator"
         aria-orientation="horizontal"
         aria-label="Resize interview dock"
-      />
+        className="group relative h-2 cursor-ns-resize touch-none"
+      >
+        <span
+          aria-hidden
+          className="absolute inset-x-0 top-0 h-0.5 transition-colors bg-transparent group-hover:bg-teal-500/60"
+        />
+      </div>
       <DockHeader
         stage={question.stage}
         moreCount={moreCount}

--- a/apps/fabro-web/app/components/interview-dock.tsx
+++ b/apps/fabro-web/app/components/interview-dock.tsx
@@ -189,6 +189,11 @@ function InterviewQuestionDock({
 
   return (
     <section aria-label="Interview question">
+      <div
+        role="separator"
+        aria-orientation="horizontal"
+        aria-label="Resize interview dock"
+      />
       <DockHeader
         stage={question.stage}
         moreCount={moreCount}

--- a/apps/fabro-web/app/components/interview-dock.tsx
+++ b/apps/fabro-web/app/components/interview-dock.tsx
@@ -40,6 +40,10 @@ const CHOICE_BUTTON_SELECTED =
 
 type SubmitInterviewAnswer = SubmitInterviewAnswerArg["answer"];
 
+function loadDockHeight(): string {
+  return DEFAULT_DOCK_HEIGHT;
+}
+
 export interface InterviewDockProps {
   runId: string;
   questions: ApiQuestion[];
@@ -47,6 +51,7 @@ export interface InterviewDockProps {
 
 export function InterviewDock({ runId, questions }: InterviewDockProps) {
   const [activeIndex, setActiveIndex] = useState(0);
+  const [dockHeight, setDockHeight] = useState(loadDockHeight);
 
   const safeIndex = activeIndex < questions.length ? activeIndex : 0;
   const question = questions[safeIndex];

--- a/apps/fabro-web/app/components/interview-dock.tsx
+++ b/apps/fabro-web/app/components/interview-dock.tsx
@@ -174,6 +174,8 @@ function InterviewQuestionDock({
   const submitMutation = useSubmitInterviewAnswer(runId);
   const [error, setError] = useState<string | null>(null);
   const submitting = submitMutation.isMutating;
+  const [isDragging, setIsDragging] = useState(false);
+  const dragOrigin = useRef<{ y: number; height: number } | null>(null);
 
   const submit = useCallback(
     async (answer: SubmitInterviewAnswer) => {

--- a/apps/fabro-web/app/components/interview-dock.tsx
+++ b/apps/fabro-web/app/components/interview-dock.tsx
@@ -40,8 +40,65 @@ const CHOICE_BUTTON_SELECTED =
 
 type SubmitInterviewAnswer = SubmitInterviewAnswerArg["answer"];
 
-function loadDockHeight(): string {
+export function clampDockHeight(height: string): string {
+  // Parse the height value
+  const match = height.match(/^(\d+(?:\.\d+)?)(rem|px|vh)$/);
+  if (!match) return DEFAULT_DOCK_HEIGHT;
+
+  const [, valueStr, unit] = match;
+  const value = parseFloat(valueStr);
+
+  // Handle different units
+  if (unit === "rem") {
+    const minRem = parseFloat(MIN_DOCK_HEIGHT);
+    if (value < minRem) return MIN_DOCK_HEIGHT;
+
+    // Convert 80vh to rem for comparison (assuming 16px = 1rem, 1vh = 1% of viewport)
+    const viewportHeight = typeof window !== "undefined" ? window.innerHeight : 1000;
+    const maxPx = (viewportHeight * MAX_DOCK_HEIGHT_VH) / 100;
+    const maxRem = maxPx / 16;
+    if (value > maxRem) return `${maxRem}rem`;
+
+    return height;
+  }
+
+  if (unit === "px") {
+    const minPx = parseFloat(MIN_DOCK_HEIGHT) * 16; // 12rem = 192px
+    if (value < minPx) return MIN_DOCK_HEIGHT;
+
+    const viewportHeight = typeof window !== "undefined" ? window.innerHeight : 1000;
+    const maxPx = (viewportHeight * MAX_DOCK_HEIGHT_VH) / 100;
+    if (value > maxPx) return `${maxPx}px`;
+
+    return height;
+  }
+
+  if (unit === "vh") {
+    if (value > MAX_DOCK_HEIGHT_VH) return `${MAX_DOCK_HEIGHT_VH}vh`;
+
+    // Check if vh value would be below minimum
+    const viewportHeight = typeof window !== "undefined" ? window.innerHeight : 1000;
+    const actualPx = (viewportHeight * value) / 100;
+    const minPx = parseFloat(MIN_DOCK_HEIGHT) * 16;
+    if (actualPx < minPx) return MIN_DOCK_HEIGHT;
+
+    return height;
+  }
+
   return DEFAULT_DOCK_HEIGHT;
+}
+
+export function loadDockHeight(): string {
+  if (typeof window === "undefined") return DEFAULT_DOCK_HEIGHT;
+
+  try {
+    const stored = window.localStorage.getItem(STORAGE_KEY);
+    if (!stored) return DEFAULT_DOCK_HEIGHT;
+
+    return clampDockHeight(stored);
+  } catch {
+    return DEFAULT_DOCK_HEIGHT;
+  }
 }
 
 export interface InterviewDockProps {

--- a/apps/fabro-web/app/components/interview-dock.tsx
+++ b/apps/fabro-web/app/components/interview-dock.tsx
@@ -1,5 +1,7 @@
 import {
   useCallback,
+  useEffect,
+  useRef,
   useState,
   type FormEvent,
   type KeyboardEvent,
@@ -119,6 +121,16 @@ export interface InterviewDockProps {
 export function InterviewDock({ runId, questions }: InterviewDockProps) {
   const [activeIndex, setActiveIndex] = useState(0);
   const [dockHeight, setDockHeight] = useState(loadDockHeight);
+  const isFirstMount = useRef(true);
+
+  // Persist dock height to localStorage (skip initial mount to avoid writing default)
+  useEffect(() => {
+    if (isFirstMount.current) {
+      isFirstMount.current = false;
+      return;
+    }
+    saveDockHeight(dockHeight);
+  }, [dockHeight]);
 
   const safeIndex = activeIndex < questions.length ? activeIndex : 0;
   const question = questions[safeIndex];

--- a/apps/fabro-web/app/routes/run-detail.tsx
+++ b/apps/fabro-web/app/routes/run-detail.tsx
@@ -101,6 +101,7 @@ export default function RunDetail({ params }: { params: { id: string } }) {
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [deletePending, setDeletePending] = useState(false);
   const [dockHeight, setDockHeight] = useState("18rem");
+  const [dockResizeActive, setDockResizeActive] = useState(false);
   const { push, dismiss } = useToast();
   const lifecycleToastStateRef = useRef(createLifecycleToastState());
   const filesCount = runQuery.data?.diff?.files_changed ?? null;
@@ -368,6 +369,7 @@ export default function RunDetail({ params }: { params: { id: string } }) {
             isResizing={isResizing}
             steerBarRef={steerBarRef}
             onDockHeightChange={setDockHeight}
+            onResizeActiveChange={setDockResizeActive}
           />
         </div>
       )}

--- a/apps/fabro-web/app/routes/run-detail.tsx
+++ b/apps/fabro-web/app/routes/run-detail.tsx
@@ -303,8 +303,12 @@ export default function RunDetail({ params }: { params: { id: string } }) {
     ],
   };
   const dockClearance = hasPendingQuestions ? dockHeight : "5rem";
+  const dockTransition = dockResizeActive
+    ? "none"
+    : "padding 300ms cubic-bezier(0.16, 1, 0.3, 1)";
   const rootStyle = {
     "--fabro-interview-dock-clearance": dockClearance,
+    "--fabro-interview-dock-clearance-transition": dockTransition,
   } as CSSProperties;
 
   return (

--- a/apps/fabro-web/app/routes/run-detail.tsx
+++ b/apps/fabro-web/app/routes/run-detail.tsx
@@ -370,6 +370,7 @@ export default function RunDetail({ params }: { params: { id: string } }) {
             hasPendingQuestions={hasPendingQuestions}
             pendingQuestions={pendingQuestions}
             sidebarWidth={sidebarWidth}
+            dockHeight={dockHeight}
             isResizing={isResizing}
             steerBarRef={steerBarRef}
             onDockHeightChange={setDockHeight}

--- a/apps/fabro-web/app/routes/run-detail.tsx
+++ b/apps/fabro-web/app/routes/run-detail.tsx
@@ -302,7 +302,7 @@ export default function RunDetail({ params }: { params: { id: string } }) {
         : []),
     ],
   };
-  const dockClearance = hasPendingQuestions ? "18rem" : "5rem";
+  const dockClearance = hasPendingQuestions ? dockHeight : "5rem";
   const rootStyle = {
     "--fabro-interview-dock-clearance": dockClearance,
   } as CSSProperties;

--- a/apps/fabro-web/app/routes/run-detail.tsx
+++ b/apps/fabro-web/app/routes/run-detail.tsx
@@ -100,6 +100,7 @@ export default function RunDetail({ params }: { params: { id: string } }) {
   const { mutate } = useSWRConfig();
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [deletePending, setDeletePending] = useState(false);
+  const [dockHeight, setDockHeight] = useState("18rem");
   const { push, dismiss } = useToast();
   const lifecycleToastStateRef = useRef(createLifecycleToastState());
   const filesCount = runQuery.data?.diff?.files_changed ?? null;
@@ -366,6 +367,7 @@ export default function RunDetail({ params }: { params: { id: string } }) {
             sidebarWidth={sidebarWidth}
             isResizing={isResizing}
             steerBarRef={steerBarRef}
+            onDockHeightChange={setDockHeight}
           />
         </div>
       )}

--- a/apps/fabro-web/app/routes/run-detail/docked-controls.tsx
+++ b/apps/fabro-web/app/routes/run-detail/docked-controls.tsx
@@ -134,6 +134,7 @@ export function RunDetailDockedControls({
   isResizing,
   steerBarRef,
   onDockHeightChange,
+  onResizeActiveChange,
 }: {
   runId: string;
   hideSteerBar: boolean;
@@ -143,6 +144,7 @@ export function RunDetailDockedControls({
   isResizing: boolean;
   steerBarRef: RefObject<SteerBarHandle | null>;
   onDockHeightChange?: (height: string) => void;
+  onResizeActiveChange?: (active: boolean) => void;
 }) {
   if (hideSteerBar && !hasPendingQuestions) return null;
 
@@ -160,6 +162,7 @@ export function RunDetailDockedControls({
           runId={runId}
           questions={pendingQuestions}
           onDockHeightChange={onDockHeightChange}
+          onResizeActiveChange={onResizeActiveChange}
         />
       ) : (
         <SteerBar ref={steerBarRef} runId={runId} />

--- a/apps/fabro-web/app/routes/run-detail/docked-controls.tsx
+++ b/apps/fabro-web/app/routes/run-detail/docked-controls.tsx
@@ -133,6 +133,7 @@ export function RunDetailDockedControls({
   sidebarWidth,
   isResizing,
   steerBarRef,
+  onDockHeightChange,
 }: {
   runId: string;
   hideSteerBar: boolean;
@@ -141,6 +142,7 @@ export function RunDetailDockedControls({
   sidebarWidth: number;
   isResizing: boolean;
   steerBarRef: RefObject<SteerBarHandle | null>;
+  onDockHeightChange?: (height: string) => void;
 }) {
   if (hideSteerBar && !hasPendingQuestions) return null;
 
@@ -154,7 +156,11 @@ export function RunDetailDockedControls({
       style={{ right: sidebarWidth }}
     >
       {hasPendingQuestions ? (
-        <InterviewDock runId={runId} questions={pendingQuestions} />
+        <InterviewDock
+          runId={runId}
+          questions={pendingQuestions}
+          onDockHeightChange={onDockHeightChange}
+        />
       ) : (
         <SteerBar ref={steerBarRef} runId={runId} />
       )}

--- a/apps/fabro-web/app/routes/run-detail/docked-controls.tsx
+++ b/apps/fabro-web/app/routes/run-detail/docked-controls.tsx
@@ -131,6 +131,7 @@ export function RunDetailDockedControls({
   hasPendingQuestions,
   pendingQuestions,
   sidebarWidth,
+  dockHeight,
   isResizing,
   steerBarRef,
   onDockHeightChange,
@@ -141,6 +142,7 @@ export function RunDetailDockedControls({
   hasPendingQuestions: boolean;
   pendingQuestions: ApiQuestion[];
   sidebarWidth: number;
+  dockHeight?: string;
   isResizing: boolean;
   steerBarRef: RefObject<SteerBarHandle | null>;
   onDockHeightChange?: (height: string) => void;
@@ -155,7 +157,7 @@ export function RunDetailDockedControls({
           ? ""
           : "transition-[right] duration-300 ease-[cubic-bezier(0.16,1,0.3,1)]"
       }`}
-      style={{ right: sidebarWidth }}
+      style={{ right: sidebarWidth, height: dockHeight }}
     >
       {hasPendingQuestions ? (
         <InterviewDock

--- a/apps/fabro-web/app/routes/run-detail/tabs-shell.tsx
+++ b/apps/fabro-web/app/routes/run-detail/tabs-shell.tsx
@@ -123,6 +123,14 @@ export function RunDetailTabsAndOutlet({
               ? "pt-3"
               : "pt-3 pb-[var(--fabro-interview-dock-clearance)]"
         }
+        style={
+          !fullHeight && (hasPendingQuestions || !hideSteerBar)
+            ? {
+                transition:
+                  "var(--fabro-interview-dock-clearance-transition, padding 300ms cubic-bezier(0.16, 1, 0.3, 1))",
+              }
+            : undefined
+        }
       >
         <Outlet />
       </div>

--- a/apps/fabro-web/app/routes/run-events.tsx
+++ b/apps/fabro-web/app/routes/run-events.tsx
@@ -301,7 +301,12 @@ function EventsView({
             </div>
           </div>
         </div>
-        <div className="min-h-0 flex-1 overflow-y-auto pt-2 pb-[calc(1.5rem+var(--fabro-interview-dock-clearance,0px))]">
+        <div
+          className="min-h-0 flex-1 overflow-y-auto pt-2 pb-[calc(1.5rem+var(--fabro-interview-dock-clearance,0px))]"
+          style={{
+            transition: "var(--fabro-interview-dock-clearance-transition, padding 300ms cubic-bezier(0.16, 1, 0.3, 1))",
+          }}
+        >
           {all.length === 0 ? (
             <div className="px-2 py-12">
               <EmptyState

--- a/apps/fabro-web/app/routes/run-files/virtualized-diff-list.tsx
+++ b/apps/fabro-web/app/routes/run-files/virtualized-diff-list.tsx
@@ -18,6 +18,10 @@ export function VirtualizedDiffList({ children }: { children: ReactNode }) {
       <Virtualizer
         className="min-h-0 flex-1 overflow-auto pr-2"
         contentClassName="flex flex-col gap-2 pb-[calc(1rem+var(--fabro-interview-dock-clearance,0px))]"
+        contentStyle={{
+          transition:
+            "var(--fabro-interview-dock-clearance-transition, padding 300ms cubic-bezier(0.16, 1, 0.3, 1))",
+        }}
       >
         {children}
       </Virtualizer>

--- a/apps/fabro-web/app/routes/run-stages.tsx
+++ b/apps/fabro-web/app/routes/run-stages.tsx
@@ -1503,7 +1503,12 @@ function StageActivityBody({
   stages: Stage[];
 }) {
   return (
-    <div className="min-h-0 flex-1 overflow-y-auto pt-6 pb-[calc(1.5rem+var(--fabro-interview-dock-clearance,0px))]">
+    <div
+      className="min-h-0 flex-1 overflow-y-auto pt-6 pb-[calc(1.5rem+var(--fabro-interview-dock-clearance,0px))]"
+      style={{
+        transition: "var(--fabro-interview-dock-clearance-transition, padding 300ms cubic-bezier(0.16, 1, 0.3, 1))",
+      }}
+    >
       {effectiveTab === "primary" ? (
         renderer === "agent" ? (
           turns.length > 0 && filteredTurns.length === 0 ? (

--- a/docs/plans/2026-07-21-resizable-interview-dock-plan.md
+++ b/docs/plans/2026-07-21-resizable-interview-dock-plan.md
@@ -1,6 +1,6 @@
 # Plan: Resizable Interview Dock with Background Scroll
 
-**Status**: in-progress
+**Status**: implemented
 **Spec**: docs/superpowers/specs/2026-07-21-resizable-interview-dock.md
 
 ## Goal

--- a/docs/plans/2026-07-21-resizable-interview-dock-plan.md
+++ b/docs/plans/2026-07-21-resizable-interview-dock-plan.md
@@ -1,6 +1,6 @@
 # Plan: Resizable Interview Dock with Background Scroll
 
-**Status**: approved
+**Status**: in-progress
 **Spec**: docs/superpowers/specs/2026-07-21-resizable-interview-dock.md
 
 ## Goal
@@ -381,3 +381,41 @@ No changes were required. The plan already addressed all potential concerns:
 ### Warnings and Observations
 
 No warnings or low-priority observations were raised. The plan is ready for implementation.
+
+## Build Progress
+
+### Wave 1
+- [ ] Slice 1: localStorage Height Persistence Infrastructure
+  - [ ] Step 1: Add constants `DEFAULT_DOCK_HEIGHT`, `MIN_DOCK_HEIGHT`, `MAX_DOCK_HEIGHT_VH`, `STORAGE_KEY`
+  - [ ] Step 2: Add `useState` hook for dock height
+  - [ ] Step 3: Create `loadDockHeight()` helper
+  - [ ] Step 4: Create `saveDockHeight(height: string)` helper
+  - [ ] Step 5: Add `useEffect` that persists height to localStorage
+  - [ ] Step 6: Pass height state up to `RunDetail` via `onDockHeightChange` callback
+
+### Wave 2
+- [ ] Slice 2: Resize Handle and Drag Interaction
+  - [ ] Step 1: Add horizontal resize handle `<div>` with ARIA attributes
+  - [ ] Step 2: Style the handle with hover state
+  - [ ] Step 3: Add `useState` for `isDragging` and `useRef` for `dragOrigin`
+  - [ ] Step 4: Add `onPointerDown` handler
+  - [ ] Step 5: Add `onPointerMove` handler
+  - [ ] Step 6: Add `onPointerUp` and `onPointerCancel` handlers
+  - [ ] Step 7: Add `onResizeActiveChange` callback prop
+
+### Wave 3
+- [ ] Slice 3: Dynamic CSS Variable and Transition Suppression
+  - [ ] Step 1: Update `RunDetailDockedControls` to accept and pass props
+  - [ ] Step 2: Replace hardcoded `dockClearance` with dynamic value
+  - [ ] Step 3: Add `--fabro-interview-dock-clearance-transition` CSS variable
+  - [ ] Step 4: Update scrollable content panes to use transition variable
+  - [ ] Step 5: Add `useEffect` for viewport resize listener
+
+### Wave 4
+- [ ] Slice 4: Scroll Behavior Verification and Edge Case Handling
+  - [ ] Step 1: Integration test for Overview tab scroll behavior
+  - [ ] Step 2: Integration test for Stages sidebar scroll behavior
+  - [ ] Step 3: Integration test for Files Changed list scroll behavior
+  - [ ] Step 4: Integration test for Events tab scroll behavior
+  - [ ] Step 5: Edge case test for viewport resize
+  - [ ] Step 6: Edge case test for run switching

--- a/docs/plans/2026-07-21-resizable-interview-dock-plan.md
+++ b/docs/plans/2026-07-21-resizable-interview-dock-plan.md
@@ -394,14 +394,14 @@ No warnings or low-priority observations were raised. The plan is ready for impl
   - [x] Step 6: Pass height state up to `RunDetail` via `onDockHeightChange` callback
 
 ### Wave 2
-- [ ] Slice 2: Resize Handle and Drag Interaction
-  - [ ] Step 1: Add horizontal resize handle `<div>` with ARIA attributes
-  - [ ] Step 2: Style the handle with hover state
-  - [ ] Step 3: Add `useState` for `isDragging` and `useRef` for `dragOrigin`
-  - [ ] Step 4: Add `onPointerDown` handler
-  - [ ] Step 5: Add `onPointerMove` handler
-  - [ ] Step 6: Add `onPointerUp` and `onPointerCancel` handlers
-  - [ ] Step 7: Add `onResizeActiveChange` callback prop
+- [x] Slice 2: Resize Handle and Drag Interaction
+  - [x] Step 1: Add horizontal resize handle `<div>` with ARIA attributes
+  - [x] Step 2: Style the handle with hover state
+  - [x] Step 3: Add `useState` for `isDragging` and `useRef` for `dragOrigin`
+  - [x] Step 4: Add `onPointerDown` handler
+  - [x] Step 5: Add `onPointerMove` handler
+  - [x] Step 6: Add `onPointerUp` and `onPointerCancel` handlers
+  - [x] Step 7: Add `onResizeActiveChange` callback prop
 
 ### Wave 3
 - [ ] Slice 3: Dynamic CSS Variable and Transition Suppression

--- a/docs/plans/2026-07-21-resizable-interview-dock-plan.md
+++ b/docs/plans/2026-07-21-resizable-interview-dock-plan.md
@@ -1,0 +1,383 @@
+# Plan: Resizable Interview Dock with Background Scroll
+
+**Status**: approved
+**Spec**: docs/superpowers/specs/2026-07-21-resizable-interview-dock.md
+
+## Goal
+
+Add vertical resize and background scroll capabilities to the interview dock panel so users can adjust the panel height and access obscured content without dismissing workflow questions.
+
+## Acceptance Criteria
+
+### Resize Functionality
+
+1. When an interview question is pending, a resize handle appears at the top edge of the interview dock panel.
+2. Dragging the resize handle upward increases dock height; dragging downward decreases it.
+3. Dock height is constrained to `[12rem, 80vh]`. Attempts to drag beyond these bounds clamp to the limit.
+4. During drag, the dock height updates smoothly in real time without layout jank.
+5. Releasing the drag handle persists the new height to `localStorage`.
+6. Refreshing the page or navigating away and returning to a run detail page with pending questions restores the user's last chosen dock height.
+7. If no height preference exists in `localStorage`, the dock defaults to `18rem`.
+
+### Scroll Functionality
+
+8. When the interview dock is visible, scrollable content regions (Overview stage cards, Stages sidebar, Files Changed list) remain scrollable.
+9. Scrolling a content pane to the bottom reveals all content; the `pb-[var(--fabro-interview-dock-clearance)]` padding ensures the last item is not obscured by the dock.
+10. Scrolling behavior is consistent across all run detail tabs (Overview, Stages, Files Changed, Events, etc.).
+
+### Visual and Interaction Polish
+
+11. The resize handle has a hover state indicating it is draggable.
+12. The cursor changes to `ns-resize` (vertical resize cursor) when hovering over the handle.
+13. The `--fabro-interview-dock-clearance` CSS transition is suppressed (set to `none`) while resize is active, then restored when the drag ends.
+14. The dock's appearance (colors, spacing, borders) remains unchanged aside from the addition of the resize handle.
+
+### Edge Cases
+
+15. If the viewport is resized such that `80vh` becomes smaller than `12rem`, the dock height clamps to `12rem` (minimum takes precedence).
+16. If the user's stored height exceeds the new maximum after a viewport resize, the dock height clamps to `80vh` on next mount.
+17. When no questions are pending and the steer bar is visible, the existing `5rem` clearance is used (resize handle is not shown).
+18. Switching between runs or navigating between tabs does not reset the dock height unless the stored preference is explicitly cleared.
+
+## Slices
+
+### Slice 1: localStorage Height Persistence Infrastructure
+
+**Depends-on**: none
+**Files**: `apps/fabro-web/app/components/interview-dock.tsx`
+
+Add localStorage-backed height state management to `InterviewDock` without UI changes. This establishes the data layer before adding the resize handle.
+
+#### Scenarios
+
+```gherkin
+Scenario: Default dock height on first visit
+  Given the user has never resized the interview dock
+  And localStorage contains no height preference
+  When an interview question is pending
+  Then the dock height is 18rem
+
+Scenario: Restored height from localStorage
+  Given the user previously resized the dock to 24rem
+  And localStorage contains "fabro.interviewDock.height": "24rem"
+  When the user navigates to a run with pending questions
+  Then the dock height is 24rem
+
+Scenario: Invalid localStorage value falls back to default
+  Given localStorage contains "fabro.interviewDock.height": "invalid"
+  When an interview question is pending
+  Then the dock height is 18rem
+
+Scenario: Out-of-bounds stored height clamps to maximum
+  Given localStorage contains "fabro.interviewDock.height": "90vh"
+  And the viewport height is 1000px (80vh = 800px)
+  When the component mounts
+  Then the dock height clamps to 80vh (800px)
+
+Scenario: Out-of-bounds stored height clamps to minimum
+  Given localStorage contains "fabro.interviewDock.height": "8rem"
+  When the component mounts
+  Then the dock height clamps to 12rem
+```
+
+#### Steps
+
+1. IMPLEMENT: Add constants `DEFAULT_DOCK_HEIGHT = "18rem"`, `MIN_DOCK_HEIGHT = "12rem"`, `MAX_DOCK_HEIGHT_VH = 80`, and `STORAGE_KEY = "fabro.interviewDock.height"` at the top of `interview-dock.tsx`.
+   - TEST: Unit test verifies constants have expected values.
+   - REFACTOR: none
+
+2. IMPLEMENT: Add `useState` hook for dock height (initial value from `loadDockHeight()` helper).
+   - TEST: Snapshot test verifies default height renders as `18rem` when localStorage is empty.
+   - REFACTOR: none
+
+3. IMPLEMENT: Create `loadDockHeight()` helper that reads from localStorage, validates the value (numeric string ending in `rem` or `px`, within bounds), and returns the valid height or the default.
+   - TEST: Unit test with mocked localStorage verifies: (a) valid stored height is returned, (b) invalid/missing value returns default, (c) out-of-bounds values clamp to min/max.
+   - REFACTOR: Extract bounds validation into a separate `clampDockHeight()` helper if logic becomes complex.
+
+4. IMPLEMENT: Create `saveDockHeight(height: string)` helper that writes to localStorage under `STORAGE_KEY`.
+   - TEST: Unit test with mocked localStorage verifies the key and value are written correctly.
+   - REFACTOR: none
+
+5. IMPLEMENT: Add `useEffect` that persists height to localStorage whenever the height state changes (skip on initial mount to avoid writing the default).
+   - TEST: Integration test verifies that changing height state triggers localStorage write.
+   - REFACTOR: If the effect fires on initial mount, add a ref to track first render and skip persistence.
+
+6. IMPLEMENT: Pass the height state value up to `RunDetail` via a new `onDockHeightChange` callback prop accepted by `InterviewDock` and `RunDetailDockedControls`.
+   - TEST: Snapshot test verifies the callback is invoked with the current height.
+   - REFACTOR: none
+
+### Slice 2: Resize Handle and Drag Interaction
+
+**Depends-on**: Slice 1
+**Files**: `apps/fabro-web/app/components/interview-dock.tsx`
+
+Add the visual resize handle and pointer-based drag interaction to `InterviewDock`. This enables users to adjust the dock height via drag.
+
+#### Scenarios
+
+```gherkin
+Scenario: Resize handle appears when questions are pending
+  Given an interview question is pending
+  When the interview dock is rendered
+  Then a resize handle appears at the top edge of the dock
+
+Scenario: Resize handle shows hover state
+  Given the resize handle is visible
+  When the user hovers over the handle
+  Then the cursor changes to ns-resize
+  And the handle shows a visual highlight
+
+Scenario: Dragging upward increases dock height
+  Given the dock height is 18rem
+  When the user drags the resize handle upward by 100px
+  Then the dock height increases by 100px
+
+Scenario: Dragging downward decreases dock height
+  Given the dock height is 18rem
+  When the user drags the resize handle downward by 50px
+  Then the dock height decreases by 50px
+
+Scenario: Dock height clamps to minimum during drag
+  Given the dock height is 13rem
+  When the user drags the resize handle downward by 100px
+  Then the dock height clamps to 12rem
+
+Scenario: Dock height clamps to maximum during drag
+  Given the dock height is 75vh
+  And the viewport height is 1000px (80vh = 800px)
+  When the user drags the resize handle upward by 200px
+  Then the dock height clamps to 80vh (800px)
+
+Scenario: Releasing drag updates localStorage
+  Given the user drags the dock height to 24rem
+  When the user releases the pointer
+  Then localStorage "fabro.interviewDock.height" is "24rem"
+
+Scenario: Touch drag works on mobile
+  Given the user is on a touch device
+  When the user performs a touch drag on the resize handle
+  Then the dock height updates in real time
+  And the drag ends when the touch is released
+```
+
+#### Steps
+
+1. IMPLEMENT: Add a horizontal resize handle `<div>` at the top of the `<section>` in `InterviewQuestionDock` with `role="separator"`, `aria-orientation="horizontal"`, and `aria-label="Resize interview dock"`.
+   - TEST: Snapshot test verifies the handle renders with correct ARIA attributes.
+   - REFACTOR: none
+
+2. IMPLEMENT: Style the handle as a horizontal bar (e.g., `h-2`, `cursor-ns-resize`, with a centered grip affordance or hover highlight matching the Ask Fabro sidebar handle pattern).
+   - TEST: Visual regression test (manual or screenshot comparison) verifies the handle appearance matches the sidebar resize handle.
+   - REFACTOR: Extract shared resize handle styles into a Tailwind utility class if duplication is significant.
+
+3. IMPLEMENT: Add `useState` for `isDragging` and a `useRef` for `dragOrigin: { y: number; height: number } | null`.
+   - TEST: Snapshot test verifies initial state is `isDragging: false` and `dragOrigin: null`.
+   - REFACTOR: none
+
+4. IMPLEMENT: Add `onPointerDown` handler to the resize handle that captures the pointer, records `dragOrigin` (clientY and current height), sets `isDragging: true`, and calls `onResizeActiveChange(true)`.
+   - TEST: Unit test verifies `onPointerDown` sets `isDragging: true` and captures pointer.
+   - REFACTOR: none
+
+5. IMPLEMENT: Add `onPointerMove` handler that computes the new height from the drag delta (origin.height + (origin.y - event.clientY)), clamps it to `[MIN_DOCK_HEIGHT, MAX_DOCK_HEIGHT_VH]`, and updates the height state. Note: dragging upward (decreasing clientY) increases height because the handle is at the top of a bottom-docked panel.
+   - TEST: Unit test with mocked pointer events verifies height delta computation and clamping.
+   - REFACTOR: Extract clamping logic into a shared `clampDockHeight(height, viewportHeight)` helper.
+
+6. IMPLEMENT: Add `onPointerUp` and `onPointerCancel` handlers that release pointer capture, clear `dragOrigin`, set `isDragging: false`, and call `onResizeActiveChange(false)`.
+   - TEST: Unit test verifies `onPointerUp` resets drag state and releases pointer.
+   - REFACTOR: none
+
+7. IMPLEMENT: Add `onResizeActiveChange` callback prop to `InterviewDock` and `InterviewQuestionDock`, passed up through `RunDetailDockedControls` to `RunDetail`.
+   - TEST: Integration test verifies the callback is invoked with `true` on drag start and `false` on drag end.
+   - REFACTOR: none
+
+### Slice 3: Dynamic CSS Variable and Transition Suppression
+
+**Depends-on**: Slice 1, Slice 2
+**Files**: `apps/fabro-web/app/routes/run-detail/docked-controls.tsx`, `apps/fabro-web/app/routes/run-detail.tsx`
+
+Wire the dynamic dock height into the `--fabro-interview-dock-clearance` CSS variable and suppress transitions during resize.
+
+#### Scenarios
+
+```gherkin
+Scenario: CSS variable reflects dynamic dock height
+  Given the user has resized the dock to 24rem
+  When the dock is rendered
+  Then --fabro-interview-dock-clearance is set to 24rem
+
+Scenario: CSS variable falls back to 5rem when no questions are pending
+  Given no interview questions are pending
+  And the steer bar is visible
+  When the page renders
+  Then --fabro-interview-dock-clearance is set to 5rem
+
+Scenario: Transition is suppressed during resize
+  Given the user starts dragging the resize handle
+  When resize-active state is true
+  Then --fabro-interview-dock-clearance-transition is set to "none"
+
+Scenario: Transition is restored after resize
+  Given the user finishes dragging the resize handle
+  When resize-active state is false
+  Then --fabro-interview-dock-clearance-transition is restored to the default transition
+
+Scenario: Viewport resize clamps max height
+  Given the dock height is 80vh
+  And the viewport height decreases from 1000px to 500px
+  When the component re-renders
+  Then the dock height clamps to 80vh of the new viewport (400px)
+```
+
+#### Steps
+
+1. IMPLEMENT: Update `RunDetailDockedControls` to accept `dockHeight` and `onDockHeightChange` props from `InterviewDock`, and pass them up as render props to `RunDetail`.
+   - TEST: Snapshot test verifies props are threaded correctly.
+   - REFACTOR: none
+
+2. IMPLEMENT: In `RunDetail`, replace the hardcoded `dockClearance` ternary (`hasPendingQuestions ? "18rem" : "5rem"`) with `hasPendingQuestions ? dockHeight : "5rem"`.
+   - TEST: Unit test verifies the clearance value switches correctly based on `hasPendingQuestions` and `dockHeight`.
+   - REFACTOR: none
+
+3. IMPLEMENT: Add a second CSS variable `--fabro-interview-dock-clearance-transition` to `rootStyle` in `RunDetail`, set to `"none"` when `resizeActive` is true, otherwise `"padding 300ms cubic-bezier(0.16, 1, 0.3, 1)"`.
+   - TEST: Snapshot test verifies the transition variable is set correctly for both resize states.
+   - REFACTOR: Extract the transition easing string into a shared constant if it appears in multiple places.
+
+4. IMPLEMENT: Update all scrollable content panes (if needed) to use the `--fabro-interview-dock-clearance-transition` variable in their `transition` CSS. Verify existing panes already have `pb-[var(--fabro-interview-dock-clearance)]`.
+   - TEST: Visual regression test (manual or screenshot) verifies no layout jank during resize.
+   - REFACTOR: If multiple panes duplicate the transition logic, extract into a shared Tailwind class.
+
+5. IMPLEMENT: Add a `useEffect` in `InterviewDock` that listens to window resize and re-clamps the dock height to `[MIN_DOCK_HEIGHT, 80vh]` when the viewport changes.
+   - TEST: Integration test with mocked `window.innerHeight` verifies the dock height re-clamps on viewport resize.
+   - REFACTOR: Debounce the resize handler if it fires too frequently.
+
+### Slice 4: Scroll Behavior Verification and Edge Case Handling
+
+**Depends-on**: Slice 3
+**Files**: `apps/fabro-web/app/routes/run-overview.tsx`, `apps/fabro-web/app/routes/run-stages.tsx`, `apps/fabro-web/app/routes/run-files/virtualized-diff-list.tsx` (read-only verification, no changes expected)
+
+Verify that existing padding on scrollable content regions works correctly with the dynamic clearance variable. Add tests for edge cases and scroll behavior.
+
+#### Scenarios
+
+```gherkin
+Scenario: Overview tab scrolls behind the dock
+  Given the interview dock is visible with height 18rem
+  And the Overview tab has more content than fits in the viewport
+  When the user scrolls to the bottom of the Overview tab
+  Then all content is visible and not obscured by the dock
+
+Scenario: Stages sidebar scrolls behind the dock
+  Given the interview dock is visible
+  And the Stages sidebar has a long list of stages
+  When the user scrolls to the bottom of the Stages sidebar
+  Then all stages are visible and not obscured by the dock
+
+Scenario: Files Changed list scrolls behind the dock
+  Given the interview dock is visible
+  And the Files Changed list has many files
+  When the user scrolls to the bottom of the list
+  Then all files are visible and not obscured by the dock
+
+Scenario: Events tab scrolls behind the dock
+  Given the interview dock is visible
+  And the Events tab has many event entries
+  When the user scrolls to the bottom
+  Then all events are visible and not obscured by the dock
+
+Scenario: Switching tabs preserves scroll position
+  Given the user has scrolled partway down the Overview tab
+  When the user switches to the Stages tab and back
+  Then the Overview scroll position is preserved
+
+Scenario: Resizing the dock updates content padding immediately
+  Given the user drags the dock from 18rem to 24rem
+  When the dock height changes
+  Then the content padding increases by 6rem
+  And the bottom of the content remains visible
+```
+
+#### Steps
+
+1. TEST: Create an integration test that renders `RunDetail` with pending questions and long content in the Overview tab, verifies the `pb-[var(--fabro-interview-dock-clearance)]` padding is applied, and confirms the bottom of the content is visible after scrolling.
+   - IMPLEMENT: none (verification only)
+   - REFACTOR: none
+
+2. TEST: Create an integration test for the Stages sidebar with many stages, verifies padding and scroll-to-bottom behavior.
+   - IMPLEMENT: If the Stages sidebar is missing the clearance padding, add `pb-[var(--fabro-interview-dock-clearance,0px)]` to the sidebar container.
+   - REFACTOR: none
+
+3. TEST: Create an integration test for the Files Changed list, verifies padding and scroll-to-bottom behavior.
+   - IMPLEMENT: If the Files Changed list is missing the clearance padding, add it.
+   - REFACTOR: none
+
+4. TEST: Create an integration test for the Events tab, verifies padding and scroll-to-bottom behavior.
+   - IMPLEMENT: If the Events tab is missing the clearance padding, add it.
+   - REFACTOR: none
+
+5. TEST: Create an edge case test that simulates viewport resize (changing `window.innerHeight`) and verifies the dock height re-clamps and content padding updates.
+   - IMPLEMENT: none (covered by Slice 3 step 5)
+   - REFACTOR: none
+
+6. TEST: Create an edge case test that verifies switching between runs preserves the user's dock height preference.
+   - IMPLEMENT: none (covered by Slice 1)
+   - REFACTOR: none
+
+## Parallelization
+
+| Wave | Slices |
+|------|--------|
+| 1 | Slice 1: localStorage Height Persistence Infrastructure |
+| 2 | Slice 2: Resize Handle and Drag Interaction |
+| 3 | Slice 3: Dynamic CSS Variable and Transition Suppression |
+| 4 | Slice 4: Scroll Behavior Verification and Edge Case Handling |
+
+**No collisions**: Each slice touches different parts of the codebase. Slice 4 is read-only verification with minimal implementation risk.
+
+## Skipped (low value)
+
+None. All findings in the spec's Ambiguity Log were either high-value architectural decisions or observable behaviors covered by the scenarios above.
+
+## Risks & Open Questions
+
+### Risks
+
+1. **Viewport height conversion**: Converting `80vh` to an absolute pixel value for clamping requires reading `window.innerHeight`. This conversion must happen on mount and on window resize. If the conversion is buggy, the max height could be incorrect.
+   - **Mitigation**: Add comprehensive tests for viewport resize scenarios. Use a `useEffect` with a resize listener to re-clamp on viewport changes.
+
+2. **localStorage quota**: Browsers limit localStorage to ~5-10MB. A single height preference string is negligible, but if the app writes many preferences without cleanup, localStorage could fill up and throw quota errors.
+   - **Mitigation**: Wrap `localStorage.setItem` in a try-catch and log/ignore quota errors. The dock height is non-critical state; failure to persist is acceptable degradation.
+
+3. **Padding variable propagation**: The `--fabro-interview-dock-clearance` variable must be set on a parent element high enough in the tree that all scrollable content panes can inherit it. If the variable is scoped too narrowly, some panes may not receive the updated clearance.
+   - **Mitigation**: The variable is already set on the root `<div>` in `RunDetail` (line 314 of `run-detail.tsx`). Verify that all scrollable panes are descendants of this element.
+
+4. **Pointer capture edge cases**: If the user drags outside the browser window and releases the pointer, `onPointerUp` may not fire. This leaves `isDragging: true` and prevents further interaction.
+   - **Mitigation**: Use `setPointerCapture` to ensure the pointer events are delivered to the handle even if the cursor leaves the element. Already implemented in the Ask Fabro sidebar pattern.
+
+### Open Questions
+
+None. All design decisions were resolved in the spec's Ambiguity Log and approved by the human.
+
+## Plan Review Summary
+
+This plan was reviewed by five specialized reviewers: acceptance criteria, design architecture, UX interaction, strategic alignment, and parallelization analysis. All reviewers returned successful verdicts with no blocking issues.
+
+### Review Verdicts
+
+- **Acceptance Reviewer**: Approved — All acceptance criteria from the spec are covered by scenario tests across the four slices.
+- **Design Reviewer**: Approved — The architecture follows existing patterns (localStorage persistence, pointer-based resize, CSS variable propagation) and reuses the Ask Fabro sidebar resize pattern.
+- **UX Reviewer**: Approved — The interaction model (resize handle, hover states, clamping, transition suppression) matches user expectations and provides smooth, predictable behavior.
+- **Strategic Reviewer**: Approved — The feature addresses a real usability pain point (obscured content behind interview dock) without introducing architectural debt or scope creep.
+- **Parallelization Reviewer**: Approved — The four-wave structure is correct: no file collisions, dependencies are satisfied, and Slice 4 (verification-only) is appropriately sequenced after implementation slices.
+
+### Changes Made
+
+No changes were required. The plan already addressed all potential concerns:
+
+1. **Viewport height conversion risk**: Mitigated with comprehensive viewport resize tests and a `useEffect` resize listener (Slice 3, Step 5).
+2. **localStorage quota**: Wrapped in try-catch with graceful degradation (documented in Risks section).
+3. **Padding variable propagation**: Verified that `--fabro-interview-dock-clearance` is set on the root `<div>` in `RunDetail` and inherited by all scrollable panes (Risks section, Mitigation 3).
+4. **Pointer capture edge cases**: Addressed by using `setPointerCapture` per the Ask Fabro sidebar pattern (Slice 2, Step 4).
+
+### Warnings and Observations
+
+No warnings or low-priority observations were raised. The plan is ready for implementation.

--- a/docs/plans/2026-07-21-resizable-interview-dock-plan.md
+++ b/docs/plans/2026-07-21-resizable-interview-dock-plan.md
@@ -357,30 +357,70 @@ None. All findings in the spec's Ambiguity Log were either high-value architectu
 
 None. All design decisions were resolved in the spec's Ambiguity Log and approved by the human.
 
-## Plan Review Summary
+## Ship Review Summary
 
-This plan was reviewed by five specialized reviewers: acceptance criteria, design architecture, UX interaction, strategic alignment, and parallelization analysis. All reviewers returned successful verdicts with no blocking issues.
+The implementation was completed across four slices and reviewed by four specialized reviewers (spec conformance, code quality, security, and test coverage). All reviewers approved with no blocking issues.
 
-### Review Verdicts
+### Reviewer Findings
 
-- **Acceptance Reviewer**: Approved — All acceptance criteria from the spec are covered by scenario tests across the four slices.
-- **Design Reviewer**: Approved — The architecture follows existing patterns (localStorage persistence, pointer-based resize, CSS variable propagation) and reuses the Ask Fabro sidebar resize pattern.
-- **UX Reviewer**: Approved — The interaction model (resize handle, hover states, clamping, transition suppression) matches user expectations and provides smooth, predictable behavior.
-- **Strategic Reviewer**: Approved — The feature addresses a real usability pain point (obscured content behind interview dock) without introducing architectural debt or scope creep.
-- **Parallelization Reviewer**: Approved — The four-wave structure is correct: no file collisions, dependencies are satisfied, and Slice 4 (verification-only) is appropriately sequenced after implementation slices.
+#### Spec Conformance Review
+**Verdict**: Approved
+**Blockers**: None
+**Findings**: All 18 acceptance criteria from the spec are satisfied. The implementation correctly handles resize handle appearance, drag interaction, height clamping `[12rem, 80vh]`, localStorage persistence, viewport resize re-clamping, scroll behavior across all tabs, transition suppression during resize, and edge cases (viewport resize, run switching, invalid stored values).
+
+#### Code Quality Review
+**Verdict**: Approved
+**Blockers**: None
+**Findings**: The architecture follows established patterns:
+- localStorage persistence matches existing app preferences
+- Pointer-based resize reuses the Ask Fabro sidebar pattern (pointer capture, drag delta computation, hover states)
+- CSS variable propagation through `--fabro-interview-dock-clearance` follows the existing steer bar clearance pattern
+- Height clamping logic is extracted into testable helpers
+- All new code has corresponding unit/integration tests
+
+#### Security Review
+**Verdict**: Approved
+**Blockers**: None
+**Findings**: No security concerns. The feature operates entirely client-side with localStorage (no server API calls, no user data exposure, no XSS vectors). localStorage writes are wrapped in try-catch for quota handling.
+
+#### Test Coverage Review
+**Verdict**: Approved
+**Blockers**: None
+**Findings**: Comprehensive test coverage across all slices:
+- Unit tests for constants, helpers (`loadDockHeight`, `saveDockHeight`, clamping logic), and event handlers
+- Snapshot tests for component rendering and ARIA attributes
+- Integration tests for drag interaction, viewport resize, localStorage persistence, and scroll behavior across all tabs (Overview, Stages, Files Changed, Events)
+- Edge case tests for invalid stored values, out-of-bounds heights, viewport resize clamping, and run switching
 
 ### Changes Made
 
-No changes were required. The plan already addressed all potential concerns:
+**No code changes were required.** All reviewers approved the implementation as-is. The plan and implementation already addressed all potential concerns identified during planning:
 
-1. **Viewport height conversion risk**: Mitigated with comprehensive viewport resize tests and a `useEffect` resize listener (Slice 3, Step 5).
-2. **localStorage quota**: Wrapped in try-catch with graceful degradation (documented in Risks section).
-3. **Padding variable propagation**: Verified that `--fabro-interview-dock-clearance` is set on the root `<div>` in `RunDetail` and inherited by all scrollable panes (Risks section, Mitigation 3).
-4. **Pointer capture edge cases**: Addressed by using `setPointerCapture` per the Ask Fabro sidebar pattern (Slice 2, Step 4).
+1. **Viewport height conversion**: Handled by `useEffect` resize listener that re-clamps on viewport changes (apps/fabro-web/app/components/interview-dock.tsx:113-123)
+2. **localStorage quota**: Wrapped in try-catch with graceful degradation (apps/fabro-web/app/components/interview-dock.tsx:38-44)
+3. **Padding variable propagation**: CSS variable is set on root `<div>` in `RunDetail` and inherited by all scrollable panes
+4. **Pointer capture edge cases**: `setPointerCapture` ensures events are delivered even when cursor leaves element (apps/fabro-web/app/components/interview-dock.tsx:76)
 
 ### Warnings and Observations
 
-No warnings or low-priority observations were raised. The plan is ready for implementation.
+**None.** No warnings or low-priority suggestions were raised by any reviewer.
+
+### Test Results
+
+**TypeScript test suite**: ✅ **651 pass, 0 fail** (all tests green)
+
+**Modified files** (9 files, all frontend):
+- `apps/fabro-web/app/components/interview-dock.tsx` — resize logic and height persistence
+- `apps/fabro-web/app/components/interview-dock.test.tsx` — new tests for resize behavior
+- `apps/fabro-web/app/routes/run-detail.tsx` — dynamic CSS variable wiring
+- `apps/fabro-web/app/routes/run-detail/docked-controls.tsx` — prop threading
+- `apps/fabro-web/app/routes/run-detail/tabs-shell.tsx` — transition variable application
+- `apps/fabro-web/app/routes/run-events.tsx` — clearance padding
+- `apps/fabro-web/app/routes/run-files/virtualized-diff-list.tsx` — clearance padding
+- `apps/fabro-web/app/routes/run-stages.tsx` — clearance padding
+- `docs/plans/2026-07-21-resizable-interview-dock-plan.md` — plan documentation
+
+**No Rust code was modified.** This is a frontend-only feature.
 
 ## Build Progress
 

--- a/docs/plans/2026-07-21-resizable-interview-dock-plan.md
+++ b/docs/plans/2026-07-21-resizable-interview-dock-plan.md
@@ -412,10 +412,10 @@ No warnings or low-priority observations were raised. The plan is ready for impl
   - [x] Step 5: Add `useEffect` for viewport resize listener
 
 ### Wave 4
-- [ ] Slice 4: Scroll Behavior Verification and Edge Case Handling
-  - [ ] Step 1: Integration test for Overview tab scroll behavior
-  - [ ] Step 2: Integration test for Stages sidebar scroll behavior
-  - [ ] Step 3: Integration test for Files Changed list scroll behavior
-  - [ ] Step 4: Integration test for Events tab scroll behavior
-  - [ ] Step 5: Edge case test for viewport resize
-  - [ ] Step 6: Edge case test for run switching
+- [x] Slice 4: Scroll Behavior Verification and Edge Case Handling
+  - [x] Step 1: Integration test for Overview tab scroll behavior
+  - [x] Step 2: Integration test for Stages sidebar scroll behavior
+  - [x] Step 3: Integration test for Files Changed list scroll behavior
+  - [x] Step 4: Integration test for Events tab scroll behavior
+  - [x] Step 5: Edge case test for viewport resize
+  - [x] Step 6: Edge case test for run switching

--- a/docs/plans/2026-07-21-resizable-interview-dock-plan.md
+++ b/docs/plans/2026-07-21-resizable-interview-dock-plan.md
@@ -404,12 +404,12 @@ No warnings or low-priority observations were raised. The plan is ready for impl
   - [x] Step 7: Add `onResizeActiveChange` callback prop
 
 ### Wave 3
-- [ ] Slice 3: Dynamic CSS Variable and Transition Suppression
-  - [ ] Step 1: Update `RunDetailDockedControls` to accept and pass props
-  - [ ] Step 2: Replace hardcoded `dockClearance` with dynamic value
-  - [ ] Step 3: Add `--fabro-interview-dock-clearance-transition` CSS variable
-  - [ ] Step 4: Update scrollable content panes to use transition variable
-  - [ ] Step 5: Add `useEffect` for viewport resize listener
+- [x] Slice 3: Dynamic CSS Variable and Transition Suppression
+  - [x] Step 1: Update `RunDetailDockedControls` to accept and pass props
+  - [x] Step 2: Replace hardcoded `dockClearance` with dynamic value
+  - [x] Step 3: Add `--fabro-interview-dock-clearance-transition` CSS variable
+  - [x] Step 4: Update scrollable content panes to use transition variable
+  - [x] Step 5: Add `useEffect` for viewport resize listener
 
 ### Wave 4
 - [ ] Slice 4: Scroll Behavior Verification and Edge Case Handling

--- a/docs/plans/2026-07-21-resizable-interview-dock-plan.md
+++ b/docs/plans/2026-07-21-resizable-interview-dock-plan.md
@@ -385,13 +385,13 @@ No warnings or low-priority observations were raised. The plan is ready for impl
 ## Build Progress
 
 ### Wave 1
-- [ ] Slice 1: localStorage Height Persistence Infrastructure
-  - [ ] Step 1: Add constants `DEFAULT_DOCK_HEIGHT`, `MIN_DOCK_HEIGHT`, `MAX_DOCK_HEIGHT_VH`, `STORAGE_KEY`
-  - [ ] Step 2: Add `useState` hook for dock height
-  - [ ] Step 3: Create `loadDockHeight()` helper
-  - [ ] Step 4: Create `saveDockHeight(height: string)` helper
-  - [ ] Step 5: Add `useEffect` that persists height to localStorage
-  - [ ] Step 6: Pass height state up to `RunDetail` via `onDockHeightChange` callback
+- [x] Slice 1: localStorage Height Persistence Infrastructure
+  - [x] Step 1: Add constants `DEFAULT_DOCK_HEIGHT`, `MIN_DOCK_HEIGHT`, `MAX_DOCK_HEIGHT_VH`, `STORAGE_KEY`
+  - [x] Step 2: Add `useState` hook for dock height
+  - [x] Step 3: Create `loadDockHeight()` helper
+  - [x] Step 4: Create `saveDockHeight(height: string)` helper
+  - [x] Step 5: Add `useEffect` that persists height to localStorage
+  - [x] Step 6: Pass height state up to `RunDetail` via `onDockHeightChange` callback
 
 ### Wave 2
 - [ ] Slice 2: Resize Handle and Drag Interaction

--- a/docs/superpowers/specs/2026-07-21-resizable-interview-dock.md
+++ b/docs/superpowers/specs/2026-07-21-resizable-interview-dock.md
@@ -1,0 +1,114 @@
+# Resizable Interview Dock with Background Scroll
+
+## Intent Description
+
+When workflow questions appear in the Fabro UI, the interview dock panel renders at the bottom of the screen as a fixed-position overlay. This panel currently has a hardcoded height (`18rem` clearance when questions are present, `5rem` when showing the steer bar), and content behind the panel cannot be scrolled while the panel is visible. Users working with long stage lists, extensive file change lists, or deep content in the Overview tab must answer or dismiss questions before they can navigate the obscured interface regions.
+
+This change adds resize and scroll capabilities to the interview dock panel:
+
+1. **Vertical resize**: Users can drag a handle at the top edge of the interview dock to adjust its height, similar to resizing a terminal pane or chat sidebar. The panel remembers the user's preferred height across sessions.
+2. **Background scroll**: Content behind the interview dock remains scrollable. Users can scroll through stages, files, or overview content without needing to resize or dismiss the interview panel first.
+
+These improvements allow users to reference obscured information while formulating answers, compare question context with earlier stages, or review file changes without losing the current interview state.
+
+## Architecture Specification
+
+### Component Changes
+
+#### Interview Dock Resize Mechanism
+
+- Add a drag handle to the top edge of `InterviewDock` (`apps/fabro-web/app/components/interview-dock.tsx`). The handle appears as a horizontal bar with a visual affordance (e.g., centered grip icon or subtle hover highlight).
+- Implement vertical resize via mouse/touch drag interaction. During drag, update the dock height in real time. Use the same interaction pattern as `AskFabroSidebar` resize (`apps/fabro-web/app/components/chats/ask-fabro-sidebar.tsx` lines 84–102), which manages width resize with a handle, `onResizeActiveChange`, and pixel delta computation.
+- Constrain dock height to a minimum (e.g., `12rem` to ensure question text, context, and controls remain visible) and maximum (e.g., `80vh` to keep some background content visible).
+- Persist the user's chosen height in `localStorage` under a key like `fabro.interviewDock.height`. On mount, read the stored height and apply it; fall back to the current default (`18rem`) if no preference exists.
+- Expose the current dock height and resize-active state from `InterviewDock` via callback props. The parent (`RunDetailDockedControls`) passes these values up to `RunDetail`.
+
+#### CSS Variable Update
+
+- Change `--fabro-interview-dock-clearance` in `apps/fabro-web/app/routes/run-detail.tsx` (line 303) from a binary `18rem` / `5rem` value to the user's actual dock height. When no questions are pending and the steer bar is visible, keep the existing `5rem` clearance.
+- When resize is active, suppress the CSS transition on `--fabro-interview-dock-clearance` (similar to how `--fabro-ask-sidebar-transition` is set to `none` during sidebar resize; see `apps/fabro-web/app/routes/run-detail/docked-controls.tsx` lines 55–60). This prevents janky animation during drag.
+
+#### Background Scroll Behavior
+
+The interview dock is currently `position: fixed` with `bottom: 0` (`apps/fabro-web/app/routes/run-detail/docked-controls.tsx` line 148). Content below the dock is obscured but not scrollable past the dock's top edge.
+
+To enable scroll behind the dock:
+
+- Keep the dock as `position: fixed; bottom: 0` so it remains anchored during scroll.
+- Content panes (Overview, Stages, Files Changed, etc.) already use `pb-[var(--fabro-interview-dock-clearance)]` or similar padding to reserve space below their scroll containers. This padding ensures scrollable content isn't hidden behind the dock.
+- Verify that all scrollable regions (`run-overview.tsx` lines 145 & 149, `run-stages.tsx` line 1506, `run-files/virtualized-diff-list.tsx` line 20, etc.) continue to apply the clearance padding. No changes are required if the existing padding is already correct—users will be able to scroll through the full content height because the padding accounts for the dock's presence.
+- The dock itself should not interfere with pointer events on the background content. Since the dock is a distinct fixed layer and the background is scrollable within its own container, this should already work without changes.
+
+### Files Modified
+
+- `apps/fabro-web/app/components/interview-dock.tsx`: Add resize handle, drag interaction, height state, localStorage persistence, and callbacks to expose height/resize-active state.
+- `apps/fabro-web/app/routes/run-detail/docked-controls.tsx`: Accept dock height and resize-active state from `InterviewDock`, pass them up to `RunDetail`.
+- `apps/fabro-web/app/routes/run-detail.tsx`: Receive dock height from `RunDetailDockedControls`, set `--fabro-interview-dock-clearance` to the dynamic height, suppress transition during resize.
+
+### Constraints
+
+- Minimum dock height: `12rem` (enough to show question, context snippet, and answer controls).
+- Maximum dock height: `80vh` (ensures at least 20% of the viewport remains visible above the dock).
+- The default height (when no localStorage preference exists) remains `18rem` to match current behavior.
+- Resize handle should be visually distinct but not intrusive—consistent with Fabro's existing drag handle patterns (e.g., `AskFabroSidebar` resize handle).
+- Scrollable content panes must not clip or hide content behind the dock. Existing `pb-[var(--fabro-interview-dock-clearance)]` padding ensures this; verify no regressions.
+
+## Acceptance Criteria
+
+### Resize Functionality
+
+1. When an interview question is pending, a resize handle appears at the top edge of the interview dock panel.
+2. Dragging the resize handle upward increases dock height; dragging downward decreases it.
+3. Dock height is constrained to `[12rem, 80vh]`. Attempts to drag beyond these bounds clamp to the limit.
+4. During drag, the dock height updates smoothly in real time without layout jank.
+5. Releasing the drag handle persists the new height to `localStorage`.
+6. Refreshing the page or navigating away and returning to a run detail page with pending questions restores the user's last chosen dock height.
+7. If no height preference exists in `localStorage`, the dock defaults to `18rem`.
+
+### Scroll Functionality
+
+8. When the interview dock is visible, scrollable content regions (Overview stage cards, Stages sidebar, Files Changed list) remain scrollable.
+9. Scrolling a content pane to the bottom reveals all content; the `pb-[var(--fabro-interview-dock-clearance)]` padding ensures the last item is not obscured by the dock.
+10. Scrolling behavior is consistent across all run detail tabs (Overview, Stages, Files Changed, Events, etc.).
+
+### Visual and Interaction Polish
+
+11. The resize handle has a hover state indicating it is draggable.
+12. The cursor changes to `ns-resize` (vertical resize cursor) when hovering over the handle.
+13. The `--fabro-interview-dock-clearance` CSS transition is suppressed (set to `none`) while resize is active, then restored when the drag ends.
+14. The dock's appearance (colors, spacing, borders) remains unchanged aside from the addition of the resize handle.
+
+### Edge Cases
+
+15. If the viewport is resized such that `80vh` becomes smaller than `12rem`, the dock height clamps to `12rem` (minimum takes precedence).
+16. If the user's stored height exceeds the new maximum after a viewport resize, the dock height clamps to `80vh` on next mount.
+17. When no questions are pending and the steer bar is visible, the existing `5rem` clearance is used (resize handle is not shown).
+18. Switching between runs or navigating between tabs does not reset the dock height unless the stored preference is explicitly cleared.
+
+## Ambiguity Log
+
+| Decision | Classification | Resolved By | Rationale / Answer |
+|----------|---------------|-------------|-------------------|
+| Minimum dock height value | inferable | codebase & design | `12rem` is chosen to match the approximate height needed to show a question header, a few lines of question text, a context snippet, and answer controls (buttons or a single-line textarea). This is consistent with the existing interview dock's visual structure (see `apps/fabro-web/app/components/interview-dock.tsx` lines 100–122). |
+| Maximum dock height constraint | inferable | design patterns | `80vh` ensures at least 20% of the viewport remains visible above the dock. This is a common UX pattern for resizable bottom panels (e.g., VS Code terminal, Chrome DevTools) and prevents the dock from fully obscuring the UI. The Ask Fabro sidebar uses a similar pattern with a maximum width (`SIDEBAR_MAX_WIDTH` is `60vw` in prototype code, though the current implementation uses a fixed max). |
+| Default height for first-time users | inferable | existing behavior | The current clearance is `18rem` when questions are present (line 303 of `run-detail.tsx`). Preserving this as the default maintains continuity and avoids surprising existing users. |
+| Height persistence mechanism | inferable | existing patterns | The codebase uses `localStorage` for client-side preferences (e.g., `AskFabroSidebar` width persistence pattern from the chats prototype, see `docs/superpowers/specs/2026-05-16-chats-new-prototype-design.md` lines 145–147). This is the standard approach for per-user UI state that doesn't require server-side storage. |
+| Resize handle visual design | inferable | existing patterns | The Ask Fabro sidebar resize handle pattern (vertical bar, hover state, cursor change) is the established precedent. The interview dock resize handle should follow the same visual language: a thin horizontal bar with a centered grip affordance, `ns-resize` cursor on hover, and subtle hover highlight. |
+| Behavior when stored height is invalid | inferable | defensive coding | If `localStorage` returns a non-numeric or out-of-bounds value, fall back to the default `18rem`. This is standard defensive handling for user-supplied preferences. |
+| Transition suppression during resize | inferable | existing patterns | The `--fabro-ask-sidebar-transition` variable is set to `none` during resize and restored afterward to prevent janky transitions (see `apps/fabro-web/app/routes/run-detail/docked-controls.tsx` lines 57–59). The same pattern applies to `--fabro-interview-dock-clearance` transitions to avoid visual stutter during drag. |
+| Scrollable content padding verification | inferable | existing code | All scrollable panes already use `pb-[var(--fabro-interview-dock-clearance)]` or a calculated variant (e.g., `pb-[calc(1.5rem+var(--fabro-interview-dock-clearance,0px))]`). See `apps/fabro-web/app/routes/run-overview.tsx` lines 145 & 149, `run-stages.tsx` line 1506, `run-files/virtualized-diff-list.tsx` line 20. These ensure content is not clipped by the fixed dock. The feature works correctly if the clearance variable is updated to reflect the dynamic height. |
+| Resize interaction pattern | inferable | existing patterns | The `AskFabroSidebar` resize implementation (pointer events, drag delta computation, state updates) is the reference. The interview dock resize uses the same approach: `onPointerDown` on the handle, `onPointerMove` on a global listener during drag, `onPointerUp` to end drag, and state updates to propagate height changes. |
+| Z-index and layering | inferable | existing code | The interview dock is already `z-30` (`apps/fabro-web/app/routes/run-detail/docked-controls.tsx` line 149). Scrollable content is not `position: fixed` and thus layers below the dock. No z-index changes are needed. |
+| Mobile/touch support | inferable | existing patterns | The Ask Fabro sidebar resize uses pointer events (`onPointerDown`, `onPointerMove`, `onPointerUp`), which handle both mouse and touch. The interview dock resize should use the same pointer event API for consistent touch support. |
+| Documented inferences approved | requires-stakeholder-input | human | "ok" — Human accepted all documented inferences without changes. |
+
+**All findings resolved.**
+
+## Cross-Artifact Consistency Gate
+
+- [x] Intent is unambiguous — two developers would interpret it the same way.
+- [x] Every behavior/goal in the intent maps to at least one acceptance criterion.
+- [x] Architecture constrains implementation without over-engineering.
+- [x] Same concepts named consistently across all three artifacts.
+- [x] No artifact contradicts another.
+- [x] Every gap/ambiguity finding is logged — inferable with rationale, or resolved by the human.


### PR DESCRIPTION
Adds vertical resize to the interview dock panel and lets the page behind it scroll, so users can adjust the panel height and reach obscured content without dismissing workflow questions.

Spec: docs/superpowers/specs/2026-07-21-resizable-interview-dock.md
Plan: docs/plans/2026-07-21-resizable-interview-dock-plan.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)