### PR TITLE
Add Claude Opus 5 to the Anthropic model catalog

### DIFF
--- a/docs/public/changelog/2026-07-24.mdx
+++ b/docs/public/changelog/2026-07-24.mdx
@@ -40,6 +40,7 @@ When a run resumes after a node was cancelled or lost mid-flight, the replay now
 </Accordion>
 
 <Accordion title="Improvements">
+- Added `claude-opus-5` to the first-party Anthropic model catalog; the `opus` and `claude-opus` aliases now resolve to Opus 5
 - Added `gpt-sol`, `gpt-terra`, and `gpt-luna` aliases for GPT-5.6 offerings
 - Added portable `glm`, `glm52`, `glm5.2`, `deepseek`, and `deepseek-flash` aliases across direct and OpenRouter offerings
 </Accordion>

--- a/docs/public/core-concepts/models.mdx
+++ b/docs/public/core-concepts/models.mdx
@@ -37,7 +37,8 @@ Fabro performs this selection once when creating a run and persists the chosen p
 | Model | Provider | Aliases | Context | Cost (in/out per Mtok) | Speed |
 |---|---|---|---|---|---|
 | `claude-fable-5` | anthropic | `fable`, `claude-fable` | 1M | $10.00 / $50.00 | n/a |
-| `claude-opus-4-8` | anthropic | `opus`, `claude-opus` | 1M | $5.00 / $25.00 | 25 tok/s |
+| `claude-opus-5` | anthropic | `opus`, `claude-opus` | 1M | $5.00 / $25.00 | n/a |
+| `claude-opus-4-8` | anthropic | | 1M | $5.00 / $25.00 | 25 tok/s |
 | `claude-opus-4-7` | anthropic | | 1M | $5.00 / $25.00 | 25 tok/s |
 | `claude-opus-4-6` | anthropic | | 1M | $5.00 / $25.00 | 25 tok/s |
 | `claude-sonnet-4-6` | anthropic | `sonnet`, `claude-sonnet` | 200K | $3.00 / $15.00 | 50 tok/s |

--- a/lib/components/fabro-llm/src/adapter_registry.rs
+++ b/lib/components/fabro-llm/src/adapter_registry.rs
@@ -299,6 +299,7 @@ mod tests {
             ("claude-opus-4-6",                    "claude-opus-4-6",                     T::Anthropic,         C::AnthropicMessages, B::Anthropic, P::Anthropic),
             ("claude-opus-4-7",                    "claude-opus-4-7",                     T::Anthropic,         C::AnthropicMessages, B::Anthropic, P::Anthropic),
             ("claude-opus-4-8",                    "claude-opus-4-8",                     T::Anthropic,         C::AnthropicMessages, B::Anthropic, P::Anthropic),
+            ("claude-opus-5",                      "claude-opus-5",                       T::Anthropic,         C::AnthropicMessages, B::Anthropic, P::Anthropic),
             ("claude-sonnet-4-5",                  "claude-sonnet-4-5",                   T::Anthropic,         C::AnthropicMessages, B::Anthropic, P::Anthropic),
             ("claude-sonnet-4-6",                  "claude-sonnet-4-6",                   T::Anthropic,         C::AnthropicMessages, B::Anthropic, P::Anthropic),
             ("gemini-3-flash-preview",             "gemini-3-flash-preview",              T::Gemini,            C::GeminiGenerate,    B::Gemini,    P::Gemini),

--- a/lib/foundation/fabro-model/src/catalog/providers/anthropic.toml
+++ b/lib/foundation/fabro-model/src/catalog/providers/anthropic.toml
@@ -31,13 +31,44 @@ input_cost_per_mtok = 10.0
 output_cost_per_mtok = 50.0
 cache_input_cost_per_mtok = 1.0
 
+[providers.anthropic.models."claude-opus-5"]
+display_name = "Claude Opus 5"
+family = "claude-5"
+training = "2026-05-01"
+knowledge_cutoff = "May 2026"
+aliases = ["opus", "claude-opus"]
+
+[providers.anthropic.models."claude-opus-5".limits]
+context_window = 1000000
+max_output = 128000
+
+[providers.anthropic.models."claude-opus-5".features]
+tools = true
+vision = true
+reasoning = true
+reasoning_effort = "levels"
+prompt_cache = true
+sampling_params = false
+
+[providers.anthropic.models."claude-opus-5".controls]
+speed = ["fast"]
+
+[providers.anthropic.models."claude-opus-5".costs]
+input_cost_per_mtok = 5.0
+output_cost_per_mtok = 25.0
+cache_input_cost_per_mtok = 0.5
+
+[providers.anthropic.models."claude-opus-5".costs.speed.fast]
+input_cost_per_mtok = 10.0
+output_cost_per_mtok = 50.0
+cache_input_cost_per_mtok = 1.0
+
 [providers.anthropic.models."claude-opus-4-8"]
 display_name = "Claude Opus 4.8"
 family = "claude-4"
 training = "2026-01-01"
 knowledge_cutoff = "Jan 2026"
 estimated_output_tps = 25
-aliases = ["opus", "claude-opus"]
 
 [providers.anthropic.models."claude-opus-4-8".limits]
 context_window = 1000000


### PR DESCRIPTION
## Summary

- add `claude-opus-5` to the first-party Anthropic catalog with its published limits, cutoffs, capabilities, standard pricing, cache pricing, and fast-mode pricing
- move the `opus` and `claude-opus` aliases from Opus 4.8 to Opus 5 while leaving the provider default unchanged
- register the native Anthropic Messages route and update the public model table and changelog

## Sources

- https://platform.claude.com/docs/en/about-claude/models/whats-new-opus-5
- https://platform.claude.com/docs/en/about-claude/models/overview
- https://platform.claude.com/docs/en/build-with-claude/fast-mode
- https://platform.claude.com/docs/en/build-with-claude/prompt-caching

## Testing

- `cargo nextest run -p fabro-model` (166 passed)
- `cargo nextest run -p fabro-llm` (635 passed, 23 skipped)
- `cargo +nightly-2026-04-14 fmt --check --all`
- `git diff --check`
