### PR TITLE
Validate completion reasoning effort values

### DIFF
--- a/docs/public/api-reference/fabro-api.yaml
+++ b/docs/public/api-reference/fabro-api.yaml
@@ -8498,7 +8498,7 @@ components:
             type: string
           description: Stop sequences.
         reasoning_effort:
-          type: string
+          $ref: "#/components/schemas/ReasoningEffort"
           description: Reasoning effort level.
         provider:
           type: string

--- a/lib/apps/fabro-server/src/server/handler/completions.rs
+++ b/lib/apps/fabro-server/src/server/handler/completions.rs
@@ -109,7 +109,7 @@ async fn create_completion(
         } else {
             Some(req.stop_sequences)
         },
-        reasoning_effort: req.reasoning_effort.as_deref().and_then(|s| s.parse().ok()),
+        reasoning_effort: req.reasoning_effort,
         speed: None,
         metadata: None,
         provider_options: req.provider_options,

--- a/lib/apps/fabro-server/src/server/tests.rs
+++ b/lib/apps/fabro-server/src/server/tests.rs
@@ -15241,6 +15241,27 @@ async fn create_completion_missing_messages_returns_422() {
 }
 
 #[tokio::test]
+async fn create_completion_invalid_reasoning_effort_returns_422() {
+    let app = test_app_with();
+
+    let req = Request::builder()
+        .method("POST")
+        .uri(api("/completions"))
+        .header("content-type", "application/json")
+        .body(Body::from(
+            serde_json::json!({
+                "messages": [],
+                "reasoning_effort": "bogus"
+            })
+            .to_string(),
+        ))
+        .unwrap();
+
+    let response = app.oneshot(req).await.unwrap();
+    assert_status!(response, StatusCode::UNPROCESSABLE_ENTITY).await;
+}
+
+#[tokio::test]
 async fn create_completion_unknown_provider_returns_clear_error() {
     let app = test_app_with();
 

--- a/lib/foundation/fabro-api/tests/create_completion_request_round_trip.rs
+++ b/lib/foundation/fabro-api/tests/create_completion_request_round_trip.rs
@@ -10,16 +10,5 @@ fn create_completion_request_reuses_canonical_reasoning_effort() {
     }))
     .unwrap();
 
-    let reasoning_effort: Option<ReasoningEffort> = request.reasoning_effort;
-    assert_eq!(reasoning_effort, Some(ReasoningEffort::High));
-}
-
-#[test]
-fn create_completion_request_rejects_unknown_reasoning_effort() {
-    let result = serde_json::from_value::<CreateCompletionRequest>(json!({
-        "messages": [],
-        "reasoning_effort": "bogus"
-    }));
-
-    assert!(result.is_err());
+    assert_eq!(request.reasoning_effort, Some(ReasoningEffort::High));
 }

--- a/lib/foundation/fabro-api/tests/create_completion_request_round_trip.rs
+++ b/lib/foundation/fabro-api/tests/create_completion_request_round_trip.rs
@@ -1,0 +1,25 @@
+use fabro_api::types::CreateCompletionRequest;
+use fabro_model::ReasoningEffort;
+use serde_json::json;
+
+#[test]
+fn create_completion_request_reuses_canonical_reasoning_effort() {
+    let request: CreateCompletionRequest = serde_json::from_value(json!({
+        "messages": [],
+        "reasoning_effort": "high"
+    }))
+    .unwrap();
+
+    let reasoning_effort: Option<ReasoningEffort> = request.reasoning_effort;
+    assert_eq!(reasoning_effort, Some(ReasoningEffort::High));
+}
+
+#[test]
+fn create_completion_request_rejects_unknown_reasoning_effort() {
+    let result = serde_json::from_value::<CreateCompletionRequest>(json!({
+        "messages": [],
+        "reasoning_effort": "bogus"
+    }));
+
+    assert!(result.is_err());
+}

--- a/lib/packages/fabro-api-client/src/models/create-completion-request.ts
+++ b/lib/packages/fabro-api-client/src/models/create-completion-request.ts
@@ -22,6 +22,9 @@ import type { CompletionToolChoice } from './completion-tool-choice';
 // May contain unused imports in some cases
 // @ts-ignore
 import type { CompletionToolDefinition } from './completion-tool-definition';
+// May contain unused imports in some cases
+// @ts-ignore
+import type { ReasoningEffort } from './reasoning-effort';
 
 export interface CreateCompletionRequest {
     /**
@@ -56,7 +59,7 @@ export interface CreateCompletionRequest {
     /**
      * Reasoning effort level.
      */
-    'reasoning_effort'?: string;
+    'reasoning_effort'?: ReasoningEffort;
     /**
      * Optional provider pin.
      */


### PR DESCRIPTION
## Summary

- type completion `reasoning_effort` requests with the canonical `ReasoningEffort` enum
- pass the validated enum directly into the LLM request instead of silently dropping parse failures
- reject unknown reasoning-effort values at the HTTP request boundary and cover the contract in Rust and server tests
- regenerate the TypeScript API client with the enum-backed field

## Testing

- `cargo nextest run -p fabro-api`
- `ulimit -n 4096 && cargo nextest run -p fabro-server`
- `cargo +nightly-2026-04-14 fmt --check --all`
- `cargo +nightly-2026-04-14 clippy -p fabro-api -p fabro-server --all-targets -- -D warnings`
- `cd lib/packages/fabro-api-client && bun run typecheck`