### PR TITLE
Fix space-separated node class parsing

### DIFF
--- a/docs/public/reference/dot-language.mdx
+++ b/docs/public/reference/dot-language.mdx
@@ -195,7 +195,7 @@ Other node types still need their shape, because their attributes don't identify
 | `label` | String | Display name in the graph visualization |
 | `shape` | Identifier | Graphviz shape — determines handler type (see table above) |
 | `type` | String | Explicit handler type (overrides shape) |
-| `class` | String | Comma-separated classes for [stylesheet](/workflows/stylesheets) targeting |
+| `class` | String | Classes for [stylesheet](/workflows/stylesheets) targeting. Separate multiple classes with spaces. Commas are also accepted for compatibility. |
 | `timeout` | Duration | Execution timeout (e.g. `900s`) |
 | `max_visits` | Integer | Max times this node can execute in a run. Overrides the graph-level `max_node_visits` for this node. |
 | `max_retries` | Integer | Override default retry count |

--- a/docs/public/tutorials/multi-model.mdx
+++ b/docs/public/tutorials/multi-model.mdx
@@ -77,7 +77,7 @@ Set the `class` attribute on a node to target it with class selectors:
 implement [label="Implement", class="coding"]
 ```
 
-Multiple classes are space-separated: `class="coding critical"`.
+Separate multiple classes with spaces: `class="coding critical"`. Fabro also accepts commas as class separators for compatibility.
 
 ## Properties
 

--- a/docs/public/tutorials/multi-model.mdx
+++ b/docs/public/tutorials/multi-model.mdx
@@ -77,7 +77,7 @@ Set the `class` attribute on a node to target it with class selectors:
 implement [label="Implement", class="coding"]
 ```
 
-Separate multiple classes with spaces: `class="coding critical"`. Fabro also accepts commas as class separators for compatibility.
+Separate multiple classes with spaces: `class="coding critical"`.
 
 ## Properties
 

--- a/docs/public/workflows/imports.mdx
+++ b/docs/public/workflows/imports.mdx
@@ -92,7 +92,7 @@ Every node from `validate.fabro` inherits `model="haiku"` and `reasoning_effort=
 Classes on the placeholder are unioned into every imported node's class list, in addition to a class derived from the placeholder ID itself (lowercased, non-alphanumeric stripped). This lets [stylesheets](/workflows/stylesheets) target imported subgraphs as a group.
 
 ```dot
-validate [import="./validate.fabro", class="fast, shared"]
+validate [import="./validate.fabro", class="fast shared"]
 ```
 
 Each imported node ends up with the classes it declared, plus `fast`, `shared`, and `validate`.

--- a/docs/public/workflows/stages-and-nodes.mdx
+++ b/docs/public/workflows/stages-and-nodes.mdx
@@ -235,7 +235,7 @@ These attributes can be set on any node type:
 | Attribute | Description |
 |---|---|
 | `label` | Display name shown in the graph visualization |
-| `class` | CSS-like class for [model stylesheet](/workflows/stylesheets) targeting (space-separated for multiple) |
+| `class` | CSS-like class for [model stylesheet](/workflows/stylesheets) targeting. Separate multiple classes with spaces. Commas are also accepted for compatibility. |
 | `max_visits` | Max times this node can execute in a run. Overrides the graph-level `max_node_visits` for this node. |
 | `goal_gate` | When `true`, the workflow fails if this node doesn't succeed |
 | `max_retries` | Override default retry count for this node |

--- a/docs/public/workflows/stages-and-nodes.mdx
+++ b/docs/public/workflows/stages-and-nodes.mdx
@@ -235,7 +235,7 @@ These attributes can be set on any node type:
 | Attribute | Description |
 |---|---|
 | `label` | Display name shown in the graph visualization |
-| `class` | CSS-like class for [model stylesheet](/workflows/stylesheets) targeting. Separate multiple classes with spaces. Commas are also accepted for compatibility. |
+| `class` | CSS-like class for [model stylesheet](/workflows/stylesheets) targeting. Separate multiple classes with spaces. |
 | `max_visits` | Max times this node can execute in a run. Overrides the graph-level `max_node_visits` for this node. |
 | `goal_gate` | When `true`, the workflow fails if this node doesn't succeed |
 | `max_retries` | Override default retry count for this node |

--- a/docs/public/workflows/stylesheets.mdx
+++ b/docs/public/workflows/stylesheets.mdx
@@ -50,13 +50,14 @@ Each rule starts with a selector that determines which nodes it applies to:
 
 ### Assigning classes
 
-Set the `class` attribute on a node to target it with class selectors. Multiple classes are space-separated:
+Set the `class` attribute on a node to target it with class selectors. Separate multiple classes with spaces:
 
 ```dot
 implement [label="Implement", class="coding critical"]
 ```
 
 This node matches both `.coding` and `.critical` rules.
+Fabro also accepts commas as class separators for compatibility.
 
 ## Properties
 

--- a/docs/public/workflows/stylesheets.mdx
+++ b/docs/public/workflows/stylesheets.mdx
@@ -57,7 +57,6 @@ implement [label="Implement", class="coding critical"]
 ```
 
 This node matches both `.coding` and `.critical` rules.
