### PR TITLE
Support comments in model stylesheets

### DIFF
--- a/docs/public/workflows/stylesheets.mdx
+++ b/docs/public/workflows/stylesheets.mdx
@@ -114,11 +114,14 @@ selector { property: value; property: value; }
 - Properties and values are separated by `:`
 - Declarations are separated by `;`
 - Whitespace is flexible — newlines and indentation are ignored
-- CSS comments (`/* ... */`) are not supported
+- CSS block comments (`/* ... */`) can appear between tokens and are ignored
+- Comments close at the first `*/` and do not nest; an unterminated comment is a syntax error
+- `//` does not start a CSS comment
 
 ### Full example
 
 ```
+/* Use a fast model by default. */
 *            { model: claude-haiku-4-5;reasoning_effort: low; }
 box          { reasoning_effort: high; }
 tab          { reasoning_effort: low; }

--- a/docs/public/workflows/stylesheets.mdx
+++ b/docs/public/workflows/stylesheets.mdx
@@ -116,7 +116,7 @@ selector { property: value; property: value; }
 - Whitespace is flexible — newlines and indentation are ignored
 - CSS block comments (`/* ... */`) can appear between tokens and are ignored
 - Comments close at the first `*/` and do not nest; an unterminated comment is a syntax error
-- `//` does not start a CSS comment
+- `//` starts a comment in the surrounding workflow file, but not inside a stylesheet
 
 ### Full example
 

--- a/lib/components/fabro-graphviz/src/stylesheet.rs
+++ b/lib/components/fabro-graphviz/src/stylesheet.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use crate::error::Error;
 
 /// A parsed stylesheet selector.
