### PR TITLE
fix(workflow): drop token accounting from agent-facing preamble

### DIFF
--- a/lib/components/fabro-workflow/src/handler/llm/preamble.rs
+++ b/lib/components/fabro-workflow/src/handler/llm/preamble.rs
@@ -115,16 +115,6 @@ fn format_value(val: &serde_json::Value) -> String {
     }
 }
 
-fn format_token_count(tokens: i64) -> String {
-    if tokens >= 1_000_000 {
-        format!("{:.1}m", tokens as f64 / 1_000_000.0)
-    } else if tokens >= 1000 {
-        format!("{:.1}k", tokens as f64 / 1000.0)
-    } else {
-        tokens.to_string()
-    }
-}
-
 fn tail_lines(text: &str, max_lines: usize, indent: &str) -> String {
     use std::fmt::Write;
 
@@ -197,14 +187,7 @@ fn render_compact_stage_details(
         h if is_llm_handler_type(h) => {
             let mut lines = Vec::new();
             if let Some(usage) = &outcome.usage {
-                let input = format_token_count(usage.tokens().input_tokens);
-                let output = format_token_count(usage.tokens().billable_output_tokens());
-                lines.push(format!(
-                    "  - Model: {}, {} tokens in / {} out",
-                    usage.model_id(),
-                    input,
-                    output
-                ));
+                lines.push(format!("  - Model: {}", usage.model_id()));
             }
             if !outcome.files_touched.is_empty() {
                 lines.push(format!("  - Files: {}", outcome.files_touched.join(", ")));
@@ -265,11 +248,6 @@ fn render_summary_high_stage_section(
         h if is_llm_handler_type(h) => {
             if let Some(usage) = &outcome.usage {
                 lines.push(format!("- Model: {}", usage.model_id()));
-                lines.push(format!(
-                    "- Tokens: {} in / {} out",
-                    format_token_count(usage.tokens().input_tokens),
-                    format_token_count(usage.tokens().billable_output_tokens())
-                ));
             }
             if !outcome.files_touched.is_empty() {
                 lines.push(format!(
@@ -928,8 +906,9 @@ mod tests {
             "should show model name"
         );
         assert!(
-            preamble.contains("1.2k tokens in"),
-            "should show token count"
+            !preamble.contains("tokens"),
+            "token accounting must stay out of the agent-facing preamble; agents \
+             read it as a budget signal, got:\n{preamble}"
         );
         assert!(
             preamble.contains("src/lib.rs, src/main.rs"),
@@ -1566,7 +1545,11 @@ mod tests {
             preamble.contains("Model: claude-sonnet-4-20250514"),
             "should show model"
         );
-        assert!(preamble.contains("1.5k in"), "should show formatted tokens");
+        assert!(
+            !preamble.contains("tokens"),
+            "token accounting must stay out of the agent-facing preamble; agents \
+             read it as a budget signal, got:\n{preamble}"
+        );
         assert!(
             preamble.contains("Files touched: src/lib.rs"),
             "should show files"
@@ -1639,20 +1622,6 @@ mod tests {
             preamble.contains("2 of 4 stages completed"),
             "should show pipeline progress with total node count, got:\n{preamble}"
         );
-    }
-
-    // --- format_token_count ---
-
-    #[test]
-    fn format_token_count_formatting() {
-        assert_eq!(format_token_count(500), "500");
-        assert_eq!(format_token_count(999), "999");
-        assert_eq!(format_token_count(1000), "1.0k");
-        assert_eq!(format_token_count(1234), "1.2k");
-        assert_eq!(format_token_count(1500), "1.5k");
-        assert_eq!(format_token_count(10000), "10.0k");
-        assert_eq!(format_token_count(1_000_000), "1.0m");
-        assert_eq!(format_token_count(3_456_789), "3.5m");
     }
 
     // --- is_context_key_excluded ---


### PR DESCRIPTION
## Problem

The stage-summary preamble rendered per-stage token usage for every completed LLM stage — `- Model: kimi-k3, 92.6k tokens in / 41.1k out` at `compact` fidelity, `- Tokens: N in / N out` at `summary:high`. Agents read that as their own remaining budget.

Run `01KYCM3EG4KMCVRDYNV93PZWBV` is the motivating case. Its implementation stage stopped after 2 of 9 planned units and recorded the remaining 7 as halted "because the unattended run has not completed the remaining serial units within the available execution window." Its reasoning trace shows where that came from:

> "It may be impossible to fully implement units U2 to U9... **We have around 100k tokens**, but time constraints are an issue."

The `92.6k` it saw was the preceding `plan` stage's billing telemetry, injected by the preamble and the only token quantity anywhere in its context. Meanwhile:

| Limit | Allowance | Used when it quit |
|---|---|---|
| Context window | 1,050,000 tokens | 116,334 — **11.1%** |
| Stage timeout | 86,400s (24h) | 668s — **0.8%** |

No harness limit was near, no compaction fired, and the final turn carried `"warnings": []`. The stage still reported `succeeded`, so nothing downstream caught it.

## Fix

Drop the token counts from both render paths. Keep the model id and files-touched, which carry provenance an agent can act on.

These counts had no task value to the agent: they describe a *different model's* usage on an *earlier* stage, they are stale by one stage, and nothing in the preamble distinguishes them from a budget. Token accounting remains fully available where it belongs — stage events, billing, and the run projection are untouched.

## Testing

- `cargo nextest run -p fabro-workflow` — 1247 passed, 30 skipped
- `cargo +nightly-2026-04-14 fmt --check --all` — clean
- `cargo +nightly-2026-04-14 clippy -p fabro-workflow --all-targets -- -D warnings` — clean

The two tests that asserted the counts now assert their absence, with the reason inline, so a reintroduction fails rather than getting re-snapshotted. `format_token_count` had no remaining callers and is removed along with its unit test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)