### PR TITLE
fix(test): strip inherited color-forcing env vars in brew upgrade tests

### DIFF
--- a/lib/crates/fabro-cli/tests/it/cmd/upgrade.rs
+++ b/lib/crates/fabro-cli/tests/it/cmd/upgrade.rs
@@ -49,6 +49,12 @@ fn brew_command(context: &TestContext, formula: &str, version: &str) -> Command 
         }
     }
     cmd.env(EnvVars::NO_COLOR, "1");
+    // Unlike context.command(), this command inherits the developer's
+    // environment, and inherited FORCE_COLOR/CLICOLOR_FORCE override NO_COLOR
+    // in the CLI's color detection — breaking these snapshots.
+    cmd.env_remove(EnvVars::FORCE_COLOR);
+    cmd.env_remove(EnvVars::CLICOLOR_FORCE);
+    cmd.env_remove(EnvVars::CLICOLOR);
     cmd.env(EnvVars::HOME, &context.home_dir);
     cmd.env(EnvVars::FABRO_NO_UPGRADE_CHECK, "true")
         .env(EnvVars::FABRO_HTTP_PROXY_POLICY, "disabled")

--- a/lib/crates/fabro-static/src/env_vars.rs
+++ b/lib/crates/fabro-static/src/env_vars.rs
@@ -114,6 +114,7 @@ impl EnvVars {
     pub const CI: &'static str = "CI";
     pub const CLICOLOR: &'static str = "CLICOLOR";
     pub const CLICOLOR_FORCE: &'static str = "CLICOLOR_FORCE";
+    pub const FORCE_COLOR: &'static str = "FORCE_COLOR";
     pub const HOME: &'static str = "HOME";
     pub const KUBERNETES_SERVICE_HOST: &'static str = "KUBERNETES_SERVICE_HOST";
     pub const LANG: &'static str = "LANG";
@@ -251,6 +252,7 @@ mod tests {
             EnvVars::CI,
             EnvVars::CLICOLOR,
             EnvVars::CLICOLOR_FORCE,
+            EnvVars::FORCE_COLOR,
             EnvVars::HOME,
             EnvVars::KUBERNETES_SERVICE_HOST,
             EnvVars::LANG,


### PR DESCRIPTION
## Summary

Two `fabro upgrade` snapshot tests fail on any machine with `FORCE_COLOR` exported (some terminals and agent sessions set it globally):

- `upgrade_brew_install_refuses_and_prints_brew_command`
- `upgrade_brew_install_rejects_version_flag`

The mechanism: the `brew_command` helper in `upgrade.rs` deliberately inherits the developer's environment (it only strips `FABRO_*` vars), unlike `context.command()` and the `fabro-test` helpers, which `env_clear()`. The harness sets `NO_COLOR=1`, but an inherited `FORCE_COLOR`/`CLICOLOR_FORCE` takes precedence in the CLI's color detection, so the spawned binary renders ANSI escapes into stderr and the plain-text snapshots fail:

```
-  × fabro is managed by Homebrew ...
+  ␛[31m×␛[0m fabro is managed by Homebrew ...
```

## Changes

- `brew_command` now `env_remove`s `FORCE_COLOR`, `CLICOLOR_FORCE`, and `CLICOLOR` next to the existing `NO_COLOR=1`.
- `EnvVars` gains the `FORCE_COLOR` constant (and the constants-completeness test entry); `CLICOLOR`/`CLICOLOR_FORCE` already existed.

The other `NO_COLOR` sites were audited and left alone: `context.command()`, `fabro-test`'s `isolated_env`/`apply_test_isolation_with_lookup`, and the doctor test all `env_clear()` first (safe), and the `server_start.rs` site asserts only on exit status, not output text.

## Test plan

- [x] With `FORCE_COLOR=3` exported: all 52 `upgrade` tests pass (previously 2 failed)
- [x] `cargo nextest run -p fabro-static -p fabro-test` — 33 passed (includes the EnvVars constants-completeness test)
- [x] `cargo +nightly-2026-04-14 clippy -p fabro-static -p fabro-cli --all-targets -- -D warnings` — clean
- [x] `cargo +nightly-2026-04-14 fmt --check --all` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)