### PR TITLE
Add Poolside provider logo

### DIFF
--- a/apps/fabro-web/public/images/providers/poolside.svg
+++ b/apps/fabro-web/public/images/providers/poolside.svg
@@ -1,0 +1,26 @@
+<svg width="24" height="24" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+<mask id="poolside-fade" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="2" y="2" width="28" height="28">
+<rect x="2" y="2" width="28" height="28" fill="url(#poolside-fade-a)"/>
+<rect x="2" y="2" width="28" height="28" fill="url(#poolside-fade-b)"/>
+<rect x="2" y="2" width="28" height="28" fill="url(#poolside-fade-c)"/>
+</mask>
+<g mask="url(#poolside-fade)">
+<path d="M3.41712 9.86302C6.80654 2.91367 15.1874 0.0275226 22.1368 3.41673C29.0863 6.80621 31.9726 15.188 28.5831 22.1374C25.1936 29.0867 16.8118 31.9722 9.86243 28.5827C4.66204 26.0461 1.73968 20.7158 2.01477 15.2849L2.05188 14.7595L2.07239 14.6081C2.21562 13.8614 2.90513 13.3305 3.67884 13.3992C4.45222 13.468 5.03641 14.1117 5.04602 14.8718L5.04016 15.0251L5.01087 15.4382C4.81888 19.2309 6.61285 22.9542 9.87512 25.1355L13.9933 16.6902L4.10755 11.8689C3.40938 11.5284 3.09379 10.7172 3.35657 10.0036L3.41712 9.86302ZM12.5714 26.4499C17.2445 27.9897 22.4003 26.2141 25.1349 22.1238L16.6896 18.0056L12.5714 26.4499ZM23.7208 8.16575C23.7497 8.57599 23.771 9.00755 23.7794 9.45579C23.8234 11.8115 23.5514 14.7561 22.5206 17.5115L26.4493 19.4275C27.7704 15.4172 26.6506 11.0524 23.7208 8.16575ZM20.5333 6.70384C19.8869 7.05321 19.0593 7.56983 18.1691 8.239C16.5266 9.47362 14.7653 11.1474 13.504 13.114L19.8097 16.1892C20.5828 13.9845 20.8187 11.5667 20.7804 9.51243C20.7596 8.39857 20.656 7.42837 20.5333 6.70384ZM17.4181 5.09153C13.3401 4.56091 9.21077 6.36601 6.86438 9.87571L10.7941 11.7917C12.3304 9.28322 14.4831 7.25617 16.3663 5.84056C16.7246 5.57129 17.0771 5.32128 17.4181 5.09153Z" fill="currentColor"/>
+</g>
+<defs>
+<linearGradient id="poolside-fade-a" x1="9.875" y1="25.975" x2="8.5625" y2="25.975" gradientUnits="userSpaceOnUse">
+<stop stop-color="black"/>
+<stop offset="1" stop-color="black" stop-opacity="0"/>
+</linearGradient>
+<linearGradient id="poolside-fade-b" x1="9.9625" y1="15.825" x2="10.4" y2="14.9937" gradientUnits="userSpaceOnUse">
+<stop stop-color="black" stop-opacity="0"/>
+<stop offset="1" stop-color="black"/>
+</linearGradient>
+<linearGradient id="poolside-fade-c" x1="3.1375" y1="25.9312" x2="3.1375" y2="14.7312" gradientUnits="userSpaceOnUse">
+<stop stop-color="black"/>
+<stop offset="0.105" stop-color="black" stop-opacity="0.9"/>
+<stop offset="0.903766" stop-color="black" stop-opacity="0.04"/>
+<stop offset="1" stop-color="black" stop-opacity="0"/>
+</linearGradient>
+</defs>
+</svg>


### PR DESCRIPTION
## Summary

Adds a Poolside logo at `apps/fabro-web/public/images/providers/poolside.svg`, so the Poolside provider row on `/settings/models` shows the brand mark instead of the letter-initial fallback. `ProviderLogo` resolves logos by convention from `/images/providers/<provider.id>.svg`, so no code changes are needed.

The SVG is adapted from poolside's official favicon (`poolside.ai/favicon/favicon.svg`) to match the existing conventions:

- `width="24" height="24"` with monochrome `fill="currentColor"` (replacing the hardcoded `#4137FF`), like all ten existing provider logos
- native `0 0 32 32` viewBox kept (precedent: inception 24, openrouter 512)
- the mark's gradient-fade tail is part of the brand design, so the original alpha mask is preserved, rewritten with clean ids and plain attributes

Verified by rasterizing in a WebKit-based renderer alongside the existing anthropic logo for visual-weight comparison.

## Test plan

- [ ] `cd apps/fabro-web && bun run dev`, open `/settings/models`, confirm the Poolside row shows the ring mark at the same size/weight as the other providers

🤖 Generated with [Claude Code](https://claude.com/claude-code)