### PR TITLE
Let repo init use the target server default environment

### DIFF
--- a/lib/crates/fabro-cli/src/commands/repo/init.rs
+++ b/lib/crates/fabro-cli/src/commands/repo/init.rs
@@ -117,11 +117,12 @@ draft = true
         );
     }
 
-    // Create workflow.toml
+    // Leave the environment unspecified so the target server can supply its
+    // default.
     let toml_path = workflow_dir.join("workflow.toml");
     std::fs::write(
         &toml_path,
-        "_version = 1\n\n[workflow]\ngraph = \"workflow.fabro\"\n\n[run.environment]\nid = \"local\"\n\n[environments.local]\nprovider = \"local\"\n",
+        "_version = 1\n\n[workflow]\ngraph = \"workflow.fabro\"\n",
     )
     .with_context(|| format!("failed to write {}", toml_path.display()))?;
     created.push(".fabro/workflows/hello/workflow.toml".to_string());

--- a/lib/crates/fabro-cli/tests/it/cmd/repo_init.rs
+++ b/lib/crates/fabro-cli/tests/it/cmd/repo_init.rs
@@ -96,12 +96,6 @@ fn repo_init_creates_project_toml_and_hello_workflow() {
 
     [workflow]
     graph = "workflow.fabro"
-
-    [run.environment]
-    id = "local"
-
-    [environments.local]
-    provider = "local"
     "###
     );
 }


### PR DESCRIPTION
## Summary

- stop pinning the generated hello workflow to the local sandbox provider
- let environment resolution fall through to the target server default
- update the repo init integration snapshot for the minimal workflow config

This prevents a freshly initialized project from failing when the selected remote server disables the local provider and supplies a remote default environment.

## Testing

- cargo nextest run -p fabro-cli --test it repo_init
- cargo +nightly-2026-04-14 fmt --check --all
- cargo +nightly-2026-04-14 clippy --workspace --all-targets -- -D warnings
- cargo insta pending-snapshots
- git diff --check