### PR TITLE
Add portable model aliases

### DIFF
--- a/docs/public/core-concepts/models.mdx
+++ b/docs/public/core-concepts/models.mdx
@@ -59,7 +59,7 @@ Fabro performs this selection once when creating a run and persists the chosen p
 | `kimi-k2.5` | kimi | `kimi` | 262K | $0.60 / $3.00 | 50 tok/s |
 | `laguna-s-2.1` | poolside | `laguna`, `laguna-s` | 1M | $0.10 / $0.20 | n/a |
 | `laguna-xs-2.1` | poolside | `laguna-xs` | 262K | $0.10 / $0.20 | n/a |
-| `glm-4.7` | zai | `glm`, `glm4` | 203K | $0.60 / $2.20 | 100 tok/s |
+| `glm-5.2` | zai | `glm`, `glm5`, `glm52`, `glm5.2` | 1M | $1.40 / $4.40 | n/a |
 | `minimax-m2.5` | minimax | `minimax` | 197K | $0.30 / $1.20 | 45 tok/s |
 | `mercury-2` | inception | `mercury` | 131K | $0.25 / $0.75 | 1000 tok/s |
 
@@ -206,7 +206,7 @@ When no model or provider is specified, Fabro chooses the default offering on th
 | `gemini` | `gemini-3.5-flash` |
 | `kimi` | `kimi-k2.5` |
 | `poolside` | `laguna-s-2.1` |
-| `zai` | `glm-4.7` |
+| `zai` | `glm-5.2` |
 | `minimax` | `minimax-m2.5` |
 | `inception` | `mercury-2` |
 

--- a/docs/public/integrations/openrouter.mdx
+++ b/docs/public/integrations/openrouter.mdx
@@ -53,10 +53,11 @@ The built-in catalog gives OpenRouter offerings the same human-facing model slug
 | `claude-haiku-4-5` | `anthropic/claude-haiku-4.5`; provider small default |
 | `gpt-5.4`, `gpt-5.5` | `openai/gpt-5.4`, `openai/gpt-5.5` |
 | `gemini-3.1-pro-preview`, `gemini-3.5-flash` | `google/...` API IDs |
-| `deepseek-v4-pro`, `deepseek-v4-flash` | `deepseek/...` API IDs |
+| `deepseek-v4-pro` (`deepseek`, `deepseek-v4`), `deepseek-v4-flash` (`deepseek-flash`) | `deepseek/...` API IDs |
 | `kimi-k2.6`, `qwen3-coder`, `qwen3.6-flash` | Vendor-prefixed API IDs |
 | `laguna-s-2.1`, `laguna-xs-2.1` | `poolside/...`; native reasoning and tool use |
-| `glm-4.6`, `minimax-m2.7`, `mimo-v2.5-pro` | Vendor-prefixed API IDs |
+| `glm-5.2` (`glm`, `glm5`, `glm52`, `glm5.2`), `glm-4.6` | `z-ai/...` API IDs |
+| `minimax-m2.7`, `mimo-v2.5-pro` | Vendor-prefixed API IDs |
 | `nemotron-3-super-120b-a12b`, `devstral-2512` | Vendor-prefixed API IDs |
 
 Any other OpenRouter model can be added under the provider. Choose a stable Fabro model slug as the table key and put OpenRouter's exact vendor/model string in `api_id`:

--- a/lib/foundation/fabro-model/src/catalog.rs
+++ b/lib/foundation/fabro-model/src/catalog.rs
@@ -3136,6 +3136,57 @@ enabled = true
     }
 
     #[test]
