### PR TITLE
Update implement-plan workflow to GPT-5.6 Sol and Claude Fable 5

### DIFF
--- a/.fabro/workflows/implement-plan/workflow.fabro
+++ b/.fabro/workflows/implement-plan/workflow.fabro
@@ -1,10 +1,5 @@
 digraph ImplementPlan {
-    graph [
-        goal="Implement and simplify",
-        model_stylesheet="
-            * { model: claude-opus-4-7; }
-        "
-    ]
+    graph [goal="Implement and simplify"]
     rankdir=LR
 
     start [shape=Mdiamond, label="Start"]
@@ -13,12 +8,12 @@ digraph ImplementPlan {
     toolchain         [label="Toolchain", shape=parallelogram, script="command -v cargo >/dev/null || { curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y && sudo ln -sf $HOME/.cargo/bin/* /usr/local/bin/; }; cargo --version 2>&1", max_retries=0]
     preflight_compile [label="Preflight Compile", shape=parallelogram, script="cargo check -q --workspace 2>&1", max_retries=0]
     preflight_lint    [label="Preflight Lint", shape=parallelogram, script="cargo +nightly-2026-04-14 clippy -q --workspace --all-targets -- -D warnings 2>&1", max_retries=0]
-    fix_lints         [label="Fix Lints", prompt="The preflight lint step failed. Read the build output from context and fix all clippy lint warnings.", max_visits=3]
-    implement         [label="Implement", prompt="Read the plan file referenced in the goal and implement every step. Make all the code changes described in the plan. Use red/green TDD.", model="gpt-55", reasoning_effort="xhigh"]
-    simplify_opus     [label="Simplify (Opus)", prompt="@prompts/simplify.md"]
-    simplify_gpt      [label="Simplify (GPT-55)", prompt="@prompts/simplify.md", model="gpt-55"]
+    fix_lints         [label="Fix Lints", prompt="The preflight lint step failed. Read the build output from context and fix all clippy lint warnings.", model="anthropic/claude-fable-5", provider="openrouter", reasoning_effort="xhigh", max_visits=3]
+    implement         [label="Implement", prompt="Read the plan file referenced in the goal and implement every step. Make all the code changes described in the plan. Use red/green TDD.", model="openai/gpt-5.6-sol", provider="openrouter", reasoning_effort="max"]
+    simplify_fable    [label="Simplify (Claude Fable 5)", prompt="@prompts/simplify.md", model="anthropic/claude-fable-5", provider="openrouter", reasoning_effort="xhigh"]
+    simplify_sol      [label="Simplify (GPT-5.6 Sol)", prompt="@prompts/simplify.md", model="openai/gpt-5.6-sol", provider="openrouter", reasoning_effort="max"]
     verify            [label="Verify", shape=parallelogram, script="git fetch origin main 2>&1 && git merge --no-edit --no-stat origin/main 2>&1 && cargo +nightly-2026-04-14 fmt --all 2>&1 && cargo dev docs refresh 2>&1 && cargo +nightly-2026-04-14 fmt --check --all 2>&1 && { command -v rg >/dev/null 2>&1 || { echo 'rg is required for verify'; exit 127; }; } && ! rg -n 'AuthMode::Disabled|RunAuthMethod|RunSubjectProvenance|\bActorRef\b|\bActorKind\b|AuthenticatedSubject|AuthenticatedService|AuthorizeRunScoped|AuthorizeRunBlob|AuthorizeStageArtifact|AuthorizeCommandLog|auth_method\s*==\s*\"disabled\"' lib/crates apps lib/packages docs/public/api-reference/fabro-api.yaml 2>&1 && cargo +nightly-2026-04-14 clippy --workspace --all-targets -- -D warnings 2>&1 && cargo nextest run --workspace --status-level slow --profile ci 2>&1 && cargo dev docs check 2>&1 && bun install --frozen-lockfile 2>&1 && (cd apps/fabro-web && bun run typecheck) 2>&1 && (cd apps/fabro-web && bun run test) 2>&1 && (cd lib/packages/fabro-api-client && bun run typecheck) 2>&1 && cargo dev build -- -p fabro-cli --release 2>&1", goal_gate=true, retry_target="fixup"]
-    fixup             [label="Fixup", prompt="The verify step failed. Read the build output from context and fix all format, clippy, Rust test, docs, TypeScript typecheck/test, and build failures.", max_visits=3]
+    fixup             [label="Fixup", prompt="The verify step failed. Read the build output from context and fix all format, clippy, Rust test, docs, TypeScript typecheck/test, and build failures.", model="anthropic/claude-fable-5", provider="openrouter", reasoning_effort="xhigh", max_visits=3]
 
     start -> toolchain
     toolchain -> preflight_compile [condition="outcome=succeeded"]
@@ -28,7 +23,7 @@ digraph ImplementPlan {
     preflight_lint -> implement [condition="outcome=succeeded"]
     preflight_lint -> fix_lints
     fix_lints -> preflight_lint
-    implement -> simplify_opus -> simplify_gpt -> verify
+    implement -> simplify_fable -> simplify_sol -> verify
     verify -> exit  [condition="outcome=succeeded"]
     verify -> fixup
     fixup -> verify


### PR DESCRIPTION
## Summary

- route implementation and the second simplification pass through GPT-5.6 Sol with max reasoning
- route lint repair, the first simplification pass, and verification repair through Claude Fable 5 with xhigh reasoning
- make OpenRouter explicit on every agent node and remove the obsolete global Claude Opus 4.7 default

## Validation

- `fabro validate .fabro/workflows/implement-plan/workflow.fabro --json --no-upgrade-check` (valid graph: 11 nodes, 14 edges)
- `fabro preflight .fabro/workflows/implement-plan/workflow.fabro --server https://fabro-testing.walleye-rainbow.ts.net --goal "Validate the updated model configuration." --json --no-upgrade-check` (passed repository, sandbox, and live OpenRouter generation checks for both models)
- `git diff --check`

The static model catalog warns about the provider-qualified OpenRouter IDs, but the deployed server successfully probed both IDs through explicit OpenRouter passthrough.