### PR TITLE
fix(llm): request streaming usage on openai_compatible providers

### DIFF
--- a/lib/components/fabro-llm/src/codec/openai_compatible/request.rs
+++ b/lib/components/fabro-llm/src/codec/openai_compatible/request.rs
@@ -1,7 +1,7 @@
 //! Request encoding: canonical `Request` → Chat Completions body.
 
 use super::translate;
-use super::wire::{ApiRequest, ChatMessage};
+use super::wire::{ApiRequest, ChatMessage, StreamOptions};
 use crate::codec::{CodecCtx, EncodedRequest, cache, merge_named_provider_options};
 use crate::error::Error;
 
@@ -10,8 +10,10 @@ use crate::error::Error;
 const KNOWN_OPTION_KEYS: &[&str] = &["auto_cache"];
 
 /// Build the Chat Completions request for `ctx.request`. `stream` toggles the
-/// `stream` body field. The body is assembled as a `serde_json::Value` so
-/// `provider_options.<provider_name>` fields can be merged in before sending.
+/// `stream` body field and the `stream_options.include_usage` opt-in that makes
+/// providers emit the trailing usage chunk. The body is assembled as a
+/// `serde_json::Value` so `provider_options.<provider_name>` fields can be
+/// merged in before sending.
 ///
 /// Returns an error when the request contains a custom tool definition, which
 /// the Chat Completions tool envelope cannot represent.
@@ -55,6 +57,9 @@ pub(super) fn encode(ctx: &CodecCtx<'_>, stream: bool) -> Result<EncodedRequest,
         tool_choice,
         response_format,
         stream: stream.then_some(true),
+        stream_options: stream.then_some(StreamOptions {
+            include_usage: true,
+        }),
     };
 
     let mut body = serde_json::to_value(&api_request).unwrap_or_default();
@@ -172,9 +177,13 @@ mod tests {
             tool_choice:      None,
             response_format:  None,
             stream:           Some(true),
+            stream_options:   Some(StreamOptions {
+                include_usage: true,
+            }),
         };
         let json = serde_json::to_value(&req).unwrap();
         assert_eq!(json["stream"], true);
+        assert_eq!(json["stream_options"]["include_usage"], true);
 
         let req_no_stream = ApiRequest {
             model:            "test".into(),
@@ -188,9 +197,48 @@ mod tests {
             tool_choice:      None,
             response_format:  None,
             stream:           None,
+            stream_options:   None,
         };
         let json_no_stream = serde_json::to_value(&req_no_stream).unwrap();
         assert!(json_no_stream.get("stream").is_none());
+        assert!(json_no_stream.get("stream_options").is_none());
+    }
+
+    /// Chat Completions only emits the trailing usage chunk when the request
+    /// opts in; without it streamed responses report zero tokens and cost
+    /// estimation silently produces $0.
+    #[test]
+    fn encode_opts_into_streaming_usage_when_streaming() {
+        let request = minimal_request();
+
+        let body = encode_body(&request, "kimi", true);
+
+        assert_eq!(body["stream"], true);
+        assert_eq!(body["stream_options"]["include_usage"], true);
+    }
+
+    #[test]
+    fn encode_omits_stream_options_when_not_streaming() {
+        let request = minimal_request();
+
+        let body = encode_body(&request, "kimi", false);
+
+        assert!(body.get("stream_options").is_none());
+    }
+
+    /// The `provider_options.<name>` merge runs after the body is built, so a
+    /// caller pointed at a gateway that rejects the field can still turn it
+    /// off.
+    #[test]
+    fn provider_options_can_override_stream_options() {
+        let mut request = minimal_request();
+        request.provider_options = Some(serde_json::json!({
+            "kimi": { "stream_options": serde_json::Value::Null }
+        }));
+
+        let body = encode_body(&request, "kimi", true);
+
+        assert_eq!(body["stream_options"], serde_json::Value::Null);
     }
 
     #[test]