-Fabro also accepts commas as class separators for compatibility.
 
 ## Properties
 

--- a/lib/components/fabro-graphviz/src/parser/semantic.rs
+++ b/lib/components/fabro-graphviz/src/parser/semantic.rs
@@ -47,6 +47,15 @@ fn convert_attrs(block: &AttrBlock) -> HashMap<String, AttrValue> {
         .collect()
 }
 
+/// Split a `class` attribute value into individual class names.
+///
+/// Classes are separated by whitespace. Commas are also accepted, because they
+/// were the only separator Fabro used to recognize. Splitting on commas first
+/// and then on whitespace drops empty entries without extra trimming.
+fn split_class_attr(class_attr: &str) -> impl Iterator<Item = &str> {
+    class_attr.split(',').flat_map(str::split_whitespace)
+}
+
 /// Derive a CSS class name from a subgraph label.
 fn derive_class_from_label(label: &str) -> String {
     label
@@ -97,13 +106,6 @@ impl SemanticState {
         })
     }
 
-    fn add_class_to_node(node: &mut Node, cls: &str) {
-        let cls_string = cls.to_string();
-        if !node.classes.contains(&cls_string) {
-            node.classes.push(cls_string);
-        }
-    }
-
     fn process_node(&mut self, node_stmt: &NodeStmt, subgraph_class: Option<&str>) {
         let node = self.ensure_node(&node_stmt.id);
         if let Some(attrs) = &node_stmt.attrs {
@@ -112,19 +114,18 @@ impl SemanticState {
             }
         }
         if let Some(cls) = subgraph_class {
-            Self::add_class_to_node(node, cls);
+            node.add_class(cls);
         }
-        // Parse explicit class attr into classes vec
-        let class_str = node
+        // Node defaults can also set `class`, so read the merged attrs. The
+        // clone releases the borrow on `node.attrs` before appending.
+        let class_attr = node
             .attrs
             .get("class")
             .and_then(AttrValue::as_str)
             .map(String::from);
-        if let Some(class_str) = class_str {
-            for cls in class_str.split(|ch: char| ch == ',' || ch.is_whitespace()) {
-                if !cls.is_empty() {
-                    Self::add_class_to_node(node, cls);
-                }
+        if let Some(class_attr) = class_attr {
+            for cls in split_class_attr(&class_attr) {
+                node.add_class(cls);
             }
         }
     }
@@ -136,7 +137,7 @@ impl SemanticState {
             }
             let node = self.ensure_node(id);
             if let Some(cls) = subgraph_class {
-                Self::add_class_to_node(node, cls);
+                node.add_class(cls);
             }
         }
         let edge_attrs = edge_stmt

--- a/lib/components/fabro-graphviz/src/parser/semantic.rs
+++ b/lib/components/fabro-graphviz/src/parser/semantic.rs
@@ -121,10 +121,9 @@ impl SemanticState {
             .and_then(AttrValue::as_str)
             .map(String::from);
         if let Some(class_str) = class_str {
-            for cls in class_str.split(',') {
-                let cls = cls.trim().to_string();
-                if !cls.is_empty() && !node.classes.contains(&cls) {
-                    node.classes.push(cls);
+            for cls in class_str.split(|ch: char| ch == ',' || ch.is_whitespace()) {
+                if !cls.is_empty() {
+                    Self::add_class_to_node(node, cls);
                 }
             }
         }
@@ -501,23 +500,38 @@ mod tests {
         assert_eq!(graph.edges[1].label(), Some("next"));
     }
 
-    #[test]
-    fn ast_to_graph_class_attr_parsed() {
+    fn classes_from_attr(class_attr: &str) -> Vec<String> {
         let dot = DotGraph {
             name:       "ClassTest".into(),
             statements: vec![Statement::Node(NodeStmt {
-                id:    "review".into(),
-                attrs: Some(vec![(
-                    "class".into(),
-                    AstValue::Str("code,critical".into()),
-                )]),
+                id:    "work".into(),
+                attrs: Some(vec![("class".into(), AstValue::Str(class_attr.into()))]),
             })],
         };
 
-        let graph = ast_to_graph(&dot).unwrap();
-        let review = &graph.nodes["review"];
-        assert!(review.classes.contains(&"code".to_string()));
-        assert!(review.classes.contains(&"critical".to_string()));
+        ast_to_graph(&dot).unwrap().nodes["work"].classes.clone()
+    }
+
+    #[test]
+    fn ast_to_graph_space_separated_class_attr_parsed() {
+        assert_eq!(classes_from_attr("coding critical"), vec![
+            "coding", "critical"
+        ]);
+    }
+
+    #[test]
+    fn ast_to_graph_comma_separated_class_attr_parsed() {
+        assert_eq!(classes_from_attr("coding,critical"), vec![
+            "coding", "critical"
+        ]);
+    }
+
+    #[test]
+    fn ast_to_graph_mixed_class_separators_ignore_empty_and_duplicate_classes() {
+        assert_eq!(
+            classes_from_attr(" coding, critical  coding,\t,review\ncritical "),
+            vec!["coding", "critical", "review"]
+        );
     }
 
     #[test]

--- a/lib/components/fabro-graphviz/src/parser/semantic.rs
+++ b/lib/components/fabro-graphviz/src/parser/semantic.rs
@@ -514,25 +514,23 @@ mod tests {
     }
 
     #[test]
-    fn ast_to_graph_space_separated_class_attr_parsed() {
-        assert_eq!(classes_from_attr("coding critical"), vec![
-            "coding", "critical"
-        ]);
-    }
-
-    #[test]
-    fn ast_to_graph_comma_separated_class_attr_parsed() {
-        assert_eq!(classes_from_attr("coding,critical"), vec![
-            "coding", "critical"
-        ]);
-    }
-
-    #[test]
-    fn ast_to_graph_mixed_class_separators_ignore_empty_and_duplicate_classes() {
-        assert_eq!(
-            classes_from_attr(" coding, critical  coding,\t,review\ncritical "),
-            vec!["coding", "critical", "review"]
-        );
+    fn ast_to_graph_class_attr_splits_on_whitespace_and_commas() {
+        let expected = vec!["coding", "critical"];
+        for class_attr in [
+            "coding critical",
+            "coding,critical",
+            "coding, critical",
+            "coding  critical",
+            "  coding\tcritical\n",
+            "coding,,critical",
+            "coding critical coding",
+        ] {
+            assert_eq!(
+                classes_from_attr(class_attr),
+                expected,
+                "class attr {class_attr:?}"
+            );
+        }
     }
 
     #[test]

--- a/lib/components/fabro-workflow/src/transforms/import.rs
+++ b/lib/components/fabro-workflow/src/transforms/import.rs
@@ -352,11 +352,9 @@ impl ImportTransform {
             Self::remap_retry_target(&mut merged_node.attrs, placeholder_id);
 
             for class_name in &placeholder.class_names {
-                Self::push_class(&mut merged_node.classes, class_name);
+                merged_node.add_class(class_name);
             }
-            if !placeholder.normalized_class.is_empty() {
-                Self::push_class(&mut merged_node.classes, &placeholder.normalized_class);
-            }
+            merged_node.add_class(&placeholder.normalized_class);
 
             graph.nodes.insert(prefixed_id, merged_node);
         }
@@ -413,24 +411,14 @@ impl ImportTransform {
             .get(placeholder_id)
             .ok_or_else(|| format!("missing import placeholder '{placeholder_id}'"))?;
         let mut default_attrs = HashMap::new();
-        let mut class_names = Vec::new();
 
         for (key, value) in &node.attrs {
             if key == "import" {
                 continue;
             }
 
+            // The parser already split `class` into `node.classes`.
             if key == "class" {
-                if let Some(class_attr) = value.as_str() {
-                    for class_name in class_attr.split(',') {
-                        let class_name = class_name.trim();
-                        if !class_name.is_empty()
-                            && !class_names.iter().any(|value| value == class_name)
-                        {
-                            class_names.push(class_name.to_string());
-                        }
-                    }
-                }
                 continue;
             }
 
@@ -446,7 +434,7 @@ impl ImportTransform {
 
         Ok(PlaceholderOptions {
             default_attrs,
-            class_names,
+            class_names: node.classes.clone(),
             normalized_class: Self::normalize_class_name(placeholder_id),
         })
     }
@@ -618,12 +606,6 @@ impl ImportTransform {
         ]
         .into_iter()
         .any(|key| edge.attrs.contains_key(key))
-    }
-
-    fn push_class(classes: &mut Vec<String>, class_name: &str) {
-        if !classes.iter().any(|value| value == class_name) {
-            classes.push(class_name.to_string());
-        }
     }
 
     fn normalize_class_name(label: &str) -> String {
@@ -1120,7 +1102,7 @@ mod tests {
         let graph = apply_import(
             r#"digraph Deploy {
                 start [shape=Mdiamond]
-                validate [import="./validate.fabro", model="haiku", backend="acp", acp.command="python fake_agent.py", class="fast, shared"]
+                validate [import="./validate.fabro", model="haiku", backend="acp", acp.command="python fake_agent.py", class="fast shared"]
                 exit [shape=Msquare]
                 start -> validate -> exit
             }"#,

--- a/lib/components/fabro-workflow/tests/it/integration.rs
+++ b/lib/components/fabro-workflow/tests/it/integration.rs
@@ -1517,6 +1517,39 @@ fn stylesheet_application_via_parsed_graph() {
 }
 
 #[test]
+fn stylesheet_application_matches_space_separated_classes_from_dot() {
+    let input = r#"digraph StyleTest {
+        graph [
+            goal="Test class selectors",
+            model_stylesheet="
+                *           { model: default-model; provider: default-provider; }
+                .research   { reasoning_effort: high; }
+                .ensemble-a { model: ensemble-model; provider: openrouter; }
+            "
+        ]
+        start [shape=Mdiamond]
+        work  [shape=tab, class="research ensemble-a", prompt="Do work"]
+        exit  [shape=Msquare]
+        start -> work -> exit
+    }"#;
+
+    let graph = parse(input).expect("parse should succeed");
+    validate_or_raise(&graph, &[]).expect("validation should pass");
+
+    let transform = StylesheetApplicationTransform;
+    let graph = transform.apply(graph).unwrap();
+    let work = &graph.nodes["work"];
+
+    assert_eq!(work.classes, vec!["research", "ensemble-a"]);
+    assert_eq!(work.model(), Some("ensemble-model"));
+    assert_eq!(work.provider(), Some("openrouter"));
+    assert_eq!(
+        work.attrs.get("reasoning_effort"),
+        Some(&AttrValue::String("high".to_string()))
+    );
+}
+
+#[test]
 fn stylesheet_parse_and_apply_directly() {
     let stylesheet_text = "* { model: base; } .fast { model: turbo; }";
     let stylesheet = parse_stylesheet(stylesheet_text).expect("stylesheet parse should succeed");

--- a/lib/foundation/fabro-types/src/graph.rs
+++ b/lib/foundation/fabro-types/src/graph.rs
@@ -155,9 +155,14 @@ impl Node {
     /// enclosing subgraphs, and import placeholders — so every caller needs the
     /// same de-duplicating append.
     ///
+    /// The name is trimmed, and a name that is empty or only whitespace is
+    /// dropped. Stylesheet selectors match class names exactly, so a padded
+    /// name would never match any rule.
+    ///
     /// Order is preserved because the first class is meaningful: it supplies
     /// the fallback thread ID for fidelity threading.
     pub fn add_class(&mut self, class: &str) {
+        let class = class.trim();
         if !class.is_empty() && !self.classes.iter().any(|existing| existing == class) {
             self.classes.push(class.to_string());
         }
@@ -682,6 +687,18 @@ mod tests {
         assert_eq!(node.retry_policy(), None);
         assert_eq!(node.max_visits(), None);
         assert!(node.project_memory());
+    }
+
+    #[test]
+    fn add_class_trims_names_and_drops_blanks_and_duplicates() {
+        let mut node = Node::new("work");
+        node.add_class("coding");
+        node.add_class(" coding ");
+        node.add_class("");
+        node.add_class("   ");
+        node.add_class("\tcritical\n");
+
+        assert_eq!(node.classes, ["coding", "critical"]);
     }
 
     fn node_with(id: &str, attrs: &[(&str, &str)]) -> Node {

--- a/lib/foundation/fabro-types/src/graph.rs
+++ b/lib/foundation/fabro-types/src/graph.rs
@@ -149,6 +149,17 @@ impl Node {
         }
     }
 
+    /// Appends a class, ignoring blank names and ones already present.
+    ///
+    /// Classes accumulate from several sources — the `class` attribute,
+    /// enclosing subgraphs, and import placeholders — so every caller needs the
+    /// same de-duplicating append.
+    pub fn add_class(&mut self, class: &str) {
+        if !class.is_empty() && !self.classes.iter().any(|existing| existing == class) {
+            self.classes.push(class.to_string());
+        }
+    }
+
     fn str_attr(&self, key: &str) -> Option<&str> {
         self.attrs.get(key).and_then(AttrValue::as_str)
     }
@@ -271,11 +282,6 @@ impl Node {
     #[must_use]
     pub fn thread_id(&self) -> Option<&str> {
         self.str_attr("thread_id")
-    }
-
-    #[must_use]
-    pub fn class(&self) -> Option<&str> {
-        self.str_attr("class")
     }
 
     pub fn timeout(&self) -> Option<Duration> {
@@ -663,7 +669,7 @@ mod tests {
         assert_eq!(node.fallback_retry_target(), None);
         assert_eq!(node.fidelity(), None);
         assert_eq!(node.thread_id(), None);
-        assert_eq!(node.class(), None);
+        assert!(node.classes.is_empty());
         assert_eq!(node.timeout(), None);
         assert_eq!(node.model(), None);
         assert_eq!(node.provider(), None);

--- a/lib/foundation/fabro-types/src/graph.rs
+++ b/lib/foundation/fabro-types/src/graph.rs
@@ -154,6 +154,9 @@ impl Node {
     /// Classes accumulate from several sources — the `class` attribute,
     /// enclosing subgraphs, and import placeholders — so every caller needs the
     /// same de-duplicating append.
+    ///
+    /// Order is preserved because the first class is meaningful: it supplies
+    /// the fallback thread ID for fidelity threading.
     pub fn add_class(&mut self, class: &str) {
         if !class.is_empty() && !self.classes.iter().any(|existing| existing == class) {
             self.classes.push(class.to_string());


### PR DESCRIPTION
## Summary

- split node `class` values on whitespace and commas
- preserve class order and remove duplicate or empty entries through the shared insertion helper
- add parser and DOT-to-stylesheet regression coverage
- standardize public documentation on space-separated classes while retaining comma compatibility

## Why

Space-separated classes were stored as one class name. Class selectors then failed to match, so nodes could silently use a universal or default model instead of the intended class-specific model.

## Test plan

- [x] `cargo nextest run -p fabro-graphviz -p fabro-workflow`
- [x] `cargo +nightly-2026-04-14 clippy -p fabro-graphviz -p fabro-workflow --all-targets -- -D warnings`
- [x] `cargo +nightly-2026-04-14 fmt --check --all`
- [x] `git diff --check`