@@ -51,6 +53,7 @@ pub struct Stylesheet {
 ///
 /// Returns an error if the input contains invalid stylesheet syntax.
 pub fn parse_stylesheet(input: &str) -> Result<Stylesheet, Error> {
+    let input = strip_css_comments(input)?;
     let input = input.trim();
     if input.is_empty() {
         return Ok(Stylesheet { rules: Vec::new() });
@@ -81,6 +84,63 @@ pub fn parse_stylesheet(input: &str) -> Result<Stylesheet, Error> {
     }
 
     Ok(Stylesheet { rules })
+}
+
+fn strip_css_comments(input: &str) -> Result<Cow<'_, str>, Error> {
+    let bytes = input.as_bytes();
+    let mut output: Option<String> = None;
+    let mut copied_through = 0;
+    let mut quote = None;
+    let mut i = 0;
+
+    while i < bytes.len() {
+        if let Some(quote_char) = quote {
+            if bytes[i] == b'\\' && i + 1 < bytes.len() {
+                i += 2;
+            } else {
+                if bytes[i] == quote_char {
+                    quote = None;
+                }
+                i += 1;
+            }
+            continue;
+        }
+
+        match bytes[i] {
+            b'\'' | b'"' => {
+                quote = Some(bytes[i]);
+                i += 1;
+            }
+            b'\\' if i + 1 < bytes.len() => {
+                i += 2;
+            }
+            b'/' if bytes.get(i + 1) == Some(&b'*') => {
+                let comment_body_start = i + 2;
+                let Some(relative_end) = input[comment_body_start..].find("*/") else {
+                    return Err(Error::Stylesheet("unterminated CSS comment".into()));
+                };
+                let comment_end = comment_body_start + relative_end + 2;
+
+                let output = output.get_or_insert_with(|| String::with_capacity(input.len()));
+                output.push_str(&input[copied_through..i]);
+                // CSS comments do not join the tokens on either side. Preserve
+                // that boundary for this parser with one whitespace character.
+                output.push(' ');
+
+                copied_through = comment_end;
+                i = comment_end;
+            }
+            _ => i += 1,
+        }
+    }
+
+    match output {
+        Some(mut output) => {
+            output.push_str(&input[copied_through..]);
+            Ok(Cow::Owned(output))
+        }
+        None => Ok(Cow::Borrowed(input)),
+    }
 }
 
 fn parse_selector(remaining: &mut &str) -> Result<Selector, Error> {
@@ -214,6 +274,65 @@ mod tests {
         ";
         let ss = parse_stylesheet(input).unwrap();
         assert_eq!(ss.rules.len(), 3);
+    }
+
+    #[test]
+    fn parse_css_comments_between_tokens() {
+        let input = r"
+            /* Defaults apply to every node. */
+            */* selector */{/* before property */
+                model/* before colon */:/* before value */claude-sonnet-4-5/* after value */;
+            /* before closing brace */}
+            /* Use Opus for coding nodes. */
+            .code { model: claude-opus-4-6; }
+        ";
+
+        let ss = parse_stylesheet(input).unwrap();
+        assert_eq!(ss.rules.len(), 2);
+        assert_eq!(ss.rules[0].selector, Selector::Universal);
+        assert_eq!(ss.rules[0].declarations[0].property, "model");
+        assert_eq!(ss.rules[0].declarations[0].value, "claude-sonnet-4-5");
+        assert_eq!(ss.rules[1].selector, Selector::Class("code".into()));
+    }
+
+    #[test]
+    fn parse_comment_only_stylesheet() {
+        let ss = parse_stylesheet("/* no rules */").unwrap();
+        assert!(ss.rules.is_empty());
+    }
+
+    #[test]
+    fn comments_do_not_join_tokens() {
+        let result = parse_stylesheet("* { mo/**/del: sonnet; }");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn comments_close_at_first_terminator() {
+        let ss = parse_stylesheet("/* outer /* inner */ * { model: sonnet; }").unwrap();
+        assert_eq!(ss.rules.len(), 1);
+        assert_eq!(ss.rules[0].selector, Selector::Universal);
+    }
+
+    #[test]
+    fn comment_markers_inside_strings_are_preserved() {
+        let ss = parse_stylesheet("* { model: 'not-a/* comment */'; }").unwrap();
+        assert_eq!(ss.rules[0].declarations[0].value, "'not-a/* comment */'");
+    }
+
+    #[test]
+    fn parse_error_unterminated_comment() {
+        let error = parse_stylesheet("/* no terminator").unwrap_err();
+        assert_eq!(
+            error.to_string(),
+            "Stylesheet error: unterminated CSS comment"
+        );
+    }
+
+    #[test]
+    fn parse_error_line_comment() {
+        let result = parse_stylesheet("// not a CSS comment\n* { model: sonnet; }");
+        assert!(result.is_err());
     }
 
     #[test]

--- a/lib/components/fabro-graphviz/src/stylesheet.rs
+++ b/lib/components/fabro-graphviz/src/stylesheet.rs
@@ -1,5 +1,3 @@
-use std::borrow::Cow;
-
 use crate::error::Error;
 
 /// A parsed stylesheet selector.
@@ -69,7 +67,7 @@ pub fn parse_stylesheet(input: &str) -> Result<Stylesheet, Error> {
         if !remaining.starts_with('{') {
             return Err(Error::Stylesheet(format!(
                 "expected '{{' after selector, got: {:?}",
-                &remaining[..remaining.len().min(20)]
+                excerpt(remaining)
             )));
         }
         remaining = remaining[1..].trim();
@@ -86,61 +84,33 @@ pub fn parse_stylesheet(input: &str) -> Result<Stylesheet, Error> {
     Ok(Stylesheet { rules })
 }
 
-fn strip_css_comments(input: &str) -> Result<Cow<'_, str>, Error> {
-    let bytes = input.as_bytes();
-    let mut output: Option<String> = None;
-    let mut copied_through = 0;
-    let mut quote = None;
-    let mut i = 0;
+fn strip_css_comments(input: &str) -> Result<String, Error> {
+    let mut output = String::with_capacity(input.len());
+    let mut remaining = input;
 
-    while i < bytes.len() {
-        if let Some(quote_char) = quote {
-            if bytes[i] == b'\\' && i + 1 < bytes.len() {
-                i += 2;
-            } else {
-                if bytes[i] == quote_char {
-                    quote = None;
-                }
-                i += 1;
-            }
-            continue;
-        }
+    while let Some(start) = remaining.find("/*") {
+        let body = &remaining[start + 2..];
+        let Some(end) = body.find("*/") else {
+            return Err(Error::Stylesheet(format!(
+                "unterminated CSS comment: {:?}",
+                excerpt(&remaining[start..])
+            )));
+        };
 
-        match bytes[i] {
-            b'\'' | b'"' => {
-                quote = Some(bytes[i]);
-                i += 1;
-            }
-            b'\\' if i + 1 < bytes.len() => {
-                i += 2;
-            }
-            b'/' if bytes.get(i + 1) == Some(&b'*') => {
-                let comment_body_start = i + 2;
-                let Some(relative_end) = input[comment_body_start..].find("*/") else {
-                    return Err(Error::Stylesheet("unterminated CSS comment".into()));
-                };
-                let comment_end = comment_body_start + relative_end + 2;
-
-                let output = output.get_or_insert_with(|| String::with_capacity(input.len()));
-                output.push_str(&input[copied_through..i]);
-                // CSS comments do not join the tokens on either side. Preserve
-                // that boundary for this parser with one whitespace character.
-                output.push(' ');
-
-                copied_through = comment_end;
-                i = comment_end;
-            }
-            _ => i += 1,
-        }
+        output.push_str(&remaining[..start]);
+        // CSS comments do not join the tokens on either side. Preserve
+        // that boundary for this parser with one whitespace character.
+        output.push(' ');
+        remaining = &body[end + 2..];
     }
 
-    match output {
-        Some(mut output) => {
-            output.push_str(&input[copied_through..]);
-            Ok(Cow::Owned(output))
-        }
-        None => Ok(Cow::Borrowed(input)),
-    }
+    output.push_str(remaining);
+    Ok(output)
+}
+
+/// A short excerpt of `input` for error messages, cut on a character boundary.
+fn excerpt(input: &str) -> String {
+    input.chars().take(20).collect()
 }
 
 fn parse_selector(remaining: &mut &str) -> Result<Selector, Error> {
@@ -177,7 +147,7 @@ fn parse_selector(remaining: &mut &str) -> Result<Selector, Error> {
         if end == 0 {
             return Err(Error::Stylesheet(format!(
                 "expected selector ('*', '#id', '.class', or shape name), got: {:?}",
-                &remaining[..remaining.len().min(20)]
+                excerpt(remaining)
             )));
         }
         let shape = remaining[..end].to_string();
@@ -315,24 +285,31 @@ mod tests {
     }
 
     #[test]
-    fn comment_markers_inside_strings_are_preserved() {
-        let ss = parse_stylesheet("* { model: 'not-a/* comment */'; }").unwrap();
-        assert_eq!(ss.rules[0].declarations[0].value, "'not-a/* comment */'");
-    }
-
-    #[test]
     fn parse_error_unterminated_comment() {
         let error = parse_stylesheet("/* no terminator").unwrap_err();
         assert_eq!(
             error.to_string(),
-            "Stylesheet error: unterminated CSS comment"
+            r#"Stylesheet error: unterminated CSS comment: "/* no terminator""#
         );
     }
 
     #[test]
     fn parse_error_line_comment() {
-        let result = parse_stylesheet("// not a CSS comment\n* { model: sonnet; }");
-        assert!(result.is_err());
+        let error = parse_stylesheet("// not a CSS comment\n* { model: sonnet; }").unwrap_err();
+        assert!(
+            error.to_string().contains("expected selector"),
+            "`//` should be reported as a bad selector, got: {error}"
+        );
+    }
+
+    #[test]
+    fn parse_error_excerpt_splits_on_character_boundary() {
+        // A multi-byte character straddling the excerpt cutoff must not panic.
+        let error = parse_stylesheet("/* ünterminated cömment, well over 20 bytes").unwrap_err();
+        assert_eq!(
+            error.to_string(),
+            r#"Stylesheet error: unterminated CSS comment: "/* ünterminated cömm""#
+        );
     }
 
     #[test]

--- a/lib/components/fabro-workflow/tests/it/integration.rs
+++ b/lib/components/fabro-workflow/tests/it/integration.rs
@@ -1483,11 +1483,17 @@ fn stylesheet_application_by_specificity() {
 }
 
 #[test]
-fn stylesheet_application_via_parsed_graph() {
+fn stylesheet_comments_apply_via_parsed_graph() {
     let input = r#"digraph StyleTest {
         graph [
             goal="Test stylesheet",
-            model_stylesheet="* { model: sonnet; }"
+            model_stylesheet="
+                /* Apply Sonnet by default. */
+                * {
+                    /* Comments can appear between declarations. */
+                    model: sonnet;
+                }
+            "
         ]
         start [shape=Mdiamond]
         exit  [shape=Msquare]


### PR DESCRIPTION
## Summary

- support CSS block comments between model stylesheet tokens
- preserve token boundaries and comment-like text inside quoted strings
- reject unterminated comments and keep non-CSS line comments invalid
- document the syntax and test comments through parsed workflow application

## Test plan

- cargo nextest run -p fabro-graphviz
- cargo nextest run -p fabro-workflow stylesheet
- cargo nextest run -p fabro-validate stylesheet
- cargo +nightly-2026-04-14 clippy -p fabro-graphviz --all-targets -- -D warnings
- cargo +nightly-2026-04-14 fmt --check --all
- git diff --check

## Reference

- https://www.w3.org/TR/css-syntax-3/#consume-comments