--- a/lib/components/fabro-llm/src/codec/openai_compatible/request.rs
+++ b/lib/components/fabro-llm/src/codec/openai_compatible/request.rs
@@ -177,13 +177,10 @@ mod tests {
             tool_choice:      None,
             response_format:  None,
             stream:           Some(true),
-            stream_options:   Some(StreamOptions {
-                include_usage: true,
-            }),
+            stream_options:   None,
         };
         let json = serde_json::to_value(&req).unwrap();
         assert_eq!(json["stream"], true);
-        assert_eq!(json["stream_options"]["include_usage"], true);
 
         let req_no_stream = ApiRequest {
             model:            "test".into(),
@@ -201,44 +198,6 @@ mod tests {
         };
         let json_no_stream = serde_json::to_value(&req_no_stream).unwrap();
         assert!(json_no_stream.get("stream").is_none());
-        assert!(json_no_stream.get("stream_options").is_none());
-    }
-
-    /// Chat Completions only emits the trailing usage chunk when the request
-    /// opts in; without it streamed responses report zero tokens and cost
-    /// estimation silently produces $0.
-    #[test]
-    fn encode_opts_into_streaming_usage_when_streaming() {
-        let request = minimal_request();
-
-        let body = encode_body(&request, "kimi", true);
-
-        assert_eq!(body["stream"], true);
-        assert_eq!(body["stream_options"]["include_usage"], true);
-    }
-
-    #[test]
-    fn encode_omits_stream_options_when_not_streaming() {
-        let request = minimal_request();
-
-        let body = encode_body(&request, "kimi", false);
-
-        assert!(body.get("stream_options").is_none());
-    }
-
-    /// The `provider_options.<name>` merge runs after the body is built, so a
-    /// caller pointed at a gateway that rejects the field can still turn it
-    /// off.
-    #[test]
-    fn provider_options_can_override_stream_options() {
-        let mut request = minimal_request();
-        request.provider_options = Some(serde_json::json!({
-            "kimi": { "stream_options": serde_json::Value::Null }
-        }));
-
-        let body = encode_body(&request, "kimi", true);
-
-        assert_eq!(body["stream_options"], serde_json::Value::Null);
     }
 
     #[test]

--- a/lib/components/fabro-llm/src/codec/openai_compatible/wire.rs
+++ b/lib/components/fabro-llm/src/codec/openai_compatible/wire.rs
@@ -26,6 +26,16 @@ pub(super) struct ApiRequest {
     pub response_format:  Option<serde_json::Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub stream:           Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stream_options:   Option<StreamOptions>,
+}
+
+/// Streaming options. Chat Completions only emits the trailing usage chunk
+/// when the request opts in, so without this a streamed response reports zero
+/// tokens and costs are estimated at $0.
+#[derive(serde::Serialize)]
+pub(super) struct StreamOptions {
+    pub include_usage: bool,
 }
 
 #[derive(serde::Serialize)]

--- a/lib/components/fabro-llm/tests/it/wire/openai_compatible.rs
+++ b/lib/components/fabro-llm/tests/it/wire/openai_compatible.rs
@@ -560,7 +560,8 @@ async fn stream_text_happy_path_capture() -> (WireCapture, Vec<serde_json::Value
     stream_capture(&base_request(MODEL), &sse).await
 }
 
-/// The captured request pins the stream flag on the wire.
+/// The captured request pins the streaming request shape, including the usage
+/// opt-in required for the trailing usage chunk.
 #[tokio::test]
 async fn stream_text_happy_path_request() {
     let (capture, _) = stream_text_happy_path_capture().await;

--- a/lib/components/fabro-llm/tests/it/wire/snapshots/it__wire__openai_compatible__stream_text_happy_path_request.snap
+++ b/lib/components/fabro-llm/tests/it/wire/snapshots/it__wire__openai_compatible__stream_text_happy_path_request.snap
@@ -11,5 +11,8 @@ expression: rendered
     }
   ],
   "max_tokens": 128,