+    fn builtin_glm_5_2_aliases_are_portable() {
+        let catalog = Catalog::from_builtin_with_overrides(&minimal_settings(
+            r"
+[providers.openrouter]
+enabled = true
+",
+        ))
+        .expect("enabled OpenRouter override should build from the built-in provider settings");
+
+        for provider in [ProviderId::new("zai"), ProviderId::new("openrouter")] {
+            for alias in ["glm", "glm5", "glm52", "glm5.2"] {
+                let model = catalog
+                    .resolve_on_provider(&provider, alias)
+                    .unwrap_or_else(|error| {
+                        panic!("{alias} should resolve on {provider}: {error}")
+                    });
+                assert_eq!(model.provider, provider, "{alias}");
+                assert_eq!(model.id, "glm-5.2", "{alias}");
+            }
+        }
+    }
+
+    #[test]
+    fn builtin_deepseek_v4_selectors_resolve_on_openrouter() {
+        let catalog = Catalog::from_builtin_with_overrides(&minimal_settings(
+            r"
+[providers.openrouter]
+enabled = true
+",
+        ))
+        .expect("enabled OpenRouter override should build from the built-in provider settings");
+        let openrouter = ProviderId::new("openrouter");
+
+        for (selector, canonical_id) in [
+            ("deepseek-v4-pro", "deepseek-v4-pro"),
+            ("deepseek-v4", "deepseek-v4-pro"),
+            ("deepseek", "deepseek-v4-pro"),
+            ("deepseek-v4-flash", "deepseek-v4-flash"),
+            ("deepseek-flash", "deepseek-v4-flash"),
+        ] {
+            let model = catalog
+                .resolve_on_provider(&openrouter, selector)
+                .unwrap_or_else(|error| {
+                    panic!("{selector} should resolve on {openrouter}: {error}")
+                });
+            assert_eq!(model.provider, openrouter, "{selector}");
+            assert_eq!(model.id, canonical_id, "{selector}");
+        }
+    }
+
+    #[test]
     fn builtin_legacy_vendor_ids_normalize_for_pinned_and_unpinned_selection() {
         let catalog = Catalog::from_builtin_with_overrides(&minimal_settings(
             r"
@@ -3260,7 +3311,12 @@ enabled = true
                 ),
             },
             estimated_output_tps: None,
-            aliases: [],
+            aliases: [
+                "glm",
+                "glm5",
+                "glm52",
+                "glm5.2",
+            ],
             default: false,
             small_default: false,
             configured: false,
@@ -6107,6 +6163,8 @@ sampling_params = false
             aliases: [
                 "glm",
                 "glm5",
+                "glm52",
+                "glm5.2",
             ],
             default: true,
             small_default: false,
@@ -6124,6 +6182,8 @@ sampling_params = false
         ]);
         assert_eq!(catalog.get("glm").unwrap().id, "glm-5.2");
         assert_eq!(catalog.get("glm5").unwrap().id, "glm-5.2");
+        assert_eq!(catalog.get("glm52").unwrap().id, "glm-5.2");
+        assert_eq!(catalog.get("glm5.2").unwrap().id, "glm-5.2");
     }
 
     #[test]

