### PR TITLE
feat(model): add Claude Opus 5 to OpenRouter

### DIFF
--- a/docs/public/changelog/2026-07-24.mdx
+++ b/docs/public/changelog/2026-07-24.mdx
@@ -40,7 +40,7 @@ When a run resumes after a node was cancelled or lost mid-flight, the replay now
 </Accordion>
 
 <Accordion title="Improvements">
-- Added `claude-opus-5` to the first-party Anthropic model catalog; the `opus` and `claude-opus` aliases now resolve to Opus 5
+- Added `claude-opus-5` to the first-party Anthropic and optional OpenRouter model catalogs; the `opus` and `claude-opus` aliases now resolve to Opus 5
 - Added `gpt-sol`, `gpt-terra`, and `gpt-luna` aliases for GPT-5.6 offerings
 - Added portable `glm`, `glm52`, `glm5.2`, `deepseek`, and `deepseek-flash` aliases across direct and OpenRouter offerings
 </Accordion>

--- a/docs/public/integrations/openrouter.mdx
+++ b/docs/public/integrations/openrouter.mdx
@@ -48,7 +48,7 @@ The built-in catalog gives OpenRouter offerings the same human-facing model slug
 
 | Fabro model slug | OpenRouter API ID / notes |
 | --- | --- |
-| `claude-fable-5`, `claude-opus-4-8`, `claude-opus-4-7` | Matching `anthropic/...` API IDs; Anthropic-style cache billing |
+| `claude-fable-5`, `claude-opus-5`, `claude-opus-4-8`, `claude-opus-4-7` | Matching `anthropic/...` API IDs; Anthropic-style cache billing |
 | `claude-sonnet-4-6` | `anthropic/claude-sonnet-4.6`; provider default |
 | `claude-haiku-4-5` | `anthropic/claude-haiku-4.5`; provider small default |
 | `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`, `gpt-5.4`, `gpt-5.5` | Matching `openai/...` API IDs |

--- a/lib/foundation/fabro-model/src/catalog.rs
+++ b/lib/foundation/fabro-model/src/catalog.rs
@@ -3084,6 +3084,19 @@ enabled = true
                 BillingPolicy::OpenAi,
             ),
             (
+                "claude-opus-5",
+                "anthropic/claude-opus-5",
+                "claude-5",
+                1_000_000,
+                5.0,
+                25.0,
+                0.5,
+                ReasoningEffortFeature::Levels,
+                false,
+                true,
+                BillingPolicy::Anthropic,
+            ),
+            (
                 "claude-opus-4-8",
                 "anthropic/claude-opus-4.8",
                 "claude-4",
@@ -3160,6 +3173,13 @@ enabled = true
                 ReasoningEffort::VARIANTS,
                 "{id}"
             );
+        }
+
+        for alias in ["opus", "claude-opus"] {
+            let model = catalog
+                .resolve_on_provider(&ProviderId::new("openrouter"), alias)
+                .unwrap_or_else(|error| panic!("{alias} should resolve on OpenRouter: {error}"));
+            assert_eq!(model.id, "claude-opus-5", "{alias}");
         }
     }
 

--- a/lib/foundation/fabro-model/src/catalog/providers/openrouter.toml
+++ b/lib/foundation/fabro-model/src/catalog/providers/openrouter.toml
@@ -58,6 +58,33 @@ input_cost_per_mtok = 10.0
 output_cost_per_mtok = 50.0
 cache_input_cost_per_mtok = 1.0
 
+[providers.openrouter.models."claude-opus-5"]
+api_id = "anthropic/claude-opus-5"
+display_name = "Claude Opus 5 (via OpenRouter)"
+family = "claude-5"
+billing_policy = "anthropic"
+training = "2026-05-01"
+knowledge_cutoff = "May 2026"
+aliases = ["opus", "claude-opus"]
+
+[providers.openrouter.models."claude-opus-5".limits]
+context_window = 1000000
+max_output = 128000
+
+[providers.openrouter.models."claude-opus-5".features]
+tools = true
+vision = true
+reasoning = true
+reasoning_effort = "levels"
+prompt_cache = true
+cache_control_breakpoints = true
+sampling_params = false
+
+[providers.openrouter.models."claude-opus-5".costs]
+input_cost_per_mtok = 5.0
+output_cost_per_mtok = 25.0
+cache_input_cost_per_mtok = 0.5
+
 [providers.openrouter.models."claude-opus-4-8"]
 api_id = "anthropic/claude-opus-4.8"
 display_name = "Claude Opus 4.8 (via OpenRouter)"
@@ -65,7 +92,6 @@ family = "claude-4"
 billing_policy = "anthropic"
 training = "2026-01-01"
 knowledge_cutoff = "Jan 2026"
-aliases = ["opus", "claude-opus"]
 
 [providers.openrouter.models."claude-opus-4-8".limits]
 context_window = 1000000


### PR DESCRIPTION
## Summary

- add Claude Opus 5 to the opt-in OpenRouter catalog using anthropic/claude-opus-5
- move the opus and claude-opus aliases from Opus 4.8 to Opus 5
- cover OpenRouter metadata and alias resolution, and update the integration docs and changelog

## Testing

- cargo nextest run -p fabro-model
- cargo +nightly-2026-04-14 fmt --check --all
- git diff --check