### PR TITLE
feat(workflow): raise the stdin_source ceiling to 30 MiB

### DIFF
--- a/docs/public/workflows/stages-and-nodes.mdx
+++ b/docs/public/workflows/stages-and-nodes.mdx
@@ -117,7 +117,7 @@ When a node has no explicit `shape` or `type`, the presence of `script` makes it
 
 For `stdin_source`, strings are passed unchanged. Other JSON values use compact
 JSON. Fabro does not add a newline. A missing source, or a value larger than
-10 MiB, fails before the command starts.
+30 MiB, fails before the command starts.
 
 ### Human
 

--- a/lib/components/fabro-workflow/src/handler/command.rs
+++ b/lib/components/fabro-workflow/src/handler/command.rs
@@ -220,8 +220,10 @@ impl Handler for CommandHandler {
 /// Ceiling on encoded stdin bytes. `stdin_source` values are runtime data —
 /// often model-produced — so their size is not something a workflow author
 /// reviewed; this bounds peak memory and remote uploads the same way
-/// `MAX_FOR_EACH_ITEMS` bounds `for_each` fan-out.
-const MAX_STDIN_BYTES: usize = 10 * 1024 * 1024;
+/// `MAX_FOR_EACH_ITEMS` bounds `for_each` fan-out. Sized for wide fan-in:
+/// a `context.parallel.results` batch from a large `for_each` round easily
+/// carries tens of structured agent outputs.
+const MAX_STDIN_BYTES: usize = 30 * 1024 * 1024;
 
 fn validated_stdin_source(node: &Node) -> Result<Option<&str>, String> {
     match node.context_key_attr("stdin_source") {


### PR DESCRIPTION
## Why

`stdin_source` values are capped at 10 MiB before a command node starts. That cap is tight for wide fan-in: a `context.parallel.results` batch from a large `for_each` round carries tens of structured agent outputs, and a merge step feeding them to a deterministic command hits the ceiling as a hard deterministic failure. (Concrete case: a security-review workflow merging findings from dozens of researcher agents into one dedup step.)

## What

- Raise `MAX_STDIN_BYTES` from 10 MiB to 30 MiB in the command handler. The ceiling still bounds peak memory and remote uploads the same way `MAX_FOR_EACH_ITEMS` bounds fan-out — just with headroom matched to the fan-in sizes `for_each` already allows.
- Update the documented limit in `stages-and-nodes.mdx`.

## Verification

- `cargo test -p fabro-workflow`: 1115 + 196 + 2 passed
- `cargo clippy -p fabro-workflow --tests`: clean
- `cargo +nightly fmt -- --check`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)