--- a/lib/foundation/fabro-model/src/catalog.rs
+++ b/lib/foundation/fabro-model/src/catalog.rs
@@ -3118,8 +3118,11 @@ enabled = true
         for provider in [ProviderId::openai(), ProviderId::new("openrouter")] {
             for (alias, canonical_id) in [
                 ("sol", "gpt-5.6-sol"),
+                ("gpt-sol", "gpt-5.6-sol"),
                 ("terra", "gpt-5.6-terra"),
+                ("gpt-terra", "gpt-5.6-terra"),
                 ("luna", "gpt-5.6-luna"),
+                ("gpt-luna", "gpt-5.6-luna"),
             ] {
                 let model = catalog
                     .resolve_on_provider(&provider, alias)

--- a/lib/foundation/fabro-model/src/catalog/providers/openai.toml
+++ b/lib/foundation/fabro-model/src/catalog/providers/openai.toml
@@ -14,7 +14,7 @@ family = "gpt-5"
 training = "2026-02-16"
 knowledge_cutoff = "February 16, 2026"
 default = true
-aliases = ["sol", "gpt56-sol", "gpt-56-sol", "gpt-5.6", "gpt56", "gpt-56"]
+aliases = ["sol", "gpt-sol", "gpt56-sol", "gpt-56-sol", "gpt-5.6", "gpt56", "gpt-56"]
 
 [providers.openai.models."gpt-5.6-sol".limits]
 context_window = 272000
@@ -37,7 +37,7 @@ display_name = "GPT-5.6 Terra"
 family = "gpt-5"
 training = "2026-02-16"
 knowledge_cutoff = "February 16, 2026"
-aliases = ["terra", "gpt56-terra", "gpt-56-terra"]
+aliases = ["terra", "gpt-terra", "gpt56-terra", "gpt-56-terra"]
 
 [providers.openai.models."gpt-5.6-terra".limits]
 context_window = 272000
@@ -60,7 +60,7 @@ display_name = "GPT-5.6 Luna"
 family = "gpt-5"
 training = "2026-02-16"
 knowledge_cutoff = "February 16, 2026"
-aliases = ["luna", "gpt56-luna", "gpt-56-luna"]
+aliases = ["luna", "gpt-luna", "gpt56-luna", "gpt-56-luna"]
 
 [providers.openai.models."gpt-5.6-luna".limits]
 context_window = 272000

--- a/lib/foundation/fabro-model/src/catalog/providers/openrouter.toml
+++ b/lib/foundation/fabro-model/src/catalog/providers/openrouter.toml
@@ -354,6 +354,7 @@ output_cost_per_mtok = 1.20
 api_id = "deepseek/deepseek-v4-pro"
 display_name = "DeepSeek V4 Pro"
 family = "deepseek-v4"
+aliases = ["deepseek-v4", "deepseek"]
 
 [providers.openrouter.models."deepseek-v4-pro".limits]
 context_window = 1050000
@@ -372,6 +373,7 @@ output_cost_per_mtok = 0.87
 api_id = "deepseek/deepseek-v4-flash"
 display_name = "DeepSeek V4 Flash"
 family = "deepseek-v4"
+aliases = ["deepseek-flash"]
 
 [providers.openrouter.models."deepseek-v4-flash".limits]
 context_window = 1050000
@@ -513,6 +515,7 @@ output_cost_per_mtok = 1.125
 api_id = "z-ai/glm-5.2"
 display_name = "GLM 5.2 (via OpenRouter)"
 family = "glm-5"
+aliases = ["glm", "glm5", "glm52", "glm5.2"]
 
 [providers.openrouter.models."glm-5.2".limits]
 context_window = 1048576

--- a/lib/foundation/fabro-model/src/catalog/providers/openrouter.toml
+++ b/lib/foundation/fabro-model/src/catalog/providers/openrouter.toml
@@ -167,7 +167,7 @@ display_name = "GPT-5.6 Sol (via OpenRouter)"
 family = "gpt-5"
 training = "2026-02-16"
 knowledge_cutoff = "February 16, 2026"
-aliases = ["sol", "gpt56-sol", "gpt-56-sol", "gpt-5.6", "gpt56", "gpt-56"]
+aliases = ["sol", "gpt-sol", "gpt56-sol", "gpt-56-sol", "gpt-5.6", "gpt56", "gpt-56"]
 
 [providers.openrouter.models."gpt-5.6-sol".limits]
 context_window = 1050000
@@ -192,7 +192,7 @@ display_name = "GPT-5.6 Terra (via OpenRouter)"
 family = "gpt-5"
 training = "2026-02-16"
 knowledge_cutoff = "February 16, 2026"
-aliases = ["terra", "gpt56-terra", "gpt-56-terra"]
+aliases = ["terra", "gpt-terra", "gpt56-terra", "gpt-56-terra"]
 
 [providers.openrouter.models."gpt-5.6-terra".limits]
 context_window = 1050000
@@ -217,7 +217,7 @@ display_name = "GPT-5.6 Luna (via OpenRouter)"
 family = "gpt-5"
 training = "2026-02-16"
 knowledge_cutoff = "February 16, 2026"
-aliases = ["luna", "gpt56-luna", "gpt-56-luna"]
+aliases = ["luna", "gpt-luna", "gpt56-luna", "gpt-56-luna"]
 
 [providers.openrouter.models."gpt-5.6-luna".limits]
 context_window = 1050000

--- a/lib/foundation/fabro-model/src/catalog/providers/zai.toml
+++ b/lib/foundation/fabro-model/src/catalog/providers/zai.toml
@@ -12,7 +12,7 @@ credentials = ["env:ZAI_API_KEY", "vault:ZAI_API_KEY"]
 display_name = "GLM 5.2"
 family = "glm-5"
 default = true
-aliases = ["glm", "glm5"]
+aliases = ["glm", "glm5", "glm52", "glm5.2"]
 
 [providers.zai.models."glm-5.2".limits]
 context_window = 1048576


### PR DESCRIPTION
## Summary

- add `gpt-sol`, `gpt-terra`, and `gpt-luna` aliases to both OpenAI and OpenRouter offerings
- make GLM 5.2 aliases portable across Z.ai and OpenRouter
- add DeepSeek V4 Pro and Flash aliases and align the public model documentation
- cover provider-scoped alias resolution with catalog regression tests

## Testing

- `cargo nextest run -p fabro-model`
- `cargo +nightly-2026-04-14 fmt --check --all`
- `cargo +nightly-2026-04-14 clippy -p fabro-model --all-targets -- -D warnings`
- `git diff --check`