### PR TITLE
fix(tool): finish the catalog-free validation work from #651

### DIFF
--- a/lib/apps/fabro-cli/src/commands/run/runner.rs
+++ b/lib/apps/fabro-cli/src/commands/run/runner.rs
@@ -263,7 +263,12 @@ impl fabro_tool::RunManifestBuilder for WorkerRunManifestBuilder {
         cwd: &Path,
         user_settings_path: &Path,
     ) -> fabro_tool::ToolResult<RunManifest> {
-        run_tool_manifest::build_run_tool_manifest(spec, cwd, user_settings_path, &self.catalog)
+        run_tool_manifest::build_run_tool_manifest(
+            spec,
+            cwd,
+            user_settings_path,
+            Arc::clone(&self.catalog),
+        )
     }
 }
 

--- a/lib/apps/fabro-cli/src/commands/run/runner.rs
+++ b/lib/apps/fabro-cli/src/commands/run/runner.rs
@@ -110,7 +110,6 @@ pub(crate) async fn execute(
             run_id,
             run_spec.source_directory.as_deref(),
             &run_dir,
-            Arc::clone(&catalog),
         )
     } else {
         None
@@ -237,13 +236,12 @@ fn build_fabro_run_tool_services(
     current_run_id: RunId,
     source_directory: Option<&str>,
     run_dir: &Path,
-    catalog: Arc<Catalog>,
 ) -> Option<FabroRunToolServices> {
     if worker_token.trim().is_empty() {
         return None;
     }
     let backend = ClientBackend::new(Arc::new(client))
-        .with_manifest_builder(Arc::new(WorkerRunManifestBuilder { catalog }));
+        .with_manifest_builder(Arc::new(WorkerRunManifestBuilder));
     Some(FabroRunToolServices {
         backend: Arc::new(backend),
         current_run_id,
@@ -252,9 +250,7 @@ fn build_fabro_run_tool_services(
     })
 }
 
-struct WorkerRunManifestBuilder {
-    catalog: Arc<Catalog>,
-}
+struct WorkerRunManifestBuilder;
 
 impl fabro_tool::RunManifestBuilder for WorkerRunManifestBuilder {
     fn build_run_manifest(
@@ -263,12 +259,7 @@ impl fabro_tool::RunManifestBuilder for WorkerRunManifestBuilder {
         cwd: &Path,
         user_settings_path: &Path,
     ) -> fabro_tool::ToolResult<RunManifest> {
-        run_tool_manifest::build_run_tool_manifest(
-            spec,
-            cwd,
-            user_settings_path,
-            Arc::clone(&self.catalog),
-        )
+        run_tool_manifest::build_run_tool_manifest(spec, cwd, user_settings_path)
     }
 }
 

--- a/lib/apps/fabro-mcp-server/src/manifest_builder.rs
+++ b/lib/apps/fabro-mcp-server/src/manifest_builder.rs
@@ -1,11 +1,8 @@
 use std::path::Path;
-use std::sync::Arc;
 
 use fabro_api::types;
-use fabro_config::load_llm_catalog_settings;
-use fabro_model::Catalog;
 use fabro_server::run_tool_manifest;
-use fabro_tool::{RunManifestBuilder, ToolError, ToolResult, ValidatedCreateRunSpec};
+use fabro_tool::{RunManifestBuilder, ToolResult, ValidatedCreateRunSpec};
 
 #[derive(Default)]
 pub(crate) struct McpRunManifestBuilder;
@@ -17,20 +14,6 @@ impl RunManifestBuilder for McpRunManifestBuilder {
         cwd: &Path,
         user_settings_path: &Path,
     ) -> ToolResult<types::RunManifest> {
-        build_mcp_run_manifest(spec, cwd, user_settings_path)
+        run_tool_manifest::build_run_tool_manifest(spec, cwd, user_settings_path)
     }
-}
-
-fn build_mcp_run_manifest(
-    spec: &ValidatedCreateRunSpec,
-    cwd: &Path,
-    user_settings_path: &Path,
-) -> ToolResult<types::RunManifest> {
-    let llm_catalog_settings = load_llm_catalog_settings(Some(user_settings_path))
-        .map_err(|err| ToolError::message(err.to_string()))?;
-    let catalog = Arc::new(
-        Catalog::from_builtin_with_overrides(&llm_catalog_settings)
-            .map_err(|err| ToolError::message(err.to_string()))?,
-    );
-    run_tool_manifest::build_run_tool_manifest(spec, cwd, user_settings_path, catalog)
 }

--- a/lib/apps/fabro-mcp-server/src/manifest_builder.rs
+++ b/lib/apps/fabro-mcp-server/src/manifest_builder.rs
@@ -32,5 +32,5 @@ fn build_mcp_run_manifest(
         Catalog::from_builtin_with_overrides(&llm_catalog_settings)
             .map_err(|err| ToolError::message(err.to_string()))?,
     );
-    run_tool_manifest::build_run_tool_manifest(spec, cwd, user_settings_path, &catalog)
+    run_tool_manifest::build_run_tool_manifest(spec, cwd, user_settings_path, catalog)
 }

--- a/lib/apps/fabro-server/src/manifest_validation.rs
+++ b/lib/apps/fabro-server/src/manifest_validation.rs
@@ -25,7 +25,7 @@ pub fn validate_manifest(
 pub fn validate_manifest_with_catalog(
     manifest_run_defaults: &RunLayer,
     manifest: &types::RunManifest,
-    catalog: &Arc<Catalog>,
+    catalog: Arc<Catalog>,
 ) -> Result<types::ValidateResponse> {
     let prepared = prepare(manifest_run_defaults, manifest)?;
     let validated =

--- a/lib/apps/fabro-server/src/manifest_validation.rs
+++ b/lib/apps/fabro-server/src/manifest_validation.rs
@@ -1,48 +1,31 @@
 use std::collections::HashMap;
-use std::sync::Arc;
 
 use anyhow::Result;
 use fabro_api::types;
 use fabro_config::RunLayer;
-use fabro_model::Catalog;
 use fabro_workflow::pipeline::TEMPLATE_UNDEFINED_VARIABLE_RULE;
 
 use crate::run_manifest;
 
-/// Validate a manifest without a model catalog. Model and provider
-/// availability is deferred to the server, which owns the catalog.
+/// Validate a manifest without a model catalog.
+///
+/// Every caller is a client — the CLI, an MCP server, a run worker — and a
+/// client's catalog is its own, not the server's. Judging model and provider
+/// availability here would reject workflows the server can run, so that is
+/// left to the server on create.
 pub fn validate_manifest(
     manifest_run_defaults: &RunLayer,
     manifest: &types::RunManifest,
 ) -> Result<types::ValidateResponse> {
-    let prepared = prepare(manifest_run_defaults, manifest)?;
-    let validated = run_manifest::validate_prepared_manifest_structural(&prepared)
-        .map_err(anyhow::Error::new)?;
-    Ok(run_manifest::validate_response(&prepared, &validated))
-}
-
-/// Validate a manifest including the catalog-backed model and provider rules.
-pub fn validate_manifest_with_catalog(
-    manifest_run_defaults: &RunLayer,
-    manifest: &types::RunManifest,
-    catalog: Arc<Catalog>,
-) -> Result<types::ValidateResponse> {
-    let prepared = prepare(manifest_run_defaults, manifest)?;
-    let validated =
-        run_manifest::validate_prepared_manifest(&prepared, catalog).map_err(anyhow::Error::new)?;
-    Ok(run_manifest::validate_response(&prepared, &validated))
-}
-
-fn prepare(
-    manifest_run_defaults: &RunLayer,
-    manifest: &types::RunManifest,
-) -> Result<run_manifest::PreparedManifest> {
-    run_manifest::prepare_manifest_with_environment_defaults(
+    let prepared = run_manifest::prepare_manifest_with_environment_defaults(
         manifest_run_defaults,
         &fabro_environment::seeded_catalog_layer(),
         &HashMap::new(),
         manifest,
-    )
+    )?;
+    let validated = run_manifest::validate_prepared_manifest_structural(&prepared)
+        .map_err(anyhow::Error::new)?;
+    Ok(run_manifest::validate_response(&prepared, &validated))
 }
 
 pub fn promote_template_undefined_variables_to_errors(response: &mut types::ValidateResponse) {

--- a/lib/apps/fabro-server/src/run_manifest.rs
+++ b/lib/apps/fabro-server/src/run_manifest.rs
@@ -188,7 +188,7 @@ pub(crate) fn prepare_manifest_with_environment_defaults(
 
 pub(crate) fn validate_prepared_manifest(
     prepared: &PreparedManifest,
-    catalog: &Arc<Catalog>,
+    catalog: Arc<Catalog>,
 ) -> Result<Validated, WorkflowError> {
     validate_prepared_manifest_with_vars(prepared, catalog, HashMap::new())
 }
@@ -201,7 +201,7 @@ pub(crate) fn validate_prepared_manifest_structural(
 
 pub(crate) fn validate_prepared_manifest_with_vars(
     prepared: &PreparedManifest,
-    catalog: &Arc<Catalog>,
+    catalog: Arc<Catalog>,
     vars: HashMap<String, String>,
 ) -> Result<Validated, WorkflowError> {
     validate_with_catalog(manifest_validate_input(prepared, vars), catalog)
@@ -209,7 +209,7 @@ pub(crate) fn validate_prepared_manifest_with_vars(
 
 pub(crate) fn validate_prepared_manifest_for_preflight(
     prepared: &PreparedManifest,
-    catalog: &Arc<Catalog>,
+    catalog: Arc<Catalog>,
     vars: HashMap<String, String>,
     ready_providers: &[ProviderId],
 ) -> Result<Validated, WorkflowError> {
@@ -1554,7 +1554,7 @@ digraph Demo {{
         .unwrap();
         let validated = validate_prepared_manifest_for_preflight(
             &prepared,
-            &state.catalog(),
+            state.catalog(),
             HashMap::new(),
             &ready_providers,
         )
@@ -1639,7 +1639,7 @@ enabled = {clone_enabled}
             &manifest,
         )
         .unwrap();
-        let validated = validate_prepared_manifest(&prepared, &test_catalog()).unwrap();
+        let validated = validate_prepared_manifest(&prepared, test_catalog()).unwrap();
         let resolved = materialize_run(
             prepared.settings.clone(),
             validated.graph(),
@@ -2199,7 +2199,7 @@ name = "Control Plane"
             &invalid_manifest(),
         )
         .unwrap();
-        let validated = validate_prepared_manifest(&prepared, &test_catalog()).unwrap();
+        let validated = validate_prepared_manifest(&prepared, test_catalog()).unwrap();
 
         assert!(validated.has_errors());
 
@@ -2244,7 +2244,7 @@ issues = "read"
             &manifest,
         )
         .unwrap();
-        let validated = validate_prepared_manifest(&prepared, &test_catalog()).unwrap();
+        let validated = validate_prepared_manifest(&prepared, test_catalog()).unwrap();
         assert!(!validated.has_errors());
 
         let (response, _ok) = resolve_and_run_preflight(state.as_ref(), &prepared, &validated)
@@ -2294,7 +2294,7 @@ id = "local"
             &manifest,
         )
         .unwrap();
-        let validated = validate_prepared_manifest(&prepared, &test_catalog()).unwrap();
+        let validated = validate_prepared_manifest(&prepared, test_catalog()).unwrap();
 
         assert!(!validated.has_errors());
 
@@ -2403,7 +2403,7 @@ id = "daytona"
             &manifest,
         )
         .unwrap();
-        let validated = validate_prepared_manifest(&prepared, &test_catalog()).unwrap();
+        let validated = validate_prepared_manifest(&prepared, test_catalog()).unwrap();
 
         let (response, _ok) = resolve_and_run_preflight(state.as_ref(), &prepared, &validated)
             .await
@@ -2471,7 +2471,7 @@ digraph Demo {
             &manifest,
         )
         .unwrap();
-        let validated = validate_prepared_manifest(&prepared, &test_catalog()).unwrap();
+        let validated = validate_prepared_manifest(&prepared, test_catalog()).unwrap();
 
         let (response, ok) = resolve_and_run_preflight(state.as_ref(), &prepared, &validated)
             .await
@@ -2585,7 +2585,7 @@ digraph Demo {
             &manifest,
         )
         .unwrap();
-        let Err(error) = validate_prepared_manifest(&prepared, &test_catalog()) else {
+        let Err(error) = validate_prepared_manifest(&prepared, test_catalog()) else {
             panic!("unknown provider should fail static validation");
         };
 
@@ -2652,7 +2652,7 @@ digraph Demo {
         assert!(ready_providers.is_empty());
         let validated = validate_prepared_manifest_for_preflight(
             &prepared,
-            &state.catalog(),
+            state.catalog(),
             HashMap::new(),
             &ready_providers,
         )

--- a/lib/apps/fabro-server/src/run_tool_manifest.rs
+++ b/lib/apps/fabro-server/src/run_tool_manifest.rs
@@ -14,7 +14,7 @@ pub fn build_run_tool_manifest(
     spec: &ValidatedCreateRunSpec,
     cwd: &Path,
     user_settings_path: &Path,
-    catalog: &Arc<Catalog>,
+    catalog: Arc<Catalog>,
 ) -> ToolResult<types::RunManifest> {
     let built = fabro_manifest::build_run_manifest(ManifestBuildInput {
         workflow:             PathBuf::from(&spec.workflow),

--- a/lib/apps/fabro-server/src/run_tool_manifest.rs
+++ b/lib/apps/fabro-server/src/run_tool_manifest.rs
@@ -1,20 +1,22 @@
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
 
 use fabro_api::types;
 use fabro_config::{CliLayer, RunGoalLayer, RunLayer};
 use fabro_manifest::{ManifestBuildInput, RunOverrideInput};
-use fabro_model::Catalog;
 use fabro_tool::{ToolError, ToolResult, ValidatedCreateRunSpec};
 use fabro_types::settings::interp::InterpString;
 
 use crate::manifest_validation;
 
+/// Build and validate a run manifest for the `fabro_run_create` tool.
+///
+/// Validation is structural. The caller is a client — an MCP server or a run
+/// worker — whose catalog is its own, not the server's, so judging model and
+/// provider availability here would reject workflows the server can run.
 pub fn build_run_tool_manifest(
     spec: &ValidatedCreateRunSpec,
     cwd: &Path,
     user_settings_path: &Path,
-    catalog: Arc<Catalog>,
 ) -> ToolResult<types::RunManifest> {
     let built = fabro_manifest::build_run_manifest(ManifestBuildInput {
         workflow:             PathBuf::from(&spec.workflow),
@@ -29,12 +31,9 @@ pub fn build_run_tool_manifest(
     })
     .map_err(|err| ToolError::from_anyhow(&err))?;
 
-    let mut validation = manifest_validation::validate_manifest_with_catalog(
-        &RunLayer::default(),
-        &built.manifest,
-        catalog,
-    )
-    .map_err(|err| ToolError::from_anyhow(&err))?;
+    let mut validation =
+        manifest_validation::validate_manifest(&RunLayer::default(), &built.manifest)
+            .map_err(|err| ToolError::from_anyhow(&err))?;
     manifest_validation::promote_template_undefined_variables_to_errors(&mut validation);
     if !validation.ok {
         return Err(ToolError::message("workflow manifest validation failed"));
@@ -105,6 +104,63 @@ mod tests {
     use serde_json::json;
 
     use super::*;
+
+    fn create_run_spec(workflow: &str) -> ValidatedCreateRunSpec {
+        ValidatedCreateRunSpec::try_from(CreateRunSpec {
+            workflow:         workflow.to_string(),
+            run_id:           None,
+            parent_id:        None,
+            cwd:              None,
+            goal:             None,
+            goal_file:        None,
+            inputs:           HashMap::new(),
+            labels:           HashMap::new(),
+            model:            None,
+            provider:         None,
+            environment:      None,
+            dry_run:          None,
+            auto_approve:     None,
+            preserve_sandbox: None,
+            start:            None,
+        })
+        .expect("create spec should validate")
+    }
+
+    /// The tool runs on a client, whose catalog is not the server's, so a
+    /// server-owned model must reach the server rather than fail here.
+    #[expect(
+        clippy::disallowed_methods,
+        reason = "sync test writes one workflow fixture before building the manifest"
+    )]
+    #[test]
+    fn server_owned_provider_is_not_rejected_by_tool_manifest_validation() {
+        let dir = tempfile::tempdir().expect("temp dir should be created");
+        let workflow = dir.path().join("server-model.fabro");
+        std::fs::write(
+            &workflow,
+            r#"digraph ServerModel {
+                graph [goal="Use a server-owned model"]
+                start [shape=Mdiamond]
+                work [prompt="Do work", model="private-model", provider="server-only"]
+                exit [shape=Msquare]
+                start -> work -> exit
+            }"#,
+        )
+        .expect("workflow fixture should be written");
+
+        let manifest = build_run_tool_manifest(
+            &create_run_spec(&workflow.to_string_lossy()),
+            dir.path(),
+            &dir.path().join("settings.toml"),
+        )
+        .expect("tool validation should leave provider availability to the server");
+
+        let encoded = serde_json::to_string(&manifest).expect("manifest should serialize");
+        assert!(
+            encoded.contains("server-only"),
+            "the authored provider should survive into the manifest: {encoded}"
+        );
+    }
 
     #[test]
     fn manifest_args_preserve_input_provenance() {

--- a/lib/apps/fabro-server/src/server/handler/graph.rs
+++ b/lib/apps/fabro-server/src/server/handler/graph.rs
@@ -52,7 +52,7 @@ async fn render_graph_from_manifest(
         Ok(prepared) => prepared,
         Err(err) => return ApiError::bad_request(err.to_string()).into_response(),
     };
-    let validated = match run_manifest::validate_prepared_manifest(&prepared, &state.catalog()) {
+    let validated = match run_manifest::validate_prepared_manifest(&prepared, state.catalog()) {
         Ok(validated) => validated,
         Err(err) => return ApiError::bad_request(err.to_string()).into_response(),
     };

--- a/lib/apps/fabro-server/src/server/handler/runs.rs
+++ b/lib/apps/fabro-server/src/server/handler/runs.rs
@@ -829,7 +829,7 @@ async fn run_preflight(
     let (llm_result, ready_providers) = state.resolve_llm_client_with_ready_ids().await;
     let mut validated = match run_manifest::validate_prepared_manifest_for_preflight(
         &prepared,
-        &state.catalog(),
+        state.catalog(),
         vars,
         &ready_providers,
     ) {
@@ -879,15 +879,17 @@ async fn validate_run_manifest(
         return ApiError::bad_request(format!("Run config variable interpolation failed: {err}"))
             .into_response();
     }
-    let validated =
-        match run_manifest::validate_prepared_manifest_with_vars(&prepared, &state.catalog(), vars)
-        {
-            Ok(validated) => validated,
-            Err(WorkflowError::Parse(_)) => {
-                return ApiError::bad_request("Validation failed").into_response();
-            }
-            Err(err) => return ApiError::bad_request(err.to_string()).into_response(),
-        };
+    let validated = match run_manifest::validate_prepared_manifest_with_vars(
+        &prepared,
+        state.catalog(),
+        vars,
+    ) {
+        Ok(validated) => validated,
+        Err(WorkflowError::Parse(_)) => {
+            return ApiError::bad_request("Validation failed").into_response();
+        }
+        Err(err) => return ApiError::bad_request(err.to_string()).into_response(),
+    };
     (
         StatusCode::OK,
         Json(run_manifest::validate_response(&prepared, &validated)),

--- a/lib/components/fabro-workflow/src/handler/manager_loop.rs
+++ b/lib/components/fabro-workflow/src/handler/manager_loop.rs
@@ -131,7 +131,7 @@ fn validate_child_workflow(
             cwd,
             custom_transforms: Vec::new(),
         },
-        &services.run.catalog,
+        Arc::clone(&services.run.catalog),
     )?;
     validated.promote_template_undefined_variables_to_errors();
     validated.raise_on_errors()?;

--- a/lib/components/fabro-workflow/src/operations/create.rs
+++ b/lib/components/fabro-workflow/src/operations/create.rs
@@ -559,7 +559,7 @@ reasoning = false
                 cwd: PathBuf::from("."),
                 custom_transforms: Vec::new(),
             },
-            &test_catalog(),
+            test_catalog(),
         )
         .unwrap()
     }

--- a/lib/components/fabro-workflow/src/operations/validate.rs
+++ b/lib/components/fabro-workflow/src/operations/validate.rs
@@ -35,12 +35,9 @@ pub fn validate(input: ValidateInput) -> Result<Validated, Error> {
 /// Parse, transform, and validate a DOT source string against `catalog`.
 pub fn validate_with_catalog(
     input: ValidateInput,
-    catalog: &Arc<Catalog>,
+    catalog: Arc<Catalog>,
 ) -> Result<Validated, Error> {
-    validate_resolving_models(
-        input,
-        Some(ModelResolutionTransform::new(Arc::clone(catalog))),
-    )
+    validate_resolving_models(input, Some(ModelResolutionTransform::new(catalog)))
 }
 
 /// Parse, transform, and validate, resolving models against the ready
@@ -48,14 +45,14 @@ pub fn validate_with_catalog(
 /// provider-readiness selection failures.
 pub fn validate_with_ready_providers(
     input: ValidateInput,
-    catalog: &Arc<Catalog>,
+    catalog: Arc<Catalog>,
     ready_providers: &[ProviderId],
 ) -> Result<Validated, Error> {
     validate_resolving_models(
         input,
         Some(
             ModelResolutionTransform::for_eligible(
-                Arc::clone(catalog),
+                catalog,
                 ready_providers.iter().cloned().collect(),
             )
             .with_catalog_fallback(true),

--- a/lib/components/fabro-workflow/src/transforms/variable_expansion.rs
+++ b/lib/components/fabro-workflow/src/transforms/variable_expansion.rs
@@ -19,17 +19,19 @@ use crate::static_reference::{
 
 /// How the template-expansion pass should treat undefined input variables.
 ///
-/// Validate is structural — it should not fail just because the user has not
-/// bound `{{ inputs.* }}` yet. Run-start is strict — missing inputs are real
-/// errors. Splitting the two lets validate work on a bare `.fabro` while
-/// run-start preserves its current hard-fail behavior.
+/// Neither validate nor run-create should fail just because the user has not
+/// bound `{{ inputs.* }}` yet, so both render structurally. Run-create then
+/// promotes the resulting warnings to errors itself, which keeps its hard-fail
+/// behavior while still reporting every undefined variable in one pass rather
+/// than aborting on the first.
 #[derive(Clone, Copy, Debug)]
 pub enum RenderMode {
-    /// Undefined inputs are hard errors. Used by run-create.
+    /// Undefined inputs abort the pass with a hard error. No production caller
+    /// uses this today; run-create promotes structural warnings instead.
     Strict,
     /// Undefined inputs render as empty and become warning diagnostics on the
     /// returned `Validated`, so structural lints still run. Used by
-    /// `fabro validate`.
+    /// `fabro validate` and by run-create.
     Structural,
 }
 

--- a/lib/components/fabro-workflow/src/transforms/variable_expansion.rs
+++ b/lib/components/fabro-workflow/src/transforms/variable_expansion.rs
@@ -19,11 +19,10 @@ use crate::static_reference::{
 
 /// How the template-expansion pass should treat undefined input variables.
 ///
-/// Neither validate nor run-create should fail just because the user has not
-/// bound `{{ inputs.* }}` yet, so both render structurally. Run-create then
-/// promotes the resulting warnings to errors itself, which keeps its hard-fail
-/// behavior while still reporting every undefined variable in one pass rather
-/// than aborting on the first.
+/// Both validate and run-create render structurally so they can report every
+/// unbound `{{ inputs.* }}` variable in one pass rather than aborting on the
+/// first. Run-create then promotes the resulting warnings to errors, which
+/// keeps its hard-fail behavior.
 #[derive(Clone, Copy, Debug)]
 pub enum RenderMode {
     /// Undefined inputs abort the pass with a hard error. No production caller


### PR DESCRIPTION
Follow-up to #651, which merged before this landed. Two commits.

## 1. `fabro_run_create` still had the bug #651 fixed

#651 stopped `fabro validate` and `fabro create` from judging model and provider availability locally, but left the tool path doing exactly that. `run_tool_manifest::build_run_tool_manifest` called `validate_manifest_with_catalog`, and both of its callers build a **client-side** catalog and then POST the manifest to the server:

- `fabro-mcp-server/src/manifest_builder.rs` — `load_llm_catalog_settings(Some(user_settings_path))`
- `fabro-cli/src/commands/run/runner.rs` — `WorkerRunManifestBuilder`, `load_llm_catalog_settings(None)`

So after #651 the product was inconsistent: `fabro create <workflow>` succeeded while the `fabro_run_create` tool on the identical workflow failed with `Model selection failed: unknown model provider 'server-only'`.

- `build_run_tool_manifest` now validates structurally, matching the CLI, and takes no catalog.
- The MCP builder sheds its `load_llm_catalog_settings` + `Catalog::from_builtin_with_overrides` pair; `WorkerRunManifestBuilder` sheds its catalog field and becomes a unit struct.
- `validate_manifest_with_catalog` had no callers left, so it is gone.

I verified the new test is meaningful rather than vacuous: with the pre-fix client-side check spliced back in, it fails with the exact reported error.

## 2. Catalog by value, and a doc fix

- #651 changed `Arc<Catalog>` to `&Arc<Catalog>` through the validation entry points. `AppState::catalog()` returns an owned `Arc`, so `&state.catalog()` cloned, borrowed the temporary, then cloned again at the leaf. Every consumer ends up owning the `Arc`, so by-value is the honest shape — and it is what `main` had before #651. The one caller holding the catalog in a field now says `Arc::clone(&self.catalog)` explicitly.
- Corrected the `RenderMode` doc comment. It claimed `Strict` is "used by run-create", but run-create renders `Structural` and promotes the resulting warnings to errors itself. `Strict` has no production caller.

## Known trade-off, accepted deliberately

Offline validation no longer runs the catalog lints `node_model_known` and `stylesheet_model_known`, so `fabro validate` catches no model typos. Both rules are `Severity::Warning` and nothing promoted them, so they never blocked anything — removing them was not required by the bug, but restoring them would warn "unknown model" for every server-owned model, which is noise for exactly the case this work enables. The server still validates on create, so typos surface there.

## Verification

3203 tests pass across `fabro-workflow`, `fabro-server`, `fabro-cli`, and `fabro-mcp-server`. `cargo check --workspace --all-targets`, nightly `clippy --workspace --all-targets -D warnings`, and `fmt --check --all` all clean; no pending snapshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)