### PR TITLE
Add Kimi K3 support and fix OpenAI-compatible tools

### DIFF
--- a/lib/crates/fabro-agent/src/profiles/openai.rs
+++ b/lib/crates/fabro-agent/src/profiles/openai.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use fabro_model::{AgentProfileKind, Catalog, ProviderId};
+use fabro_model::{AgentProfileKind, Catalog, CodecKind, ProviderId};
 
 use super::EnvContext;
 use crate::agent_profile::AgentProfile;
@@ -12,10 +12,27 @@ use crate::skills::Skill;
 use crate::todo_runtime::TodoRuntime;
 use crate::todo_tools::make_update_plan_tool;
 use crate::tool_registry::ToolRegistry;
-use crate::tools::{WebFetchSummarizer, register_core_tools};
+use crate::tools::{self, WebFetchSummarizer, register_core_tools};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum FileEditToolKind {
+    ApplyPatch,
+    EditFile,
+}
+
+impl FileEditToolKind {
+    fn for_codec(codec: CodecKind) -> Self {
+        if codec == CodecKind::OpenAiResponses {
+            Self::ApplyPatch
+        } else {
+            Self::EditFile
+        }
+    }
+}
 
 pub struct OpenAiProfile {
-    base: BaseProfile,
+    base:           BaseProfile,
+    file_edit_tool: FileEditToolKind,
 }
 
 impl OpenAiProfile {
@@ -39,13 +56,14 @@ impl OpenAiProfile {
         registry.register(make_update_plan_tool(todo_runtime));
 
         Self {
-            base: BaseProfile {
+            base:           BaseProfile {
                 profile_kind: AgentProfileKind::OpenAi,
                 provider_id: ProviderId::openai(),
                 model: model.into(),
                 catalog: None,
                 registry,
             },
+            file_edit_tool: FileEditToolKind::ApplyPatch,
         }
     }
 
@@ -53,13 +71,41 @@ impl OpenAiProfile {
     #[must_use]
     pub fn with_provider_id(mut self, provider_id: ProviderId) -> Self {
         self.base.provider_id = provider_id;
+        self.configure_file_edit_tool();
         self
     }
 
     #[must_use]
     pub fn with_catalog(mut self, catalog: Arc<Catalog>) -> Self {
         self.base.catalog = Some(catalog);
+        self.configure_file_edit_tool();
         self
+    }
+
+    fn configure_file_edit_tool(&mut self) {
+        let Some(codec) = self.base.catalog.as_ref().and_then(|catalog| {
+            catalog.effective_codec(&self.base.provider_id, Some(&self.base.model))
+        }) else {
+            return;
+        };
+        let desired = FileEditToolKind::for_codec(codec);
+        if desired == self.file_edit_tool {
+            return;
+        }
+
+        match desired {
+            FileEditToolKind::ApplyPatch => {
+                self.base.registry.unregister("edit_file");
+                self.base
+                    .registry
+                    .register(apply_patch::make_apply_patch_tool());
+            }
+            FileEditToolKind::EditFile => {
+                self.base.registry.unregister("apply_patch");
+                self.base.registry.register(tools::make_edit_file_tool());
+            }
+        }
+        self.file_edit_tool = desired;
     }
 
     fn provider_display_name(&self) -> String {
@@ -108,13 +154,47 @@ impl AgentProfile for OpenAiProfile {
         skills: &[Skill],
     ) -> String {
         let provider_name = self.provider_display_name();
+        let (file_edit_tool_name, file_edit_failure_guidance, file_edit_tool_guidance) =
+            match self.file_edit_tool {
+                FileEditToolKind::ApplyPatch => (
+                    "apply_patch",
+                    "- When apply_patch fails, use the error text to construct a corrected patch. \
+Re-read the target file if you need fresh context.",
+                    "## apply_patch
+Use the `apply_patch` tool for all file modifications. This is a freeform tool: pass the raw \
+patch text directly, never wrap it in JSON. The format uses `*** Begin Patch` / \
+`*** End Patch` delimiters with `*** Add File:`, `*** Delete File:`, `*** Update File:` \
+operations. Use `-` for removals, `+` for additions, and space-prefix for unchanged context \
+lines. Show 3 lines of context around each change. NEVER use `applypatch` or `apply-patch`, \
+only `apply_patch`.
+
+Example:
+```
+*** Begin Patch
+*** Update File: src/main.py
+@@ def hello():
+-    print(\"old\")
++    print(\"new\")
+*** End Patch
+```",
+                ),
+                FileEditToolKind::EditFile => (
+                    "edit_file",
+                    "- When edit_file fails, use the error text to construct a corrected exact \
+replacement. Re-read the target file if you need fresh context.",
+                    "## edit_file
+Use `edit_file` to modify an existing file by replacing an exact string. Read the file first. \
+The `old_string` must match exactly and be unique unless `replace_all` is true; include enough \
+surrounding context to make the match unique and preserve the existing indentation.",
+                ),
+            };
         let core_prompt = format!("\
 You are a coding agent powered by {provider_name}, running in a terminal-based agentic coding assistant. \
 You are expected to be precise, safe, and helpful.
 
 You can receive user prompts and context such as files in the workspace, communicate with the \
 user by streaming thinking and responses, and emit function calls to run terminal commands and \
-apply patches.
+edit files.
 
 # Personality
 
@@ -146,8 +226,7 @@ If completing the task requires writing or modifying files:
 and focused on the task.
 - Use `git log` and `git blame` to search the history of the codebase if additional context is needed.
 - NEVER add copyright or license headers unless specifically requested.
-- When apply_patch fails, use the error text to construct a corrected patch. Re-read the target \
-file if you need fresh context.
+{file_edit_failure_guidance}
 - Do not `git commit` your changes or create new git branches unless explicitly requested.
 
 # Validating Your Work
@@ -163,26 +242,10 @@ Use the provided tools to interact with the codebase and environment.
 ## read_file
 Read files to understand code before modifying. Use offset/limit for large files.
 
-## apply_patch
-Use the `apply_patch` tool for all file modifications. This is a freeform tool: pass the raw \
-patch text directly, never wrap it in JSON. The format uses `*** Begin Patch` / \
-`*** End Patch` delimiters with `*** Add File:`, `*** Delete File:`, `*** Update File:` \
-operations. Use `-` for removals, `+` for additions, and space-prefix for unchanged context \
-lines. Show 3 lines of context around each change. NEVER use `applypatch` or `apply-patch`, \
-only `apply_patch`.
-
-Example:
-```
-*** Begin Patch
-*** Update File: src/main.py
-@@ def hello():
--    print(\"old\")
-+    print(\"new\")
-*** End Patch
-```
+{file_edit_tool_guidance}
 
 ## write_file
-Use for creating new files. For modifications, prefer apply_patch.
+Use for creating new files. For modifications, prefer {file_edit_tool_name}.
 
 ## shell
 Execute shell commands. Default timeout is 10 seconds. Use timeout_ms parameter for \
@@ -348,6 +411,44 @@ mod tests {
         let prompt = profile.build_system_prompt(&env, &EnvContext::default(), &[], None, &[]);
         assert!(prompt.contains("powered by Kimi"));
         assert!(!prompt.contains("powered by OpenAI"));
+    }
+
+    #[test]
+    fn openai_compatible_profile_uses_json_schema_edit_tool() {
+        let profile = OpenAiProfile::new("kimi-k2.5")
+            .with_provider_id(ProviderId::new("kimi"))
+            .with_catalog(test_catalog());
+
+        let names = profile.tool_registry().names();
+        assert!(names.contains(&"edit_file".to_string()));
+        assert!(!names.contains(&"apply_patch".to_string()));
+
+        let edit_file = profile.tool_registry().get("edit_file").unwrap();
+        assert!(!edit_file.definition.is_custom());
+        assert_eq!(edit_file.definition.parameters["type"], "object");
+        for definition in profile.tool_registry().definitions() {
+            assert_eq!(
+                definition.parameters["type"], "object",
+                "tool '{}' must use an object parameter schema",
+                definition.name
+            );
+        }
+
+        let env = MockSandbox::linux();
+        let prompt = profile.build_system_prompt(&env, &EnvContext::default(), &[], None, &[]);
+        assert!(prompt.contains("## edit_file"));
+        assert!(!prompt.contains("## apply_patch"));
+        assert!(!prompt.contains("freeform tool"));
+    }
+
+    #[test]
+    fn file_edit_tool_selection_is_builder_order_independent() {
+        let profile = OpenAiProfile::new("kimi-k2.5")
+            .with_catalog(test_catalog())
+            .with_provider_id(ProviderId::new("kimi"));
+
+        assert!(profile.tool_registry().get("edit_file").is_some());
+        assert!(profile.tool_registry().get("apply_patch").is_none());
     }
 
     #[test]

--- a/lib/crates/fabro-agent/tests/it/parity_matrix.rs
+++ b/lib/crates/fabro-agent/tests/it/parity_matrix.rs
@@ -17,6 +17,7 @@ use fabro_auth::EnvCredentialSource;
 use fabro_llm::client::Client;
 use fabro_llm::provider::ProviderAdapter;
 use fabro_llm::providers::{OpenAiAdapter, OpenAiCompatibleAdapter};
+use fabro_model::catalog::{LlmCatalogSettings, ProviderCatalogSettings};
 use fabro_model::{Catalog, ModelHandle, ProviderId};
 use fabro_test::{TwinScenario, TwinScenarios, TwinToolCall, twin_openai};
 use tokio::sync::Mutex as AsyncMutex;
@@ -184,7 +185,20 @@ fn make_openai_compatible_twin_session(
     twin: &OpenAiTwinOptions,
 ) -> Session {
     let client = make_openai_compatible_twin_client(&provider, twin);
-    let catalog = Arc::new(Catalog::from_builtin().expect("default catalog should build"));
+    // LiteLLM is opt-in in the built-in catalog. Enable the provider in this
+    // twin fixture so the profile can resolve the same OpenAI-compatible
+    // codec that the manually registered adapter uses.
+    let mut settings = LlmCatalogSettings::default();
+    settings
+        .providers
+        .insert(provider.to_string(), ProviderCatalogSettings {
+            enabled: Some(true),
+            ..ProviderCatalogSettings::default()
+        });
+    let catalog = Arc::new(
+        Catalog::from_builtin_with_overrides(&settings)
+            .expect("OpenAI-compatible twin catalog should build"),
+    );
     let profile: Arc<dyn AgentProfile> = Arc::new(
         OpenAiProfile::new(model)
             .with_provider_id(provider)

--- a/lib/crates/fabro-agent/tests/it/parity_matrix.rs
+++ b/lib/crates/fabro-agent/tests/it/parity_matrix.rs
@@ -56,11 +56,16 @@ fn build_summarizer(provider: &Provider, client: &Client) -> WebFetchSummarizer 
 
 fn build_profile(provider: &Provider, model: &str, client: &Client) -> Box<dyn AgentProfile> {
     let summarizer = Some(build_summarizer(provider, client));
+    let catalog = Arc::new(Catalog::from_builtin().expect("default catalog should build"));
     match provider.as_str() {
         ProviderId::ANTHROPIC => Box::new(AnthropicProfile::with_summarizer(model, summarizer)),
-        ProviderId::OPENAI => Box::new(OpenAiProfile::with_summarizer(model, summarizer)),
+        ProviderId::OPENAI => Box::new(
+            OpenAiProfile::with_summarizer(model, summarizer).with_catalog(Arc::clone(&catalog)),
+        ),
         "kimi" | "zai" | "minimax" | "inception" => Box::new(
-            OpenAiProfile::with_summarizer(model, summarizer).with_provider_id(provider.clone()),
+            OpenAiProfile::with_summarizer(model, summarizer)
+                .with_provider_id(provider.clone())
+                .with_catalog(Arc::clone(&catalog)),
         ),
         ProviderId::GEMINI => Box::new(GeminiProfile::with_summarizer(model, summarizer)),
         other => panic!("unexpected provider {other}"),
@@ -85,6 +90,7 @@ async fn make_session(
     let factory_cwd = cwd.to_path_buf();
     let factory_provider = provider.clone();
     let factory: SessionFactory = Arc::new(move || {
+        let catalog = Arc::new(Catalog::from_builtin().expect("default catalog should build"));
         let sub_profile: Arc<dyn AgentProfile> = {
             let summarizer = Some(build_summarizer(&factory_provider, &factory_client));
             match factory_provider.as_str() {
@@ -92,12 +98,14 @@ async fn make_session(
                     &factory_model,
                     summarizer,
                 )),
-                ProviderId::OPENAI => {
-                    Arc::new(OpenAiProfile::with_summarizer(&factory_model, summarizer))
-                }
+                ProviderId::OPENAI => Arc::new(
+                    OpenAiProfile::with_summarizer(&factory_model, summarizer)
+                        .with_catalog(Arc::clone(&catalog)),
+                ),
                 "kimi" | "zai" | "minimax" | "inception" => Arc::new(
                     OpenAiProfile::with_summarizer(&factory_model, summarizer)
-                        .with_provider_id(factory_provider.clone()),
+                        .with_provider_id(factory_provider.clone())
+                        .with_catalog(Arc::clone(&catalog)),
                 ),
                 ProviderId::GEMINI => {
                     Arc::new(GeminiProfile::with_summarizer(&factory_model, summarizer))
@@ -176,8 +184,12 @@ fn make_openai_compatible_twin_session(
     twin: &OpenAiTwinOptions,
 ) -> Session {
     let client = make_openai_compatible_twin_client(&provider, twin);
-    let profile: Arc<dyn AgentProfile> =
-        Arc::new(OpenAiProfile::new(model).with_provider_id(provider));
+    let catalog = Arc::new(Catalog::from_builtin().expect("default catalog should build"));
+    let profile: Arc<dyn AgentProfile> = Arc::new(
+        OpenAiProfile::new(model)
+            .with_provider_id(provider)
+            .with_catalog(catalog),
+    );
     let env = Arc::new(LocalSandbox::new(cwd.to_path_buf()));
     Session::new(client, profile, env, config, None)
 }
@@ -271,27 +283,25 @@ macro_rules! provider_tests {
 }
 
 #[fabro_macros::e2e_test(twin)]
-async fn openai_compatible_twin_preserves_raw_apply_patch_arguments() {
+async fn openai_compatible_twin_uses_json_edit_file_tool() {
     let tmp = tempfile::tempdir().expect("failed to create tempdir");
     let file_path = tmp.path().join("data.txt");
     std::fs::write(&file_path, "old\n").expect("failed to write data.txt");
 
     let (base_url, api_key) = fabro_test::e2e_openai!();
     let twin = OpenAiTwinOptions { base_url, api_key };
-    let patch = "\
-*** Begin Patch
-*** Update File: data.txt
-@@
--old
-+new
-*** End Patch
-";
-
     TwinScenarios::new(twin.api_key.clone())
         .scenario(
             TwinScenario::chat_completions("gpt-5.4-mini")
                 .input_contains("Replace old with new")
-                .tool_call(TwinToolCall::apply_patch_raw_arguments(patch)),
+                .tool_call(TwinToolCall::new(
+                    "edit_file",
+                    serde_json::json!({
+                        "file_path": "data.txt",
+                        "old_string": "old",
+                        "new_string": "new"
+                    }),
+                )),
         )
         .load(twin_openai().await)
         .await;
@@ -311,7 +321,7 @@ async fn openai_compatible_twin_preserves_raw_apply_patch_arguments() {
     let mut rx = session.subscribe();
 
     session
-        .process_input("Replace old with new in data.txt using apply_patch")
+        .process_input("Replace old with new in data.txt using edit_file")
         .await
         .expect("process_input failed");
 

--- a/lib/crates/fabro-llm/src/adapter_registry.rs
+++ b/lib/crates/fabro-llm/src/adapter_registry.rs
@@ -310,6 +310,7 @@ mod tests {
             ("gpt-5.6-sol",                        "gpt-5.6-sol",                         T::OpenAi,            C::OpenAiResponses,   B::OpenAi,    P::OpenAi),
             ("gpt-5.6-terra",                      "gpt-5.6-terra",                       T::OpenAi,            C::OpenAiResponses,   B::OpenAi,    P::OpenAi),
             ("kimi-k2.5",                          "kimi-k2.5",                           T::OpenAiCompatible,  C::OpenAiCompatible,  B::OpenAi,    P::OpenAi),
+            ("kimi-k3",                            "kimi-k3",                             T::OpenAiCompatible,  C::OpenAiCompatible,  B::OpenAi,    P::OpenAi),
             ("mercury-2",                          "mercury-2",                           T::OpenAiCompatible,  C::OpenAiCompatible,  B::OpenAi,    P::OpenAi),
             ("minimax-m2.5",                       "minimax-m2.5",                        T::OpenAiCompatible,  C::OpenAiCompatible,  B::OpenAi,    P::OpenAi),
             ("venice-uncensored-1-2",              "venice-uncensored-1-2",               T::OpenAiCompatible,  C::OpenAiCompatible,  B::OpenAi,    P::OpenAi),

--- a/lib/crates/fabro-llm/src/client.rs
+++ b/lib/crates/fabro-llm/src/client.rs
@@ -1183,6 +1183,26 @@ output_cost_per_mtok = 2.0
     }
 
     #[tokio::test]
+    async fn complete_accepts_supported_kimi_k3_reasoning_effort() {
+        let catalog = Arc::new(Catalog::from_builtin().unwrap());
+        let mut client = Client::new(HashMap::new(), None, vec![]);
+        client.catalog = Some(Arc::clone(&catalog));
+        client
+            .register_provider(Arc::new(MockProvider::new("kimi", "accepted")))
+            .await
+            .unwrap();
+
+        let mut request = test_request();
+        request.model = "kimi-k3".to_string();
+        request.provider = Some("kimi".to_string());
+        request.reasoning_effort = Some(ReasoningEffort::High);
+
+        let response = client.complete(&request).await.unwrap();
+
+        assert_eq!(response.text(), "accepted");
+    }
+
+    #[tokio::test]
     async fn complete_rejects_unsupported_speed_before_dispatch() {
         let catalog = Arc::new(Catalog::from_builtin().unwrap());
         let mut client = Client::new(HashMap::new(), None, vec![]);

--- a/lib/crates/fabro-llm/src/codec/openai_compatible/mod.rs
+++ b/lib/crates/fabro-llm/src/codec/openai_compatible/mod.rs
@@ -21,7 +21,7 @@ pub(crate) struct OpenAiCompatible;
 
 impl Codec for OpenAiCompatible {
     fn encode(&self, ctx: &CodecCtx<'_>, stream: bool) -> Result<EncodedRequest, Error> {
-        Ok(request::encode(ctx, stream))
+        request::encode(ctx, stream)
     }
 
     fn decode_response(

--- a/lib/crates/fabro-llm/src/codec/openai_compatible/request.rs
+++ b/lib/crates/fabro-llm/src/codec/openai_compatible/request.rs
@@ -27,13 +27,22 @@ pub(super) fn encode(ctx: &CodecCtx<'_>, stream: bool) -> Result<EncodedRequest,
         .response_format
         .as_ref()
         .map(translate::translate_response_format);
+    let (temperature, top_p) = if ctx
+        .model
+        .is_none_or(fabro_model::Model::supports_sampling_params)
+    {
+        (request.temperature, request.top_p)
+    } else {
+        (None, None)
+    };
 
     let api_request = ApiRequest {
         model: ctx.deployment_id.to_string(),
         messages: chat_messages,
-        temperature: request.temperature,
+        temperature,
         max_tokens: request.max_tokens,
-        top_p: request.top_p,
+        top_p,
+        reasoning_effort: request.reasoning_effort,
         stop: request.stop_sequences.clone(),
         tools,
         tool_choice,
@@ -70,10 +79,12 @@ pub(super) fn merge_provider_options(
 
 #[cfg(test)]
 mod tests {
+    use fabro_model::Catalog;
+
     use super::super::wire::ApiRequest;
     use super::*;
     use crate::codec::CodecParams;
-    use crate::types::{Message, Request, ToolDefinition};
+    use crate::types::{Message, ReasoningEffort, Request, ToolDefinition};
 
     fn minimal_request() -> Request {
         Request {
@@ -112,31 +123,33 @@ mod tests {
     #[test]
     fn api_request_stream_field_serialization() {
         let req = ApiRequest {
-            model:           "test".into(),
-            messages:        vec![],
-            temperature:     None,
-            max_tokens:      None,
-            top_p:           None,
-            stop:            None,
-            tools:           None,
-            tool_choice:     None,
-            response_format: None,
-            stream:          Some(true),
+            model:            "test".into(),
+            messages:         vec![],
+            temperature:      None,
+            max_tokens:       None,
+            top_p:            None,
+            reasoning_effort: None,
+            stop:             None,
+            tools:            None,
+            tool_choice:      None,
+            response_format:  None,
+            stream:           Some(true),
         };
         let json = serde_json::to_value(&req).unwrap();
         assert_eq!(json["stream"], true);
 
         let req_no_stream = ApiRequest {
-            model:           "test".into(),
-            messages:        vec![],
-            temperature:     None,
-            max_tokens:      None,
-            top_p:           None,
-            stop:            None,
-            tools:           None,
-            tool_choice:     None,
-            response_format: None,
-            stream:          None,
+            model:            "test".into(),
+            messages:         vec![],
+            temperature:      None,
+            max_tokens:       None,
+            top_p:            None,
+            reasoning_effort: None,
+            stop:             None,
+            tools:            None,
+            tool_choice:      None,
+            response_format:  None,
+            stream:           None,
         };
         let json_no_stream = serde_json::to_value(&req_no_stream).unwrap();
         assert!(json_no_stream.get("stream").is_none());
@@ -156,6 +169,38 @@ mod tests {
         };
         let body = encode(&ctx, false).unwrap().body;
         assert_eq!(body["model"], "acme/model-large");
+    }
+
+    #[test]
+    fn encode_serializes_reasoning_effort_at_top_level() {
+        let mut request = minimal_request();
+        request.reasoning_effort = Some(ReasoningEffort::High);
+
+        let body = encode_body(&request, "kimi", false);
+
+        assert_eq!(body["reasoning_effort"], "high");
+    }
+
+    #[test]
+    fn encode_omits_sampling_params_for_models_that_reject_them() {
+        let model = Catalog::builtin().get("kimi-k3").unwrap();
+        let mut request = minimal_request();
+        request.model = model.id.clone();
+        request.temperature = Some(0.7);
+        request.top_p = Some(0.9);
+        let params = CodecParams::default();
+        let ctx = CodecCtx {
+            request:       &request,
+            provider_name: "kimi",
+            deployment_id: &model.id,
+            model:         Some(model),
+            params:        &params,
+        };
+
+        let body = encode(&ctx, false).unwrap().body;
+
+        assert!(body.get("temperature").is_none());
+        assert!(body.get("top_p").is_none());
     }
 
     #[test]

--- a/lib/crates/fabro-llm/src/codec/openai_compatible/request.rs
+++ b/lib/crates/fabro-llm/src/codec/openai_compatible/request.rs
@@ -3,20 +3,22 @@
 use super::translate;
 use super::wire::ApiRequest;
 use crate::codec::{CodecCtx, EncodedRequest, merge_named_provider_options};
+use crate::error::Error;
 
 /// Build the Chat Completions request for `ctx.request`. `stream` toggles the
 /// `stream` body field. The body is assembled as a `serde_json::Value` so
 /// `provider_options.<provider_name>` fields can be merged in before sending.
 ///
-/// Infallible for this dialect — the `Codec::encode` `Result` is wrapped by the
-/// trait impl.
-pub(super) fn encode(ctx: &CodecCtx<'_>, stream: bool) -> EncodedRequest {
+/// Returns an error when the request contains a custom tool definition, which
+/// the Chat Completions tool envelope cannot represent.
+pub(super) fn encode(ctx: &CodecCtx<'_>, stream: bool) -> Result<EncodedRequest, Error> {
     let request = ctx.request;
     let chat_messages = translate::translate_messages(&request.messages);
     let tools = request
         .tools
         .as_ref()
-        .map(|t| translate::translate_tools(t));
+        .map(|t| translate::translate_tools(t))
+        .transpose()?;
     let tool_choice = request
         .tool_choice
         .as_ref()
@@ -46,11 +48,11 @@ pub(super) fn encode(ctx: &CodecCtx<'_>, stream: bool) -> EncodedRequest {
         ctx.provider_name,
     );
 
-    EncodedRequest {
+    Ok(EncodedRequest {
         body,
         endpoint: "/chat/completions".to_string(),
         headers: Vec::new(),
-    }
+    })
 }
 
 /// Merge `provider_options.<provider_name>` fields into the serialized API
@@ -71,7 +73,7 @@ mod tests {
     use super::super::wire::ApiRequest;
     use super::*;
     use crate::codec::CodecParams;
-    use crate::types::{Message, Request};
+    use crate::types::{Message, Request, ToolDefinition};
 
     fn minimal_request() -> Request {
         Request {
@@ -104,7 +106,7 @@ mod tests {
             model: None,
             params: &params,
         };
-        encode(&ctx, stream).body
+        encode(&ctx, stream).unwrap().body
     }
 
     #[test]
@@ -152,8 +154,36 @@ mod tests {
             model:         None,
             params:        &params,
         };
-        let body = encode(&ctx, false).body;
+        let body = encode(&ctx, false).unwrap().body;
         assert_eq!(body["model"], "acme/model-large");
+    }
+
+    #[test]
+    fn encode_rejects_custom_tool_definitions() {
+        let mut request = minimal_request();
+        request.tools = Some(vec![ToolDefinition::custom(
+            "apply_patch",
+            "Apply a patch",
+            serde_json::json!({"type": "grammar"}),
+        )]);
+        let params = CodecParams::default();
+        let deployment_id = request.model.clone();
+        let ctx = CodecCtx {
+            request:       &request,
+            provider_name: "kimi",
+            deployment_id: &deployment_id,
+            model:         None,
+            params:        &params,
+        };
+
+        let Err(error) = encode(&ctx, false) else {
+            panic!("custom tool definition should be rejected");
+        };
+        assert!(matches!(
+            error,
+            Error::Configuration { message, source: None }
+                if message.contains("custom tool definition 'apply_patch'")
+        ));
     }
 
     #[test]

--- a/lib/crates/fabro-llm/src/codec/openai_compatible/translate.rs
+++ b/lib/crates/fabro-llm/src/codec/openai_compatible/translate.rs
@@ -1,6 +1,7 @@
 //! Pure mapping between canonical types and the Chat Completions wire shapes.
 
 use super::wire::{ChatFunction, ChatMessage, ChatToolCall};
+use crate::error::Error;
 use crate::types::{
     ContentPart, CostSource, FinishReason, Message, Request, ResponseFormat, ResponseFormatType,
     Role, ToolChoice, ToolDefinition,
@@ -146,18 +147,28 @@ pub(super) fn translate_messages(messages: &[Message]) -> Vec<ChatMessage> {
         .collect()
 }
 
-pub(super) fn translate_tools(tools: &[ToolDefinition]) -> Vec<serde_json::Value> {
+pub(super) fn translate_tools(tools: &[ToolDefinition]) -> Result<Vec<serde_json::Value>, Error> {
     tools
         .iter()
         .map(|t| {
-            serde_json::json!({
+            if t.is_custom() {
+                return Err(Error::Configuration {
+                    message: format!(
+                        "openai_compatible codec does not support custom tool definition '{}'",
+                        t.name
+                    ),
+                    source:  None,
+                });
+            }
+
+            Ok(serde_json::json!({
                 "type": "function",
                 "function": {
                     "name": t.name,
                     "description": t.description,
                     "parameters": t.parameters,
                 }
-            })
+            }))
         })
         .collect()
 }

--- a/lib/crates/fabro-llm/src/codec/openai_compatible/wire.rs
+++ b/lib/crates/fabro-llm/src/codec/openai_compatible/wire.rs
@@ -1,27 +1,29 @@
 //! Serde types mirroring the OpenAI Chat Completions wire shapes.
 
-use crate::types::TokenCounts;
+use crate::types::{ReasoningEffort, TokenCounts};
 
 #[derive(serde::Serialize)]
 pub(super) struct ApiRequest {
-    pub model:           String,
-    pub messages:        Vec<ChatMessage>,
+    pub model:            String,
+    pub messages:         Vec<ChatMessage>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub temperature:     Option<f64>,
+    pub temperature:      Option<f64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub max_tokens:      Option<i64>,
+    pub max_tokens:       Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub top_p:           Option<f64>,
+    pub top_p:            Option<f64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub stop:            Option<Vec<String>>,
+    pub reasoning_effort: Option<ReasoningEffort>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub tools:           Option<Vec<serde_json::Value>>,
+    pub stop:             Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub tool_choice:     Option<serde_json::Value>,
+    pub tools:            Option<Vec<serde_json::Value>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub response_format: Option<serde_json::Value>,
+    pub tool_choice:      Option<serde_json::Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub stream:          Option<bool>,
+    pub response_format:  Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stream:           Option<bool>,
 }
 
 #[derive(serde::Serialize)]

--- a/lib/crates/fabro-llm/src/providers/openai_compatible.rs
+++ b/lib/crates/fabro-llm/src/providers/openai_compatible.rs
@@ -8,7 +8,7 @@ use crate::error::Error;
 use crate::provider::{
     ProviderAdapter, StreamEventStream, validate_standard_speed, validate_tool_choice,
 };
-use crate::providers::common::api_model_id;
+use crate::providers::common::{self as common};
 use crate::transport::{self, HttpTransport, SseFraming};
 use crate::types::{AdapterTimeout, Request, Response};
 
@@ -88,7 +88,7 @@ impl Adapter {
     /// Resolve the wire model id (catalog `api_id`, falling back to the
     /// requested model).
     fn deployment_id(&self, request: &Request) -> String {
-        api_model_id(self.catalog.as_deref(), &request.model)
+        common::api_model_id(self.catalog.as_deref(), &request.model)
     }
 
     /// Build the borrowed codec context. `deployment_id` and `params` are
@@ -103,7 +103,7 @@ impl Adapter {
             request,
             provider_name: &self.provider_name,
             deployment_id,
-            model: None,
+            model: common::catalog_model(self.catalog.as_deref(), &request.model),
             params,
         }
     }

--- a/lib/crates/fabro-llm/tests/integration.rs
+++ b/lib/crates/fabro-llm/tests/integration.rs
@@ -10,7 +10,9 @@ use fabro_llm::provider::ProviderAdapter;
 use fabro_llm::providers::{
     AnthropicAdapter, BedrockAdapter, GeminiAdapter, OpenAiAdapter, OpenAiCompatibleAdapter,
 };
-use fabro_llm::types::{CostSource, FinishReason, Message, Request};
+use fabro_llm::types::{
+    CostSource, FinishReason, Message, ReasoningEffort, Request, ToolChoice, ToolDefinition,
+};
 use fabro_model::Catalog;
 use fabro_static::EnvVars;
 
@@ -123,6 +125,74 @@ async fn openai_gpt_5_5_pro_complete() {
     assert!(response.usage.input_tokens > 0);
     assert!(response.usage.output_tokens > 0);
     assert_eq!(response.provider, "openai");
+}
+
+#[fabro_macros::e2e_test(live("KIMI_API_KEY"))]
+async fn kimi_k3_reasoning_tool_round_trip() {
+    let api_key = std::env::var(EnvVars::KIMI_API_KEY).expect("KIMI_API_KEY must be set");
+    let adapter = OpenAiCompatibleAdapter::new(api_key, "https://api.moonshot.ai/v1")
+        .with_name("kimi")
+        .with_catalog(Arc::new(Catalog::from_builtin().unwrap()));
+    let tool = ToolDefinition::function(
+        "multiply",
+        "Multiply two integers",
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "a": {"type": "integer"},
+                "b": {"type": "integer"}
+            },
+            "required": ["a", "b"]
+        }),
+    );
+    let request = Request {
+        model: "kimi-k3".to_string(),
+        messages: vec![Message::user(
+            "Use the multiply tool to calculate 19 times 23. Do not calculate it yourself.",
+        )],
+        tools: Some(vec![tool]),
+        tool_choice: Some(ToolChoice::Required),
+        temperature: Some(0.0),
+        max_tokens: Some(4096),
+        reasoning_effort: Some(ReasoningEffort::Low),
+        ..make_request("kimi-k3")
+    };
+
+    let tool_response = adapter.complete(&request).await.unwrap();
+    assert_eq!(tool_response.finish_reason, FinishReason::ToolCalls);
+    assert!(
+        tool_response.reasoning().is_some(),
+        "K3 should return reasoning content before its tool call"
+    );
+    let tool_call = tool_response
+        .tool_calls()
+        .into_iter()
+        .next()
+        .expect("K3 should call the required tool");
+    assert_eq!(tool_call.name, "multiply");
+
+    let mut messages = request.messages.clone();
+    messages.push(tool_response.message);
+    messages.push(Message::tool_result(
+        tool_call.id,
+        serde_json::json!({"product": 437}),
+        false,
+    ));
+    let final_request = Request {
+        model: "kimi-k3".to_string(),
+        messages,
+        temperature: Some(0.0),
+        max_tokens: Some(2048),
+        reasoning_effort: Some(ReasoningEffort::Low),
+        ..make_request("kimi-k3")
+    };
+
+    let final_response = adapter.complete(&final_request).await.unwrap();
+    assert_eq!(final_response.finish_reason, FinishReason::Stop);
+    assert!(
+        final_response.text().contains("437"),
+        "K3 should incorporate the replayed tool result"
+    );
 }
 
 #[fabro_macros::e2e_test(twin)]

--- a/lib/crates/fabro-llm/tests/it/wire/openai_compatible.rs
+++ b/lib/crates/fabro-llm/tests/it/wire/openai_compatible.rs
@@ -2,11 +2,15 @@
 //! `OpenAiCompatibleAdapter` (kimi, zai, minimax, venice, inception, ollama,
 //! litellm — all config-only routes over this adapter).
 
+use std::sync::Arc;
+
 use fabro_llm::provider::ProviderAdapter;
 use fabro_llm::providers::OpenAiCompatibleAdapter;
 use fabro_llm::types::{
-    Message, Request, ResponseFormat, ResponseFormatType, ToolChoice, ToolDefinition,
+    Message, ReasoningEffort, Request, ResponseFormat, ResponseFormatType, ToolChoice,
+    ToolDefinition,
 };
+use fabro_model::Catalog;
 use httpmock::prelude::*;
 
 use crate::support::{
@@ -229,6 +233,27 @@ async fn encode_response_format_json_schema() {
 async fn encode_sampling_params() {
     let capture = encode_capture(&corpus_sampling_params(MODEL)).await;
     fabro_test::fabro_json_snapshot!(capture.body);
+}
+
+#[tokio::test]
+async fn encode_kimi_k3_uses_catalog_reasoning_and_sampling_controls() {
+    let catalog = Arc::new(Catalog::from_builtin().expect("built-in catalog should build"));
+    let request = Request {
+        model: "kimi-k3".to_string(),
+        reasoning_effort: Some(ReasoningEffort::High),
+        temperature: Some(0.7),
+        top_p: Some(0.9),
+        ..base_request(MODEL)
+    };
+    let capture = encode_capture_with(&request, move |adapter| {
+        adapter.with_name("kimi").with_catalog(catalog)
+    })
+    .await;
+
+    assert_eq!(capture.body["model"], "kimi-k3");
+    assert_eq!(capture.body["reasoning_effort"], "high");
+    assert!(capture.body.get("temperature").is_none());
+    assert!(capture.body.get("top_p").is_none());
 }
 
 /// The provider_options namespace key is the runtime adapter NAME, not a

--- a/lib/crates/fabro-model/src/catalog.rs
+++ b/lib/crates/fabro-model/src/catalog.rs
@@ -2266,9 +2266,7 @@ enabled = true
             "claude-haiku-4-5",
             &fallbacks,
         );
-        assert_eq!(chain.len(), 1);
-        assert_eq!(chain[0].provider, "kimi");
-        assert_eq!(chain[0].model, "kimi-k2.5");
+        assert!(chain.is_empty());
     }
 
     #[test]
@@ -4246,7 +4244,7 @@ sampling_params = false
             limits: ModelLimits {
                 context_window: 262144,
                 max_output: Some(
-                    16000,
+                    32768,
                 ),
             },
             training: Some(
@@ -4258,10 +4256,10 @@ sampling_params = false
             features: ModelFeatures {
                 tools: true,
                 vision: true,
-                reasoning: false,
+                reasoning: true,
                 reasoning_effort: None,
-                prompt_cache: false,
-                sampling_params: true,
+                prompt_cache: true,
+                sampling_params: false,
             },
             costs: ModelCosts {
                 input_cost_per_mtok: Some(
@@ -4270,11 +4268,59 @@ sampling_params = false
                 output_cost_per_mtok: Some(
                     3.0,
                 ),
-                cache_input_cost_per_mtok: None,
+                cache_input_cost_per_mtok: Some(
+                    0.1,
+                ),
             },
             estimated_output_tps: Some(
                 50.0,
             ),
+            aliases: [],
+            default: false,
+            small_default: false,
+            configured: false,
+        }
+        "#);
+    }
+
+    #[test]
+    fn kimi_k3_in_catalog() {
+        let catalog = Catalog::builtin();
+        let m = catalog.get("kimi-k3").unwrap();
+        insta::assert_debug_snapshot!(m, @r#"
+        Model {
+            id: "kimi-k3",
+            provider: kimi,
+            family: "kimi-k3",
+            display_name: "Kimi K3",
+            limits: ModelLimits {
+                context_window: 1048576,
+                max_output: Some(
+                    131072,
+                ),
+            },
+            training: None,
+            knowledge_cutoff: None,
+            features: ModelFeatures {
+                tools: true,
+                vision: true,
+                reasoning: true,
+                reasoning_effort: AlwaysAdaptive,
+                prompt_cache: true,
+                sampling_params: false,
+            },
+            costs: ModelCosts {
+                input_cost_per_mtok: Some(
+                    3.0,
+                ),
+                output_cost_per_mtok: Some(
+                    15.0,
+                ),
+                cache_input_cost_per_mtok: Some(
+                    0.3,
+                ),
+            },
+            estimated_output_tps: None,
             aliases: [
                 "kimi",
             ],
@@ -4283,11 +4329,23 @@ sampling_params = false
             configured: false,
         }
         "#);
+        assert_eq!(
+            catalog
+                .model_settings("kimi-k3")
+                .unwrap()
+                .controls
+                .reasoning_effort,
+            vec![
+                ReasoningEffort::Low,
+                ReasoningEffort::High,
+                ReasoningEffort::Max,
+            ]
+        );
     }
 
     #[test]
     fn kimi_alias() {
-        assert_eq!(Catalog::builtin().get("kimi").unwrap().id, "kimi-k2.5");
+        assert_eq!(Catalog::builtin().get("kimi").unwrap().id, "kimi-k3");
     }
 
     #[test]
@@ -4485,10 +4543,11 @@ context_window = 1050000
     #[test]
     fn closest_model_haiku_to_kimi() {
         let haiku = Catalog::builtin().get("claude-haiku-4-5").unwrap();
-        let result = Catalog::builtin()
-            .closest(&ProviderId::new("kimi"), haiku)
-            .unwrap();
-        assert_eq!(result.id, "kimi-k2.5");
+        assert!(
+            Catalog::builtin()
+                .closest(&ProviderId::new("kimi"), haiku)
+                .is_none()
+        );
     }
 
     #[test]

--- a/lib/crates/fabro-model/src/catalog/providers/kimi.toml
+++ b/lib/crates/fabro-model/src/catalog/providers/kimi.toml
@@ -1,7 +1,7 @@
 [providers.kimi]
 display_name = "Kimi"
 adapter = "openai_compatible"
-api_key_url = "https://platform.moonshot.cn/console/api-keys"
+api_key_url = "https://platform.kimi.ai/console/api-keys"
 base_url = "https://api.moonshot.ai/v1"
 priority = 70
 
@@ -15,19 +15,50 @@ display_name = "Kimi K2.5"
 family = "kimi-k2"
 training = "2025-10-01"
 knowledge_cutoff = "October 2025"
-default = true
 estimated_output_tps = 50
-aliases = ["kimi"]
 
 [models."kimi-k2.5".limits]
 context_window = 262144
-max_output = 16000
+max_output = 32768
 
 [models."kimi-k2.5".features]
 tools = true
 vision = true
-reasoning = false
+reasoning = true
+prompt_cache = true
+sampling_params = false
 
 [models."kimi-k2.5".costs]
 input_cost_per_mtok = 0.6
 output_cost_per_mtok = 3.0
+cache_input_cost_per_mtok = 0.1
+
+[models."kimi-k3"]
+provider = "kimi"
+api_id = "kimi-k3"
+display_name = "Kimi K3"
+family = "kimi-k3"
+default = true
+aliases = ["kimi"]
+
+[models."kimi-k3".limits]
+context_window = 1048576
+# K3 accepts explicit completion budgets up to 1048576, but Fabro also uses
+# max_output as the default request budget. Match Kimi's 131072-token default.
+max_output = 131072
+
+[models."kimi-k3".features]
+tools = true
+vision = true
+reasoning = true
+reasoning_effort = "always_adaptive"
+prompt_cache = true
+sampling_params = false
+
+[models."kimi-k3".controls]
+reasoning_effort = ["low", "high", "max"]
+
+[models."kimi-k3".costs]
+input_cost_per_mtok = 3.0
+output_cost_per_mtok = 15.0
+cache_input_cost_per_mtok = 0.3

--- a/test/twin/openai/docs/compatibility-matrix.md
+++ b/test/twin/openai/docs/compatibility-matrix.md
@@ -30,6 +30,7 @@ Supported `/v1/responses` fields:
 Supported `/v1/chat/completions` fields:
 
 - bearer auth
+- `max_tokens`
 - `stream`
 - `tools`
 - `tool_choice`

--- a/test/twin/openai/src/openai/models.rs
+++ b/test/twin/openai/src/openai/models.rs
@@ -531,6 +531,7 @@ pub fn normalize_whitespace(input: &str) -> String {
 pub struct ChatCompletionsRequest {
     pub model:           String,
     pub messages:        Vec<ChatMessage>,
+    pub max_tokens:      Option<i64>,
     #[serde(default)]
     pub stream:          bool,
     pub tools:           Option<Vec<Value>>,

--- a/test/twin/openai/tests/chat_completions_contract.rs
+++ b/test/twin/openai/tests/chat_completions_contract.rs
@@ -69,6 +69,7 @@ async fn chat_completions_accepts_supported_openai_compatible_fields() {
                 },
                 { "role": "user", "content": "structured chat" }
             ],
+            "max_tokens": 128,
             "stream": false,
             "tools": [{ "type": "function", "function": { "name": "lookup" } }],
             "tool_choice": "auto",


### PR DESCRIPTION
## Summary

- use the OpenAI-compatible tool envelope for coding-agent tools and preserve reasoning content across tool turns
- correct the existing Kimi K2.5 catalog metadata and move the `kimi` default alias to Kimi K3
- add Kimi K3 with its 1M context, current pricing, automatic caching, and documented `low` / `high` / `max` reasoning levels
- encode the standard top-level `reasoning_effort` field and honor catalog sampling-parameter support in the generic OpenAI-compatible codec
- add a live K3 reasoning/tool round-trip test

The production implementation remains provider-neutral: Kimi behavior is expressed through static catalog data and the shared OpenAI-compatible path, without Kimi-specific Rust branches.

Official references:

- https://platform.kimi.ai/docs/models
- https://platform.kimi.ai/docs/api/models-overview
- https://platform.kimi.ai/docs/guide/kimi-k3-quickstart
- https://platform.kimi.ai/

## Verification

- `cargo +nightly-2026-04-14 fmt --check --all`
- `cargo nextest run -p fabro-model --no-fail-fast` — 138 passed
- `cargo nextest run -p fabro-llm --no-fail-fast` — 614 passed
- `cargo +nightly-2026-04-14 clippy -p fabro-model -p fabro-llm --all-targets -- -D warnings`
- live `kimi_k3_reasoning_tool_round_trip` — passed against the Kimi API
