### PR TITLE
Finalize parallel branch stages instead of leaving them Running

### DIFF
--- a/lib/crates/fabro-store/src/run_state.rs
+++ b/lib/crates/fabro-store/src/run_state.rs
@@ -2033,15 +2033,19 @@ mod tests {
         // terminal. Guards against branches spinning Running forever.
         let mut state = initialized_projection();
         let branch = StageId::new("review_ux", 1);
+        let branch_started_at = test_dt("2026-04-07T12:00:00Z");
 
         state
-            .apply_event(&test_stage_event(
+            .apply_event(&test_stage_event_at(
                 3,
+                "2026-04-07T12:00:00Z",
                 EventBody::ParallelBranchStarted(ParallelBranchStartedProps { index: 0 }),
                 branch.clone(),
             ))
             .unwrap();
-        assert_eq!(state.stage(&branch).unwrap().state, StageState::Running);
+        let stage = state.stage(&branch).unwrap();
+        assert_eq!(stage.state, StageState::Running);
+        assert_eq!(stage.started_at, Some(branch_started_at));
 
         state
             .apply_event(&test_stage_event(
@@ -2062,6 +2066,42 @@ mod tests {
         assert_eq!(
             stage.completion.as_ref().unwrap().outcome,
             StageOutcome::Succeeded
+        );
+    }
+
+    #[test]
+    fn parallel_branch_completed_folds_failed_status_as_failed() {
+        let mut state = initialized_projection();
+        let branch = StageId::new("review_ux", 1);
+
+        state
+            .apply_event(&test_stage_event(
+                3,
+                EventBody::ParallelBranchStarted(ParallelBranchStartedProps { index: 0 }),
+                branch.clone(),
+            ))
+            .unwrap();
+        state
+            .apply_event(&test_stage_event(
+                4,
+                EventBody::ParallelBranchCompleted(ParallelBranchCompletedProps {
+                    index:       0,
+                    duration_ms: 500,
+                    status:      "failed".to_string(),
+                    head_sha:    None,
+                }),
+                branch.clone(),
+            ))
+            .unwrap();
+
+        let stage = state.stage(&branch).unwrap();
+        assert_eq!(stage.state, StageState::Failed);
+        assert_eq!(stage.timing.unwrap().wall_time_ms, 500);
+        assert_eq!(
+            stage.completion.as_ref().unwrap().outcome,
+            StageOutcome::Failed {
+                retry_requested: false,
+            }
         );
     }
 

--- a/lib/crates/fabro-store/src/run_state.rs
+++ b/lib/crates/fabro-store/src/run_state.rs
@@ -513,6 +513,38 @@ impl RunProjectionReducer for RunProjection {
                 };
                 stage.parallel_results = Some(parallel_results);
             }
+            EventBody::ParallelBranchStarted(_) => {
+                // Branches bypass the engine's StageStarted/StageCompleted
+                // lifecycle. Seed started_at so the branch stage drives a live
+                // wall-clock timer while it runs (the entry is created Running).
+                let Some(stage) = stage_at_stored_or_current_visit(self, stored, event.seq) else {
+                    return Ok(());
+                };
+                if stage.started_at.is_none() {
+                    stage.started_at = Some(ts);
+                }
+                stage.state = StageState::Running;
+            }
+            EventBody::ParallelBranchCompleted(props) => {
+                // A branch never emits its own StageCompleted, so finalize it
+                // here; otherwise the stage spins Running forever after the run
+                // (and the fan-in) is done.
+                let outcome =
+                    StageOutcome::from_str(&props.status).unwrap_or(StageOutcome::Failed {
+                        retry_requested: false,
+                    });
+                let Some(stage) = stage_at_stored_or_current_visit(self, stored, event.seq) else {
+                    return Ok(());
+                };
+                stage.completion = Some(StageCompletion {
+                    outcome,
+                    notes: None,
+                    failure_reason: None,
+                    timestamp: ts,
+                });
+                stage.timing = Some(fabro_types::StageTiming::wall_only(props.duration_ms));
+                stage.state = StageState::from(outcome);
+            }
             EventBody::TodoCreated(props) => {
                 let Some(stage) = stage_at_stored_or_current_visit(self, stored, event.seq) else {
                     return Ok(());
@@ -1259,8 +1291,9 @@ mod tests {
         AgentSubFailedProps, AgentSubSpawnedProps, AgentToolCategory, AgentToolSource,
         AgentToolStartedProps, AgentToolSummary, AgentToolsAvailableProps,
         CheckpointCompletedProps, InterviewCompletedProps, InterviewOption, InterviewStartedProps,
-        RunCompletedProps, RunControlEffectProps, StageCompletedProps, StageFailedProps,
-        StagePromptProps, StageRetryingProps, StageStartedProps,
+        ParallelBranchCompletedProps, ParallelBranchStartedProps, RunCompletedProps,
+        RunControlEffectProps, StageCompletedProps, StageFailedProps, StagePromptProps,
+        StageRetryingProps, StageStartedProps,
     };
     use fabro_types::settings::run::{DockerfileSource, EnvironmentProvider};
     use fabro_types::{
@@ -1990,6 +2023,46 @@ mod tests {
         let stage = state.stage(&stage_id).unwrap();
         assert_eq!(stage.first_event_seq, first_event_seq(3));
         assert_eq!(stage.prompt.as_deref(), Some("prompt"));
+    }
+
+    #[test]
+    fn parallel_branch_completed_finalizes_branch_stage() {
+        // A parallel branch never runs through the engine's StageStarted/
+        // StageCompleted lifecycle: its stage entry is created Running by the
+        // first branch-scoped event, and only ParallelBranchCompleted marks it
+        // terminal. Guards against branches spinning Running forever.
+        let mut state = initialized_projection();
+        let branch = StageId::new("review_ux", 1);
+
+        state
+            .apply_event(&test_stage_event(
+                3,
+                EventBody::ParallelBranchStarted(ParallelBranchStartedProps { index: 0 }),
+                branch.clone(),
+            ))
+            .unwrap();
+        assert_eq!(state.stage(&branch).unwrap().state, StageState::Running);
+
+        state
+            .apply_event(&test_stage_event(
+                4,
+                EventBody::ParallelBranchCompleted(ParallelBranchCompletedProps {
+                    index:       0,
+                    duration_ms: 1234,
+                    status:      "succeeded".to_string(),
+                    head_sha:    None,
+                }),
+                branch.clone(),
+            ))
+            .unwrap();
+
+        let stage = state.stage(&branch).unwrap();
+        assert_eq!(stage.state, StageState::Succeeded);
+        assert_eq!(stage.timing.unwrap().wall_time_ms, 1234);
+        assert_eq!(
+            stage.completion.as_ref().unwrap().outcome,
+            StageOutcome::Succeeded
+        );
     }
 
     fn start_stage(state: &mut RunProjection, stage_id: &StageId) {


### PR DESCRIPTION
## Problem

Parallel fan-out branch stages spin a Running spinner forever in the stages sidebar, with a `--` duration, even after the run and its fan-in are done. Seen on run `01KY4AR7B1NW365DTER6TJ6BBN` (`review_acceptance/design/ux/strategic/parallel` stuck spinning while `merge_reviews` shows ✅ 22ms).

Before:
<img width="254" height="242" alt="image" src="https://github.com/user-attachments/assets/687c6270-7b0c-42ef-9000-53ee72cde1ed" />

After:
<img width="249" height="234" alt="image" src="https://github.com/user-attachments/assets/58be924b-fa99-4910-8f69-15ab6b341815" />


## Root cause

Branch handlers are dispatched in `tokio::spawn` (`handler/parallel.rs`), bypassing the engine's `EventLifecycle`. So branch stages never emit `StageStarted`/`StageCompleted`. Their `StageProjection` is created by the first branch-scoped event (e.g. `Prompt`) and defaults to `state: Running`. The projection fold in `fabro-store` handled the group-level `ParallelCompleted` but ignored `ParallelBranchStarted`/`ParallelBranchCompleted`, so branch stages never reached a terminal state. `RunFailed` sweeps unfinished stages; `RunCompleted` does not, so successful parallel runs leave the branches Running.

## Fix

Fold the two branch events in the run projection (`run_state.rs`):

- `ParallelBranchStarted` → seed `started_at` so the branch drives a live wall-clock timer while it runs.
- `ParallelBranchCompleted` → set the terminal state and wall-time from the branch's own status.

Both events already carry `stage_id = (branch, 1)` via their scope, so they key to the right stage. Pure projection change: it re-folds from the persisted event log, so existing runs render correctly once the server picks up the change — no migration.

## Test

Added `parallel_branch_completed_finalizes_branch_stage`: a branch stage goes Running → Succeeded with timing. Full `fabro-store` suite passes. Verified in the UI against the run above on a debug server built from a copy of its event log.

Out of scope: branch stages still show no handler icon (`handler: None`), since they don't emit `StageStarted` carrying a `handler_type`. Pre-existing and cosmetic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)