### PR TITLE
Show run size chips consistently across list, board, and detail

### DIFF
--- a/apps/fabro-web/app/components/runs-list/run-table-row.tsx
+++ b/apps/fabro-web/app/components/runs-list/run-table-row.tsx
@@ -116,7 +116,11 @@ export function RunTableRow({
       )}
       {show("size") && (
         <td className="whitespace-nowrap px-3 py-2.5 text-center">
-          {run.size != null && <SizeChip size={run.size} />}
+          {run.size != null && (
+            <span className="relative z-10 inline-flex">
+              <SizeChip size={run.size} totalUsdMicros={run.totalUsdMicros} />
+            </span>
+          )}
         </td>
       )}
       {show("changes") && (

--- a/apps/fabro-web/app/components/runs-list/run-table-row.tsx
+++ b/apps/fabro-web/app/components/runs-list/run-table-row.tsx
@@ -115,11 +115,9 @@ export function RunTableRow({
         </td>
       )}
       {show("size") && (
-        <td className="whitespace-nowrap px-3 py-2.5 text-center">
+        <td className="relative z-10 px-3 py-2.5 text-center whitespace-nowrap">
           {run.size != null && (
-            <span className="relative z-10 inline-flex">
-              <SizeChip size={run.size} totalUsdMicros={run.totalUsdMicros} />
-            </span>
+            <SizeChip size={run.size} totalUsdMicros={run.totalUsdMicros} />
           )}
         </td>
       )}

--- a/apps/fabro-web/app/components/size-chip.test.tsx
+++ b/apps/fabro-web/app/components/size-chip.test.tsx
@@ -1,25 +1,43 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import TestRenderer, { act } from "react-test-renderer";
 
+import { setupReactTestEnv } from "../lib/test-utils";
 import { SizeChip } from "./size-chip";
 import { Tooltip } from "./ui";
 
-function tooltipLabel(element: React.ReactElement): string {
+let teardownReactTestEnv: (() => void) | undefined;
+const mountedRenderers: TestRenderer.ReactTestRenderer[] = [];
+
+function render(element: React.ReactElement): TestRenderer.ReactTestRenderer {
   let renderer: TestRenderer.ReactTestRenderer | undefined;
   act(() => {
     renderer = TestRenderer.create(element);
   });
-  return renderer!.root.findByType(Tooltip).props.label as string;
+  mountedRenderers.push(renderer!);
+  return renderer!;
+}
+
+function tooltipLabel(element: React.ReactElement): string {
+  return render(element).root.findByType(Tooltip).props.label as string;
 }
 
 describe("SizeChip", () => {
-  test("renders the size letter", () => {
-    let renderer: TestRenderer.ReactTestRenderer | undefined;
-    act(() => {
-      renderer = TestRenderer.create(<SizeChip size="M" />);
-    });
+  beforeEach(() => {
+    teardownReactTestEnv = setupReactTestEnv();
+  });
 
-    expect(JSON.stringify(renderer!.toJSON())).toContain("M");
+  afterEach(() => {
+    act(() => {
+      for (const renderer of mountedRenderers.splice(0)) {
+        renderer.unmount();
+      }
+    });
+    teardownReactTestEnv?.();
+    teardownReactTestEnv = undefined;
+  });
+
+  test("renders the size letter", () => {
+    expect(JSON.stringify(render(<SizeChip size="M" />).toJSON())).toContain("M");
   });
 
   test("appends the cost to the tooltip", () => {

--- a/apps/fabro-web/app/components/size-chip.test.tsx
+++ b/apps/fabro-web/app/components/size-chip.test.tsx
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test";
+import TestRenderer, { act } from "react-test-renderer";
+
+import { SizeChip } from "./size-chip";
+import { Tooltip } from "./ui";
+
+function tooltipLabel(element: React.ReactElement): string {
+  let renderer: TestRenderer.ReactTestRenderer | undefined;
+  act(() => {
+    renderer = TestRenderer.create(element);
+  });
+  return renderer!.root.findByType(Tooltip).props.label as string;
+}
+
+describe("SizeChip", () => {
+  test("renders the size letter", () => {
+    let renderer: TestRenderer.ReactTestRenderer | undefined;
+    act(() => {
+      renderer = TestRenderer.create(<SizeChip size="M" />);
+    });
+
+    expect(JSON.stringify(renderer!.toJSON())).toContain("M");
+  });
+
+  test("appends the cost to the tooltip", () => {
+    expect(tooltipLabel(<SizeChip size="M" totalUsdMicros={12_340_000} />))
+      .toBe("Size M · $12.34");
+  });
+
+  test("omits the cost when the run has no billing yet", () => {
+    expect(tooltipLabel(<SizeChip size="M" />)).toBe("Size M");
+    expect(tooltipLabel(<SizeChip size="M" totalUsdMicros={null} />)).toBe("Size M");
+  });
+
+  test("calls out the tiers that warrant attention", () => {
+    expect(tooltipLabel(<SizeChip size="L" totalUsdMicros={150_000_000} />))
+      .toBe("Size L (risky) · $150.00");
+    expect(tooltipLabel(<SizeChip size="XL" />)).toBe("Size XL (unhealthy)");
+  });
+});

--- a/apps/fabro-web/app/components/size-chip.tsx
+++ b/apps/fabro-web/app/components/size-chip.tsx
@@ -19,10 +19,10 @@ export function SizeChip({
   totalUsdMicros?: number | null;
 }) {
   const tone = SIZE_TONE[size];
-  const billed = totalUsdMicros != null ? ` · ${formatUsdMicros(totalUsdMicros)} billed` : "";
+  const amount = totalUsdMicros != null ? ` · ${formatUsdMicros(totalUsdMicros)}` : "";
   const tooltip = tone.note != null
-    ? `Size ${size} (${tone.note})${billed}`
-    : `Size ${size}${billed}`;
+    ? `Size ${size} (${tone.note})${amount}`
+    : `Size ${size}${amount}`;
   return (
     <Tooltip label={tooltip}>
       <span className={`rounded px-1.5 py-0.5 font-mono text-xs font-bold tabular-nums ${tone.className}`}>

--- a/apps/fabro-web/app/components/size-chip.tsx
+++ b/apps/fabro-web/app/components/size-chip.tsx
@@ -1,3 +1,4 @@
+import { memo } from "react";
 import type { RunSize } from "@qltysh/fabro-api-client";
 
 import { formatUsdMicros } from "../lib/format";
@@ -11,7 +12,7 @@ const SIZE_TONE: Record<RunSize, { className: string; note: string | null }> = {
   XL: { className: "bg-coral/15 text-coral",     note: "unhealthy" },
 };
 
-export function SizeChip({
+export const SizeChip = memo(function SizeChip({
   size,
   totalUsdMicros,
 }: {
@@ -30,4 +31,4 @@ export function SizeChip({
       </span>
     </Tooltip>
   );
-}
+});

--- a/apps/fabro-web/app/data/runs.test.ts
+++ b/apps/fabro-web/app/data/runs.test.ts
@@ -103,6 +103,17 @@ describe("mapRunListItem", () => {
 
     expect(mapRunListItem(summary).title).toBe("Untitled run");
   });
+
+  test("carries the billed total so the size chip can show it on hover", () => {
+    expect(mapRunListItem(makeRun()).totalUsdMicros).toBe(500000);
+  });
+
+  test("leaves the billed total undefined for runs without terminal billing", () => {
+    expect(mapRunListItem(makeRun({ billing: null })).totalUsdMicros).toBeUndefined();
+    expect(
+      mapRunListItem(makeRun({ billing: { total_usd_micros: null } })).totalUsdMicros,
+    ).toBeUndefined();
+  });
 });
 
 describe("mapRunToRunItem", () => {

--- a/apps/fabro-web/app/data/runs.ts
+++ b/apps/fabro-web/app/data/runs.ts
@@ -46,6 +46,7 @@ export interface RunItem {
   createdBy: Principal;
   lastEventAt?: string;
   size?: RunSize;
+  totalUsdMicros?: number;
 }
 
 export const columnStatuses = [
@@ -119,6 +120,7 @@ export function mapRunListItem(item: Run): RunItem {
     additions: item.diff?.additions,
     deletions: item.diff?.deletions,
     size: item.size,
+    totalUsdMicros: item.billing?.total_usd_micros ?? undefined,
   };
 }
 

--- a/apps/fabro-web/app/routes/runs.tsx
+++ b/apps/fabro-web/app/routes/runs.tsx
@@ -26,6 +26,7 @@ import { ciConfig, columnForRun, columnStatusDisplay, columnStatuses, deriveCiSt
 import type { CiStatus, CheckRun, CheckStatus, RunItem } from "../data/runs";
 import { EmptyState } from "../components/state";
 import { PullRequestChip } from "../components/pull-request-chip";
+import { SizeChip } from "../components/size-chip";
 import {
   summarizeBatchLifecycleAction,
 } from "../components/runs-list/batch-lifecycle";
@@ -345,7 +346,7 @@ function PrCard({
 
 // All inline footer metadata on PrCard belongs in this one row. Adding a new
 // piece as a sibling `<div>` below the card body recreates a recurring bug
-// where stats stack onto separate lines instead of sitting next to elapsed/actions.
+// where stats stack onto separate lines instead of sitting next to size/actions.
 function PrCardFooter({ pr, actions }: { pr: RunItem; actions?: string[] }) {
   const hasActions = actions != null && actions.length > 0;
   const hasStats =
@@ -354,7 +355,7 @@ function PrCardFooter({ pr, actions }: { pr: RunItem; actions?: string[] }) {
     (pr.additions != null && pr.additions !== 0) ||
     (pr.deletions != null && pr.deletions !== 0);
 
-  if (!hasStats && !hasActions && pr.elapsed == null) return null;
+  if (!hasStats && !hasActions && pr.size == null) return null;
 
   return (
     <div className="mt-3 flex items-center gap-3 font-mono text-xs">
@@ -416,9 +417,9 @@ function PrCardFooter({ pr, actions }: { pr: RunItem; actions?: string[] }) {
           ))}
         </div>
       )}
-      {pr.elapsed != null && (
-        <span className={`text-fg-muted ${hasActions ? "" : "ml-auto"}`}>
-          {pr.elapsed}
+      {pr.size != null && (
+        <span className={`inline-flex ${hasActions ? "" : "ml-auto"}`}>
+          <SizeChip size={pr.size} totalUsdMicros={pr.totalUsdMicros} />
         </span>
       )}
     </div>

--- a/apps/fabro-web/app/routes/runs.tsx
+++ b/apps/fabro-web/app/routes/runs.tsx
@@ -418,7 +418,7 @@ function PrCardFooter({ pr, actions }: { pr: RunItem; actions?: string[] }) {
         </div>
       )}
       {pr.size != null && (
-        <span className={`inline-flex ${hasActions ? "" : "ml-auto"}`}>
+        <span className={hasActions ? "inline-flex" : "ml-auto inline-flex"}>
           <SizeChip size={pr.size} totalUsdMicros={pr.totalUsdMicros} />
         </span>
       )}


### PR DESCRIPTION
## What

Brings the run size chip to the same level of usefulness in all three places runs are shown.

**Runs list (`/runs?view=list`)** — the Size column rendered `SizeChip` without the billed total, so its tooltip read `Size M` while the run detail header read `Size M · $12.34`. The tooltip was also unreachable: the row title link paints a `before:absolute before:inset-0` overlay across the whole row, which sat above the chip and swallowed hover. The chip is now wrapped in `relative z-10`, matching how the created-by and pull request cells already handle interactive content in the same row.

**Tooltip wording** — dropped the trailing word "billed", so it reads `Size M · $12.34`.

**Board (`/runs`)** — replaced the wall-clock duration in the card footer's bottom-right corner with the same chip, so cost is the consistent signal across views.

## Behavior note

`PrCardFooter`'s early return used to key off `elapsed`, which is only set once a run has timing data. It now keys off `size`, which the server always populates (defaulting to `XS`). So the footer renders on every board card now, and a brand-new run shows an `XS` chip where it previously showed nothing. That matches the list view, which also always renders the chip. Easy to gate on `pr.size !== "XS"` if it reads as noise.

The cost only appears once a run reaches a terminal state — `billing` is populated at conclusion (`run_state.rs:1259`), so in-flight runs show a plain `Size M`. That was already true of the detail header. The size *letter* behaves differently: it is computed from the running projection, so it climbs the buckets while a run is active.

`RunItem.elapsed` is unchanged and still backs the list view's Elapsed column.

## Testing

- `bun run typecheck` clean.
- `bun test` — 735 pass, 13 fail. The 13 failures are pre-existing on `main` (verified by stashing); they are in build-version detection and RunFiles rendering, unrelated to this change.
- New `app/components/size-chip.test.tsx` pins the tooltip label for each tier.
- New cases in `app/data/runs.test.ts` cover the billed total flowing into `RunItem`, including the `billing: null` and `total_usd_micros: null` cases.

Not verified in a browser — the layout reasoning is from the CSS and reuses the positioning the duration already had, so the placement should carry over, but the chip is a bolder visual than the muted timestamp it replaced. Worth an eyeball on the testing instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)