### PR TITLE
Keep server tests off the developer's real ~/.fabro/storage

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -12,10 +12,6 @@ leak-timeout = "500ms"
     slow-timeout = { period = "5s", terminate-after = 4 }
 
     [[profile.default.overrides]]
-    filter = "package(fabro-server) & test(all_spec_routes_are_routable)"
-    slow-timeout = { period = "15s", terminate-after = 4 }
-
-    [[profile.default.overrides]]
     filter = "package(fabro-workflow)"
     slow-timeout = { period = "2s", terminate-after = 3 }
 

--- a/lib/apps/fabro-server/src/test_support.rs
+++ b/lib/apps/fabro-server/src/test_support.rs
@@ -13,6 +13,7 @@ use axum::middleware::Next;
 use axum::response::Response;
 use axum::{Router, middleware};
 use chrono::Duration as ChronoDuration;
+use fabro_config::user::default_storage_dir;
 use fabro_config::{RunLayer, ServerSettingsBuilder, Storage, envfile};
 use fabro_db::DbPool;
 use fabro_interview::Interviewer;
@@ -253,9 +254,10 @@ impl TestAppStateBuilder {
         self.try_build().expect("test app state should build")
     }
 
-    pub fn try_build(self) -> anyhow::Result<Arc<AppState>> {
+    pub fn try_build(mut self) -> anyhow::Result<Arc<AppState>> {
         let (store, artifact_store) = self.store_bundle.unwrap_or_else(test_store_bundle);
         let vault_path = self.vault_path.unwrap_or_else(test_secret_store_path);
+        redirect_default_storage_root(&mut self.server_settings, &vault_path);
         if !self.vault_entries.is_empty() {
             let mut vault = Vault::load(vault_path.clone()).expect("test vault should load");
             for (name, value) in &self.vault_entries {
@@ -670,6 +672,25 @@ pub fn test_secret_store_path() -> PathBuf {
     let dir = std::env::temp_dir().join(format!("fabro-test-{}", Ulid::new()));
     std::fs::create_dir_all(&dir).expect("test temp dir should be creatable");
     dir.join("secrets.json")
+}
+
+/// Keeps tests off the developer's real `~/.fabro/storage`.
+///
+/// Settings built for tests usually omit `[server.storage] root`, which
+/// resolves to the production default. Handlers that walk that tree — `df`,
+/// `system/resources`, `prune` — then read whatever runs and scratch
+/// directories the machine happens to have, making tests slow and
+/// machine-dependent, and letting run-creating tests write there.
+///
+/// Only settings still carrying the production default are redirected; a test
+/// that chose its own root keeps it.
+fn redirect_default_storage_root(settings: &mut ServerSettings, vault_path: &Path) {
+    if Path::new(&settings.server.storage.root) != default_storage_dir() {
+        return;
+    }
+    let root = vault_path.with_file_name("storage");
+    std::fs::create_dir_all(&root).expect("test storage root should be creatable");
+    settings.server.storage.root = root.display().to_string();
 }
 
 #[must_use]


### PR DESCRIPTION
Test settings usually omit `[server.storage] root`, so it resolved to the production default from `fabro_config::user::default_storage_dir()` — the developer's real `~/.fabro/storage`. Handlers that walk that tree read whatever the machine happened to have, and run-creating tests wrote there.

## How this surfaced

`openapi_conformance::all_spec_routes_are_routable` was slow enough to trip its nextest timeout. Timing every request in it showed the cost was not route volume — 91% sat in two routes:

```
=== total in-loop time: 11.94s over 159 operations ===
    6304.5ms  GET  /api/v1/system/resources
    4573.5ms  GET  /api/v1/system/df
     583.3ms  POST /api/v1/system/prune/runs
     234.7ms  POST /api/v1/providers/test
     190.2ms  POST /api/v1/health/diagnostics
      18.8ms  GET  /api/v1/sandboxes
       ...
remaining 134 operations: 8.3ms combined
```

Both size Fabro-managed storage — `build_disk_usage_response` walks every run directory, `sample_fabro_storage_usage` walks the root. On my machine that tree is 193MB with 90,795 entries under `scratch/`, so the test's duration tracked how long I had been running Fabro locally rather than anything about the code. It also explains the run-to-run variance.

## Changes

**`TestAppStateBuilder::try_build`** redirects the storage root to a `storage` directory beside the test vault, joining the existing `server.env` and `settings.toml` siblings derived from `vault_path`. No extra temp directory per built state. Only settings still carrying the production default are redirected, so a test that chose its own root — `tests/it/api/system.rs:42` — keeps it.

**Dropped the special-case nextest timeout** for `all_spec_routes_are_routable`. It needed room only because of the storage walk, and the package-wide fabro-server timeout now covers it with wide margin. The override was inert regardless: nextest resolves each setting from the first matching override and `package(fabro-server)` sat above it, so the narrower filter never applied. Removing it makes the config say what was already true.

## Results

| | before | after |
|---|---|---|
| `all_spec_routes_are_routable` | ~15s, machine-dependent | ~0.6s |
| full workspace run | ~33s | ~25s |

The workspace-wide gain is larger than this one test, so other `test_app_state()` users were paying the same cost.

All 7400 tests pass with the override removed; fmt and clippy clean; `cargo build --workspace` without `test-support` still builds.

One flake seen once under full parallel load: `cmd::server_start::concurrent_autostart_converges_on_one_shared_daemon_and_cleans_up` timed out at 24s, then passed alone in 0.79s and on full re-runs. It spawns real subprocesses with an explicit `--storage-dir` from `isolated_storage_dir()`, so it never goes through `TestAppStateBuilder` and is unaffected by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)