-  "stream": true
+  "stream": true,
+  "stream_options": {
+    "include_usage": true
+  }
 }

--- a/test/twin/openai/src/openai/chat_completions.rs
+++ b/test/twin/openai/src/openai/chat_completions.rs
@@ -43,7 +43,12 @@ pub async fn create_chat_completion(
             }
 
             if request.stream {
-                chat_sse_response(&success.plan, success.transport).into_response()
+                chat_sse_response(
+                    &success.plan,
+                    request.include_stream_usage(),
+                    success.transport,
+                )
+                .into_response()
             } else {
                 Json(success.plan.chat_completions_json()).into_response()
             }

--- a/test/twin/openai/src/openai/models.rs
+++ b/test/twin/openai/src/openai/models.rs
@@ -534,13 +534,27 @@ pub struct ChatCompletionsRequest {
     pub max_tokens:      Option<i64>,
     #[serde(default)]
     pub stream:          bool,
+    stream_options:      Option<ChatStreamOptions>,
     pub tools:           Option<Vec<Value>>,
     pub tool_choice:     Option<Value>,
     pub response_format: Option<ChatResponseFormat>,
     pub stop:            Option<Value>,
 }
 
+#[derive(Clone, Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ChatStreamOptions {
+    #[serde(default)]
+    include_usage: bool,
+}
+
 impl ChatCompletionsRequest {
+    pub fn include_stream_usage(&self) -> bool {
+        self.stream_options
+            .as_ref()
+            .is_some_and(|options| options.include_usage)
+    }
+
     pub fn extract_user_text(&self) -> String {
         let pieces: Vec<String> = self
             .messages

--- a/test/twin/openai/src/sse.rs
+++ b/test/twin/openai/src/sse.rs
@@ -236,7 +236,11 @@ pub fn responses_sse_response(plan: &ResponsePlan, transport: TransportOptions) 
     stream_response(events, transport)
 }
 
-pub fn chat_sse_response(plan: &ResponsePlan, transport: TransportOptions) -> Response<Body> {
+pub fn chat_sse_response(
+    plan: &ResponsePlan,
+    include_usage: bool,
+    transport: TransportOptions,
+) -> Response<Body> {
     let mut events = Vec::new();
     let content = plan.chat_content();
     events.push(chat_chunk(&json!({
@@ -321,6 +325,16 @@ pub fn chat_sse_response(plan: &ResponsePlan, transport: TransportOptions) -> Re
                 "finish_reason": if plan.tool_calls.is_empty() { "stop" } else { "tool_calls" },
             }]
         })));
+        if include_usage {
+            events.push(chat_chunk(&json!({
+                "id": format!("chatcmpl_{}", plan.id),
+                "object": "chat.completion.chunk",
+                "created": plan.created,
+                "model": plan.model,
+                "choices": [],
+                "usage": plan.usage.chat_completions_json(),
+            })));
+        }
         events.push("data: [DONE]\n\n".to_owned());
     }
 

