### PR TITLE
fix(workflow): stop a provider spend limit classifying as transient_infra

### DIFF
--- a/lib/components/fabro-workflow/src/error.rs
+++ b/lib/components/fabro-workflow/src/error.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::fmt;
 use std::sync::{Arc, LazyLock};
 
@@ -44,6 +45,14 @@ pub fn classify_sdk_error(err: &LlmError) -> FailureCategory {
         | LlmError::UnsupportedToolChoice { .. } => FailureCategory::Deterministic,
     }
 }
+
+/// Failures caused by a permanent provider spend/billing ceiling.
+///
+/// These are permanent and human-actionable: only a person raising the limit
+/// clears them, so retrying is always wasted work. This list is checked before
+/// `TRANSIENT_INFRA_HINTS` so an explicit permanent ceiling wins if the same
+/// provider payload also contains a transient phrase such as `rate limited`.
+const PERMANENT_BUDGET_EXHAUSTED_HINTS: &[&str] = &["spend limit"];
 
 const TRANSIENT_INFRA_HINTS: &[&str] = &[
     "timeout",
@@ -97,6 +106,7 @@ const BUDGET_EXHAUSTED_HINTS: &[&str] = &[
     "context window exceeded",
     "budget exhausted",
     "token limit exceeded",
+    "you've hit your limit",
 ];
 
 const STRUCTURAL_HINTS: &[&str] = &[
@@ -158,15 +168,122 @@ impl miette::Diagnostic for SharedTemplateError {
 static HEX_RE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"\b[0-9a-f]{7,64}\b").expect("hardcoded regex should compile"));
 
+/// Blank a Cargo registry source path in a structured `spawned_at` field.
+///
+/// ACP internal errors include this field as provenance. Its value identifies
+/// where the provider-side process raised the error; it is not fault text.
+/// Removing only this structured value prevents the `index.crates.io` path
+/// component from triggering a transient hint without parsing arbitrary prose
+/// or consuming fault text outside the matched field value.
+fn discount_cargo_registry_source_paths(reason: &str) -> Cow<'_, str> {
+    static JSON_STRING_FIELD_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(
+            r#"(?P<field_prefix>"(?P<field_name>(?:\\.|[^"\\])*)"\s*:\s*")(?P<field_value>(?:\\.|[^"\\])*)(?P<field_end>")"#,
+        )
+        .expect("hardcoded regex should compile")
+    });
+    static REGISTRY_SRC_MARKER_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(concat!(
+            r#"(?:^|[/\\])registry[/\\]+src[/\\]+"#,
+            r#"[a-z0-9._-]+-(?:[a-f0-9]{7,64}|<hex>)"#,
+            r#"(?:[/\\]|$)"#,
+        ))
+        .expect("hardcoded regex should compile")
+    });
+
+    JSON_STRING_FIELD_RE.replace_all(reason, |captures: &regex::Captures<'_>| {
+        let field_name = captures
+            .name("field_name")
+            .expect("hardcoded regex always captures the field name")
+            .as_str();
+        let decoded_field_name = decode_json_string_contents(field_name);
+        if !decoded_field_name
+            .as_deref()
+            .is_some_and(|name| name.eq_ignore_ascii_case("spawned_at"))
+        {
+            return captures
+                .get(0)
+                .expect("capture zero always contains the full regex match")
+                .as_str()
+                .to_string();
+        }
+
+        let value = captures
+            .name("field_value")
+            .expect("hardcoded regex always captures the field value")
+            .as_str();
+        let Some(decoded_value) = decode_json_string_contents(value) else {
+            return captures
+                .get(0)
+                .expect("capture zero always contains the full regex match")
+                .as_str()
+                .to_string();
+        };
+        let decoded_value = decoded_value.to_lowercase();
+        let is_url = spawned_at_value_is_url(&decoded_value);
+        if is_url || !REGISTRY_SRC_MARKER_RE.is_match(&decoded_value) {
+            return captures
+                .get(0)
+                .expect("capture zero always contains the full regex match")
+                .as_str()
+                .to_string();
+        }
+
+        format!(
+            "{} {}",
+            captures
+                .name("field_prefix")
+                .expect("hardcoded regex always captures the field prefix")
+                .as_str(),
+            captures
+                .name("field_end")
+                .expect("hardcoded regex always captures the field terminator")
+                .as_str(),
+        )
+    })
+}
+
+fn decode_json_string_contents(serialized_value: &str) -> Option<String> {
+    serde_json::from_str(&format!(r#""{serialized_value}""#)).ok()
+}
+
+/// Whether decoded `spawned_at` text describes a URL.
+fn spawned_at_value_is_url(value: &str) -> bool {
+    if value.starts_with("//") {
+        return true;
+    }
+
+    value.split_once(':').is_some_and(|(scheme, _)| {
+        scheme.len() > 1
+            && scheme
+                .as_bytes()
+                .first()
+                .is_some_and(u8::is_ascii_alphabetic)
+            && scheme
+                .bytes()
+                .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'+' | b'-' | b'.'))
+    })
+}
+
 /// Classify a failure reason string using heuristics.
 ///
 /// This is the fallback when structured error information is not available
 /// (e.g. for `Handler(String)` or `Engine(String)` errors).