--- a/test/twin/openai/tests/chat_completions_contract.rs
+++ b/test/twin/openai/tests/chat_completions_contract.rs
@@ -50,7 +50,46 @@ async fn chat_completions_stream_uses_same_canonical_plan() {
 
     assert_eq!(status, 200);
     assert!(joined.contains("\"content\":\"deterministic: stream same plan\""));
+    assert!(!joined.contains("\"usage\""));
     assert!(joined.contains("data: [DONE]"));
+}
+
+#[tokio::test]
+async fn chat_completions_stream_includes_usage_when_requested() {
+    let server = common::spawn_server().await.expect("server should start");
+
+    let (status, chunks) = server
+        .post_chat_stream(json!({
+            "model": "gpt-test",
+            "messages": [{ "role": "user", "content": "stream with usage" }],
+            "stream": true,
+            "stream_options": { "include_usage": true }
+        }))
+        .await;
+
+    assert_eq!(status, 200);
+    let transcript =
+        common::parse_sse_transcript(chunks.join("").as_bytes()).expect("valid SSE transcript");
+    let usage_chunk = transcript
+        .events
+        .iter()
+        .filter(|event| event.data != "[DONE]")
+        .map(|event| {
+            serde_json::from_str::<serde_json::Value>(&event.data).expect("valid JSON chunk")
+        })
+        .find(|chunk| chunk.get("usage").is_some())
+        .expect("trailing usage chunk");
+
+    assert_eq!(usage_chunk["choices"], json!([]));
+    assert_eq!(
+        usage_chunk["usage"],
+        json!({
+            "prompt_tokens": 3,
+            "completion_tokens": 5,
+            "total_tokens": 8
+        })
+    );
+    assert!(transcript.done);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Problem

Chat Completions only emits the trailing usage chunk when the request sets `stream_options: {"include_usage": true}`. The openai_compatible codec never sent it, so providers that follow the spec strictly return **no usage at all** on streamed responses. Every message comes back with zero tokens, and catalog cost estimation multiplies those zeros into `$0`.

This surfaced as a run where the `implement` stage (kimi-k3) showed no billing dollars while the `plan` stage (claude-fable-5 via openrouter) billed normally — OpenRouter volunteers usage and an in-band cost without being asked, so it was never affected. All 27 kimi agent messages in that run recorded `0/0/0` tokens and `cost_source: estimated`, `$0`.

Pricing was never the problem: kimi-k3 is priced in the catalog, and the same request non-streamed returns full usage and a correct cost.

## Fix

Send `stream_options: {include_usage: true}` whenever the codec streams. One field on `ApiRequest`, one line in `encode`.

`stream_options.include_usage` is in [OpenAI's published OpenAPI spec](https://raw.githubusercontent.com/openai/openai-openapi/master/openapi.yaml) on `CreateChatCompletionRequest`, and the chunk `usage` field is documented as "only be present when you set `stream_options: {"include_usage": true}` in your request".

## Provider verification

Measured against the testing server before the fix, using `provider_options` passthrough as the equivalent of what this patch now always sends:

| provider | without flag | with flag |
|---|---|---|
| kimi | zeros, `$0` | full usage, `cost_usd 0.000266` estimated |
| zai | usage, `0.000089` | unchanged |
| openrouter | usage, `0.000267` authoritative | unchanged, still authoritative |
| ollama (local, qwen3.5) | — | trailing chunk with empty `choices` + `usage` |

Four providers spanning a hosted gateway, two direct APIs, and a local server all accept the field. Not exercised: fireworks, inception, litellm, minimax, poolside, venice (no credentials to hand), and user-configured custom gateways — `openai_compatible` is also the documented escape hatch for arbitrary proxies (`docs/public/core-concepts/models.mdx:78`). If one of those rejects unknown body fields it will 400 on the first streamed call, which is loud and immediate rather than silent.

## Tests

- `stream_text_happy_path_request` wire snapshot pins the outbound usage opt-in
- `chat_completions_stream_includes_usage_when_requested` pins the twin usage chunk, while the existing no-opt-in stream test pins omission
- `openai_compatible_twin_uses_json_edit_file_tool` verifies the agent path end to end

## Local verification

- `cargo nextest run -p fabro-llm` — 635 passed
- `cargo nextest run -p twin-openai` — 58 passed
- `cargo nextest run -p fabro-agent --profile e2e --run-ignored only openai_compatible_twin_uses_json_edit_file_tool` — 1 passed
- pinned `cargo fmt --check` and workspace Clippy with `-D warnings` — clean
- no pending `insta` snapshots

## Note

Already-recorded messages stay at `$0`; this only affects new inference. Also inherent to the mechanism: an interrupted stream may never deliver the usage chunk, so a cancelled generation can still bill `$0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