+///
+/// Hint lists are consulted in order and the first match wins, so the order is
+/// load-bearing: permanent provider limits are tested before transient infra
+/// precisely because their payloads also contain transient-looking text.
 #[must_use]
 pub fn classify_failure_reason(reason: &str) -> FailureCategory {
-    // Mask commit SHAs first. They are hex, so one contains "500" or "503"
-    // often enough to matter, which would read as a transient infra hint. The
-    // bare status codes those hints look for are too short to be masked.
+    // Discount structured provenance before normalizing case or masking hex.
+    // JSON escapes are case-sensitive, so lowercasing first could turn an
+    // invalid string into a valid one and cross the structured boundary.
+    // Masking first could rewrite a registry identifier or URI scheme and make
+    // its semantics impossible to recognize. Commit SHAs are then masked
+    // because one contains "500" or "503" often enough to read as a transient
+    // hint. The bare status codes those hints look for are too short to be
+    // masked.
+    let reason = discount_cargo_registry_source_paths(reason);
     let lowered = reason.to_lowercase();
     let lower = HEX_RE.replace_all(&lowered, "<hex>");
 
@@ -176,6 +293,13 @@ pub fn classify_failure_reason(reason: &str) -> FailureCategory {
             && !lower.contains("canceling due to test failure"))
     {
         return FailureCategory::Canceled;
+    }
+
+    if PERMANENT_BUDGET_EXHAUSTED_HINTS
+        .iter()
+        .any(|hint| lower.contains(hint))
+    {
+        return FailureCategory::BudgetExhausted;
     }
 
     if TRANSIENT_INFRA_HINTS
@@ -1280,13 +1404,18 @@ mod tests {
     // --- hints count guards ---
 
     #[test]
+    fn permanent_budget_exhausted_hints_count() {
+        assert_eq!(PERMANENT_BUDGET_EXHAUSTED_HINTS.len(), 1);
+    }
+
+    #[test]
     fn transient_infra_hints_count() {
         assert_eq!(TRANSIENT_INFRA_HINTS.len(), 38);
     }
 
     #[test]
     fn budget_exhausted_hints_count() {
-        assert_eq!(BUDGET_EXHAUSTED_HINTS.len(), 10);
+        assert_eq!(BUDGET_EXHAUSTED_HINTS.len(), 11);
     }
 
     #[test]
@@ -1402,6 +1531,16 @@ mod tests {
     fn classify_reason_token_limit_exceeded() {
         assert_eq!(
             classify_failure_reason("token limit exceeded"),
+            FailureCategory::BudgetExhausted
+        );
+    }
+
+    #[test]
+    fn classify_reason_resetting_provider_limit_is_budget_exhausted() {
+        assert_eq!(
+            classify_failure_reason(
+                "Internal error: You've hit your limit · resets Jul 31, 5am (UTC)"
+            ),
             FailureCategory::BudgetExhausted
         );
     }
@@ -2236,5 +2375,389 @@ mod tests {
             failure.signature.as_deref(),
             Some("api_transient|openai|rate_limited")
         );
+    }
+
+    // --- provider limits: resource exhaustion, not provenance or code faults ---
+
+    /// Representative ACP failure payload. The only
+    /// `TRANSIENT_INFRA_HINTS` entry this payload matches is `index.crates.io`,
+    /// and it matches inside a `spawned_at` cargo registry *source* path.
+    const SPEND_LIMIT_MESSAGE: &str = "ACP turn failed";
+    const SPEND_LIMIT_PROTOCOL_CAUSE: &str = "ACP protocol error";
+    const SPEND_LIMIT_INTERNAL_CAUSE: &str = r#"Internal error: You've hit your org's monthly spend limit · ask your admin to raise it at claude.ai/settings/usage: {
+  "spawned_at": "/home/ubuntu/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/agent-client-protocol-0.11.1/src/session.rs:567:14",
+  "data": {
+    "errorKind": "rate_limit"
+  }
+}"#;
+    const RESETTING_LIMIT_INTERNAL_CAUSE: &str = r#"Internal error: You've hit your limit · resets Jul 31, 5am (UTC): {
+  "spawned_at": "/home/ubuntu/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/agent-client-protocol-0.11.1/src/session.rs:567:14",
+  "data": {
+    "errorKind": "rate_limit"
+  }
+}"#;
+
+    #[test]
+    fn classify_reason_provider_spend_limit_is_budget_exhausted() {
+        let rendered = render_with_causes(SPEND_LIMIT_MESSAGE, &[
+            SPEND_LIMIT_PROTOCOL_CAUSE.to_string(),
+            SPEND_LIMIT_INTERNAL_CAUSE.to_string(),
+        ]);
+
+        assert_eq!(
+            classify_failure_reason(&rendered),
+            FailureCategory::BudgetExhausted,
+            "an org spend limit is permanent and human-actionable: retrying never clears it"
+        );
+    }
+
+    #[test]
+    fn classify_reason_spend_limit_wins_over_transient_hint() {
+        assert_eq!(
+            classify_failure_reason("provider rate limited: monthly spend limit reached"),
+            FailureCategory::BudgetExhausted,
+            "an explicit permanent provider ceiling must override a transient phrase"
+        );
+    }
+
+    #[test]
+    fn acp_spend_limit_failure_detail_is_not_transient_infra() {
+        let err = Error::handler_with_source(SPEND_LIMIT_MESSAGE, TestOuterError {
+            message: SPEND_LIMIT_PROTOCOL_CAUSE,
+            source:  TestCause(SPEND_LIMIT_INTERNAL_CAUSE),
+        });
+
+        let detail = err.to_failure_detail();
+        assert_eq!(detail.message, "ACP turn failed");
+        assert_eq!(detail.causes, vec![
+            SPEND_LIMIT_PROTOCOL_CAUSE.to_string(),
+            SPEND_LIMIT_INTERNAL_CAUSE.to_string(),
+        ]);
+        assert_eq!(detail.category, FailureCategory::BudgetExhausted);
+    }
+
+    #[test]
+    fn acp_resetting_limit_failure_detail_is_budget_exhausted() {
+        let err = Error::handler_with_source(SPEND_LIMIT_MESSAGE, TestOuterError {
+            message: SPEND_LIMIT_PROTOCOL_CAUSE,
+            source:  TestCause(RESETTING_LIMIT_INTERNAL_CAUSE),
+        });
+
+        let detail = err.to_failure_detail();
+        assert_eq!(detail.message, SPEND_LIMIT_MESSAGE);
+        assert_eq!(detail.causes, vec![
+            SPEND_LIMIT_PROTOCOL_CAUSE.to_string(),
+            RESETTING_LIMIT_INTERNAL_CAUSE.to_string(),
+        ]);
+        assert_eq!(detail.category, FailureCategory::BudgetExhausted);
+    }
+
+    #[test]
+    fn resetting_limit_does_not_override_a_genuine_transient_fault() {
+        let rendered =
+            format!("{RESETTING_LIMIT_INTERNAL_CAUSE}\n  caused by: connection reset by peer");
+
+        assert_eq!(
+            classify_failure_reason(&rendered),
+            FailureCategory::TransientInfra,
+            "ordinary budget hints remain below genuine transient faults"
+        );
+    }
+
+    #[test]
+    fn classify_reason_cargo_registry_source_path_is_not_a_network_fault() {
+        // `registry/src/index.crates.io-<hash>` names already-extracted crate
+        // source. It rides along as `spawned_at` provenance on ACP internal
+        // errors and describes no network fault whatsoever.
+        let rendered = concat!(
+            "ACP turn failed\n  caused by: ACP protocol error\n  caused by: ",
+            r#"Internal error: agent refused the request: {"spawned_at": "#,
+            r#""/home/ubuntu/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f"#,
+            r#"/agent-client-protocol-0.11.1/src/session.rs:567:14"}"#,
+        );
+
+        assert_eq!(
+            classify_failure_reason(rendered),
+            FailureCategory::Deterministic,
+            "a cargo registry source path is provenance, not a transient fault"
+        );
+    }
+
+    #[test]
+    fn classify_reason_hex_masked_registry_source_path_is_not_a_network_fault() {
+        // Guards the port to a caller that masks hex blobs before classifying:
+        // the registry hash then reads `index.crates.io-<hex>`, and a strict
+        // `[0-9a-f]+` hash pattern would stop matching without failing loudly.
+        let rendered = concat!(
+            "acp turn failed\n  caused by: acp protocol error\n  caused by: ",
+            r#"internal error: agent refused the request: {"spawned_at": "#,
+            r#""/home/ubuntu/.cargo/registry/src/index.crates.io-<hex>"#,
+            r#"/agent-client-protocol-0.11.1/src/session.rs:567:14"}"#,
+        );
+
+        assert_eq!(
+            classify_failure_reason(rendered),
+            FailureCategory::Deterministic,
+            "a hex-masked registry source path is still provenance, not a fault"
+        );
+    }
+
+    #[test]
+    fn classify_reason_unicode_escaped_registry_source_path_is_not_a_network_fault() {
+        let rendered = r#"internal error: {"spawned_at":"\u002fhome\u002fu\u002f.cargo\u002fregistry\u002fsrc\u002findex.crates.io-1949cf8c6b5b557f\u002fserde\u002fsrc\u002flib.rs"}"#;
+
+        assert_eq!(
+            discount_cargo_registry_source_paths(rendered),
+            r#"internal error: {"spawned_at":" "}"#,
+        );
+        assert_eq!(
+            classify_failure_reason(rendered),
+            FailureCategory::Deterministic,
+            "JSON escapes must not hide structured Cargo source provenance"
+        );
+    }
+
+    #[test]
+    fn classify_reason_partially_escaped_registry_hash_is_not_a_network_fault() {
+        let rendered = r#"{"spawned_at":"/home/u/.cargo/registry/src/index.crates.io-1949cf8\u00636b5b557f/serde/src/lib.rs"}"#;
+
+        assert!(
+            !discount_cargo_registry_source_paths(rendered).contains("index.crates.io"),
+            "the semantic hash must be checked before global hex normalization"
+        );
+        assert_eq!(
+            classify_failure_reason(rendered),
+            FailureCategory::Deterministic
+        );
+    }
+
+    #[test]
+    fn classify_reason_json_escaped_spawned_at_key_is_not_a_network_fault() {
+        for key in [r"spawned\u005fat", r"\u0053pawned_at"] {
+            let rendered = format!(
+                r#"{{"{key}":"/home/u/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/serde/src/lib.rs"}}"#
+            );
+
+            assert!(
+                !discount_cargo_registry_source_paths(&rendered).contains("index.crates.io"),
+                "JSON-equivalent spellings of the structured key must be recognized"
+            );
+            assert_eq!(
+                classify_failure_reason(&rendered),
+                FailureCategory::Deterministic
+            );
+        }
+    }
+
+    #[test]
+    fn classify_reason_malformed_spawned_at_value_is_not_discounted() {
+        let path = "/home/u/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/serde/src/lib.rs";
+        let invalid_escape = format!(r#"{{"spawned_at":"connection reset\q {path}"}}"#);
+        let literal_newline = format!("{{\"spawned_at\":\"connection reset\n{path}\"}}");
+        let uppercase_unicode_escapes = r#"{"spawned_at":"connection reset \U002fhome\U002fu\U002f.cargo\U002fregistry\U002fsrc\U002findex.crates.io-1949cf8c6b5b557f\U002fserde"}"#.to_string();
+        let uppercase_newline_escape = format!(r#"{{"spawned_at":"connection reset\N{path}"}}"#);
+        let malformed_key = format!(r#"{{"spawned\U005fat":"connection reset {path}"}}"#);
+
+        for rendered in [
+            invalid_escape,
+            literal_newline,
+            uppercase_unicode_escapes,
+            uppercase_newline_escape,
+            malformed_key,
+        ] {
+            assert_eq!(
+                discount_cargo_registry_source_paths(&rendered),
+                rendered,
+                "malformed JSON is outside the structured-field boundary"
+            );
+            assert_eq!(
+                classify_failure_reason(&rendered),
+                FailureCategory::TransientInfra,
+                "fault text in a malformed value must remain available to the classifier"
+            );
+        }
+    }
+
+    // --- non-weakening guards: genuine registry faults stay transient ---
+
+    #[test]
+    fn classify_reason_registry_download_url_still_transient() {
+        assert_eq!(
+            classify_failure_reason(
+                "error: failed to download from https://index.crates.io/api/v1/crates/serde/1.0.0/download"
+            ),
+            FailureCategory::TransientInfra
+        );
+    }
+
+    #[test]
+    fn classify_reason_registry_source_shaped_url_still_transient() {
+        for value in [
+            "https://index.crates.io/registry/src/index.crates.io-1949cf8c6b5b557f/config.json",
+            "//index.crates.io/registry/src/index.crates.io-1949cf8c6b5b557f/config.json",
+            r"https:\/\/index.crates.io\/registry\/src\/index.crates.io-1949cf8c6b5b557f\/config.json",
+            r"\/\/index.crates.io\/registry\/src\/index.crates.io-1949cf8c6b5b557f\/config.json",
+            r"file:\/srv\/cargo\/registry\/src\/index.crates.io-1949cf8c6b5b557f\/config.json",
+            r"https:\u002f\u002findex.crates.io\u002fregistry\u002fsrc\u002findex.crates.io-1949cf8c6b5b557f\u002fconfig.json",
+            "abcdef0:/srv/registry/src/index.crates.io-1949cf8c6b5b557f/config.json",
+            "deadbeef+pkg:/srv/registry/src/index.crates.io-1949cf8c6b5b557f/config.json",
+        ] {
+            let rendered = format!(r#"{{"spawned_at":"{value}"}}"#);
+            assert_eq!(
+                discount_cargo_registry_source_paths(&rendered),
+                rendered,
+                "a URL-valued spawned_at field must not be mistaken for a local source path"
+            );
+            assert_eq!(
+                classify_failure_reason(&rendered),
+                FailureCategory::TransientInfra
+            );
+        }
+    }
+
+    #[test]
+    fn discount_spawned_at_preserves_field_structure_and_flexible_spacing() {
+        let rendered = r#"internal error: { "spawned_at" : "/home/u/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/serde-1.0.0/src/lib.rs:1:1" }"#;
+
+        assert_eq!(
+            discount_cargo_registry_source_paths(rendered),
+            r#"internal error: { "spawned_at" : " " }"#,
+            "only the provenance value should be blanked"
+        );
+        assert_eq!(
+            classify_failure_reason(rendered),
+            FailureCategory::Deterministic,
+            "spacing around the structured field must not affect classification"
+        );
+    }
+
+    #[test]
+    fn classify_reason_registry_source_path_beside_real_fault_still_transient() {
+        let rendered = concat!(
+            r#"internal error: {"error":"connection reset by peer","spawned_at":"#,
+            r#""/home/u/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/"#,
+            r#"serde-1.0.0/src/lib.rs"}"#,
+        );
+
+        assert_eq!(
+            classify_failure_reason(rendered),
+            FailureCategory::TransientInfra,
+            "discounting spawned_at must not hide a genuine fault elsewhere in the payload"
+        );
+    }
+
+    #[test]
+    fn classify_reason_registry_path_in_an_unrelated_field_is_not_discounted() {
+        let rendered = r#"{"log":"panic at /home/u/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/serde-1.0.0/src/lib.rs"}"#;
+
+        assert_eq!(discount_cargo_registry_source_paths(rendered), rendered);
+        assert_eq!(
+            classify_failure_reason(rendered),
+            FailureCategory::TransientInfra,
+            "only the structured spawned_at provenance field is discounted"
+        );
+    }
+
+    #[test]
+    fn classify_reason_mixed_separator_windows_source_path_is_not_a_network_fault() {
+        for rendered in [
+            r#"{"spawned_at":"c:/cargo/registry/src/github.com-1ecc6299db9ec823/serde-1.0.0/src\\timeout.rs"}"#,
+            r#"{"spawned_at":"/cargo/registry/src/github.com-1ecc6299db9ec823/serde-1.0.0/src\\timeout.rs"}"#,
+            r#"{"spawned_at":"cargo/registry/src/github.com-1ecc6299db9ec823/serde-1.0.0/src\\timeout.rs"}"#,
+            r#"{"spawned_at":"/cargo/econnreset\\n/home/registry/src/github.com-1ecc6299db9ec823/serde-1.0.0/src/lib.rs"}"#,
+        ] {
+            let discounted = discount_cargo_registry_source_paths(rendered);
+            assert!(
+                !discounted.contains("timeout") && !discounted.contains("econnreset"),
+                "source-path provenance must not retain fault hints: {rendered}"
+            );
+            assert_eq!(
+                classify_failure_reason(rendered),
+                FailureCategory::Deterministic,
+                "a mixed-separator source path is provenance, not escaped fault text: {rendered}"
+            );
+        }
+    }
+
+    #[test]
+    fn classify_reason_invalid_registry_hash_is_not_discounted() {
+        let hashes = [
+            "2",
+            "abcdef0z",
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        ];
+
+        for hash in hashes {
+            let rendered = format!(
+                r#"{{"spawned_at":"/srv/app/registry/src/index.crates.io-{hash}/src/main.rs"}}"#
+            );
+            assert_eq!(
+                discount_cargo_registry_source_paths(&rendered),
+                rendered,
+                "an invalid registry hash must leave spawned_at untouched"
+            );
+            assert_eq!(
+                classify_failure_reason(&rendered),
+                FailureCategory::TransientInfra,
+                "a short, non-hex, or overlong suffix is not a Cargo registry source hash: {hash}"
+            );
+        }
+    }
+
+    #[test]
+    fn classify_reason_relative_registry_source_path_is_not_a_network_fault() {
+        assert_eq!(
+            classify_failure_reason(
+                r#"internal error: {"spawned_at":"registry/src/index.crates.io-1949cf8c6b5b557f/serde-1.0.0/src/lib.rs:1:1"}"#
+            ),
+            FailureCategory::Deterministic,
+            "a relative cargo registry source path in spawned_at is still provenance"
+        );
+    }
+
+    #[test]
+    fn discount_relative_registry_source_path_preserves_spawned_at_quotes() {
+        let rendered = r#"error: {"spawned_at":"registry/src/index.crates.io-1949cf8c6b5b557f/foo/src/lib.rs:1:1"}"#;
+
+        assert_eq!(
+            discount_cargo_registry_source_paths(rendered),
+            r#"error: {"spawned_at":" "}"#,
+            "discounting a relative path must preserve the structured field and its quotes"
+        );
+        assert_eq!(
+            classify_failure_reason(rendered),
+            FailureCategory::Deterministic
+        );
+    }
+
+    #[test]
+    fn classify_reason_non_default_registry_source_path_is_not_a_network_fault() {
+        for registry in ["github.com", "abcdef0", "abcdef0.index.crates.io"] {
+            let rendered = format!(
+                r#"internal error: {{"spawned_at":"/home/u/.cargo/registry/src/{registry}-1ecc6299db9ec823/hyper-timeout-0.5.2/src/lib.rs:1:1"}}"#
+            );
+
+            assert_eq!(
+                classify_failure_reason(&rendered),
+                FailureCategory::Deterministic,
+                "a crate name inside non-default registry {registry:?} is still provenance"
+            );
+        }
+    }
+
+    #[test]
+    fn classify_reason_hint_bearing_registry_source_path_parents_are_not_faults() {
+        for rendered in [
+            r#"{"spawned_at":"/tmp/build-500/econnreset/.cargo/registry/src/github.com-1ecc6299db9ec823/serde-1.0.0/src/lib.rs:1:1"}"#,
+            r#"{"spawned_at":"tmp/build-500/econnreset/.cargo/registry/src/github.com-1ecc6299db9ec823/serde-1.0.0/src/lib.rs:1:1"}"#,
+            r#"{"spawned_at":"/tmp/build 500/econnreset/.cargo/registry/src/github.com-1ecc6299db9ec823/serde-1.0.0/src/lib.rs:1:1"}"#,
+            r#"internal error: {"spawned_at":"C:\\build-500\\econnreset\\.cargo\\registry\\src\\github.com-1ecc6299db9ec823\\serde-1.0.0\\src\\lib.rs:1:1"}"#,
+        ] {
+            assert_eq!(
+                classify_failure_reason(rendered),
+                FailureCategory::Deterministic,
+                "parent components of a cargo registry source path are also provenance: {rendered}"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

An ACP provider spend-limit error is currently classified as
`transient_infra`. The classifier examines the rendered message and full cause
chain, and the embedded `spawned_at` Cargo registry source path contains
`index.crates.io`, one of the transient-infrastructure hints. Provenance text
therefore wins over the actual permanent, human-actionable billing failure.

A second observed provider message exposes the companion failure after that
provenance is removed: `You've hit your limit · resets Jul 31, 5am (UTC)`
matches none of the existing budget hints and would fall through to
`Deterministic`. A resetting usage quota is a resource limit, not a code fault,
and `Deterministic` would incorrectly feed it to failure-signature tracking.
This PR covers these two observed phrasings without claiming to recognize every
provider-limit message.

This does not change per-stage retry policy: `Handler`, `Engine`, and `Io`
errors remain retryable regardless of `FailureCategory`. It does correct the
operator-facing category and failure-class edge conditions, and it prevents
these failures from taking `loop_restart` edges, which require
`transient_infra`. Signature tracking also remains disabled: neither the
observed pre-fix `TransientInfra` nor the corrected `BudgetExhausted` category
is tracked.

## Observed payloads

The monthly spend-cap payload is permanent within its billing period and asks
for human action:

```text
message:    "ACP turn failed"
causes[0]:  "ACP protocol error"
causes[1]:  "Internal error: You've hit your org's monthly spend limit · ask your
             admin to raise it at claude.ai/settings/usage: {
               \"spawned_at\": \"/home/ubuntu/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/agent-client-protocol-0.11.1/src/session.rs:567:14\",
               \"data\": { \"errorKind\": \"rate_limit\" }
             }"
category:   "transient_infra"
```

In this payload, the registry source path is the sole transient hint match:
`errorKind` uses `rate_limit` with an underscore, while the classifier looks
for `rate limit`.

The second provider message reports a resetting usage window:

```text
Internal error: You've hit your limit · resets Jul 31, 5am (UTC)
```

Provenance sanitization prevents a Cargo source path from deciding its class,
but sanitization alone would leave this phrase on the `Deterministic` fallback.

## Fix

Before matching classifier hints, blank a `spawned_at` value when it contains a
local Cargo `registry/src/<registry>-<hash>/…` source path. `spawned_at` is
provenance: it identifies where the provider-side process raised the error,
not what failed. Restricting the sanitizer to that structured field avoids
interpreting arbitrary prose or consuming fault text outside that field value.

The matcher handles absolute, relative, non-default-registry, Windows, and
mixed-separator paths. It accepts both 7–64-character hexadecimal registry
hashes and, as a compatibility guard for callers that may have already applied
the classifier's hex normalization, the resulting `<hex>` placeholder. It
decodes the JSON key and value before matching, so escaped key spellings,
Unicode-escaped local paths, and partially escaped hashes behave like their
plain equivalents. The current classifier runs the sanitizer before case
normalization and global hex masking. JSON escapes are case-sensitive, so
validating the original spelling prevents malformed `\U`, `\N`, and similar
escapes from becoming valid after lowercasing; running before hex masking
ensures hex-like registry identifiers and URI schemes retain their meaning.

URL detection uses that same decoded value. Raw, escaped-solidus,
Unicode-escaped, protocol-relative, `file:`, and other multi-character URI
schemes remain untouched; one-character drive prefixes remain local Windows
paths. Invalid registry hashes, registry paths in unrelated fields, and
ordinary registry fetch/download errors also remain untouched.
Malformed JSON key/value strings are outside the structured boundary and are
preserved verbatim, including case-changing invalid escapes, so fault text in
them remains available to the classifier.

A separate permanent-provider-limit hint maps `spend limit` to
`BudgetExhausted` before transient hints are checked. The measured
`you've hit your limit` phrase joins the ordinary budget hints after transient
matching. That ordering is deliberate: the monthly cap overrides
transient-looking provider prose, while a genuine adjacent network fault still
wins over the resetting quota phrase.

Fabro's public failure documentation defines `budget_exhausted` as a resource
limit and lists quota exhaustion as an example, so the resetting usage window
uses an existing category rather than inventing a new one. The embedded
`errorKind: rate_limit` is intentionally not used as the discriminator:
ordinary throttling and the permanent monthly spend cap can carry the same
value, while Fabro's structured SDK `RateLimit` category is normally
`TransientInfra`.

Together, provenance sanitization and the two evidence-backed message hints
prevent these observed provider limits from landing on the signature-tracked
`Deterministic` fallback. This remains heuristic fallback classification for
rendered errors, not a claim that all provider-limit prose is recognized.

## Verification

- The representative payload classifies as `BudgetExhausted` through both the
  direct classifier and the
  `Error::handler_with_source` → `FailureDetail` path.
- The exact resetting-window message and a representative full ACP cause-chain
  form classify as `BudgetExhausted`.
- A genuine adjacent `connection reset` still wins over the ordinary
  resetting-window budget hint and remains `TransientInfra`.
- Structured Cargo source provenance without fault text falls back to
  `Deterministic`, including absolute, relative, hex-masked, non-default
  registry, Windows, and mixed-separator paths.
- A real network failure elsewhere in the same payload remains
  `TransientInfra`.
- Registry fetch/download failures, covered URL-valued `spawned_at` forms, and
  registry paths in unrelated fields remain `TransientInfra`, including
  escaped URLs and hex-like multi-character URI schemes.
- Short, non-hex, and overlong registry suffixes are not sanitized.
- Malformed `spawned_at` keys and values with invalid lowercase or
  case-changing uppercase escapes, or a literal newline, are preserved,
  including their real transient fault text.
- Existing transient and structural hint-count guards remain unchanged; the
  ordinary budget-hint guard increases from 10 to 11, and the new one-entry
  permanent list has its own guard.
- The diff contains 527 insertions and four replaced lines; no existing test or
  guard is removed, weakened, or ignored.
- `cargo test -p fabro-workflow --lib error::` — 175 passed
- `cargo test -p fabro-workflow --lib` — 1,146 passed
- `cargo nextest run -p fabro-workflow` — the unchanged
  `handler::parallel::tests::for_each_accepts_an_array_at_the_item_limit`
  exceeds the repository's 6-second nextest timeout; it passes under
  `cargo test`, including in the full library run above
- `cargo +nightly-2026-04-14 fmt --check --all` — passed
- `cargo +nightly-2026-04-14 clippy --workspace --all-targets -- -D warnings`
  — passed
