### PR TITLE
fix(daytona): accept newer permission scopes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1854,7 +1854,7 @@ checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 [[package]]
 name = "daytona-api-client"
 version = "0.1.0"
-source = "git+https://github.com/brynary/daytona-sdk-rust?rev=fc58e22f7f25183df6264276ee186bbc32635738#fc58e22f7f25183df6264276ee186bbc32635738"
+source = "git+https://github.com/brynary/daytona-sdk-rust?rev=73c9c458dd1a1d096afd3521175637af82afd8d8#73c9c458dd1a1d096afd3521175637af82afd8d8"
 dependencies = [
  "reqwest 0.13.2",
  "reqwest-middleware",
@@ -1868,7 +1868,7 @@ dependencies = [
 [[package]]
 name = "daytona-sdk"
 version = "0.1.0"
-source = "git+https://github.com/brynary/daytona-sdk-rust?rev=fc58e22f7f25183df6264276ee186bbc32635738#fc58e22f7f25183df6264276ee186bbc32635738"
+source = "git+https://github.com/brynary/daytona-sdk-rust?rev=73c9c458dd1a1d096afd3521175637af82afd8d8#73c9c458dd1a1d096afd3521175637af82afd8d8"
 dependencies = [
  "daytona-api-client",
  "daytona-toolbox-client",
@@ -1888,7 +1888,7 @@ dependencies = [
 [[package]]
 name = "daytona-toolbox-client"
 version = "0.1.0"
-source = "git+https://github.com/brynary/daytona-sdk-rust?rev=fc58e22f7f25183df6264276ee186bbc32635738#fc58e22f7f25183df6264276ee186bbc32635738"
+source = "git+https://github.com/brynary/daytona-sdk-rust?rev=73c9c458dd1a1d096afd3521175637af82afd8d8#73c9c458dd1a1d096afd3521175637af82afd8d8"
 dependencies = [
  "reqwest 0.13.2",
  "reqwest-middleware",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,8 +96,8 @@ twin-openai = { path = "test/twin/openai" }
 twin-github = { path = "test/twin/github" }
 tokio-tungstenite = { version = "0.26", features = ["rustls-tls-webpki-roots"] }
 futures-util = "0.3"
-daytona-sdk = { git = "https://github.com/brynary/daytona-sdk-rust", rev = "fc58e22f7f25183df6264276ee186bbc32635738", package = "daytona-sdk" }
-daytona-api-client = { git = "https://github.com/brynary/daytona-sdk-rust", rev = "fc58e22f7f25183df6264276ee186bbc32635738", package = "daytona-api-client" }
+daytona-sdk = { git = "https://github.com/brynary/daytona-sdk-rust", rev = "73c9c458dd1a1d096afd3521175637af82afd8d8", package = "daytona-sdk" }
+daytona-api-client = { git = "https://github.com/brynary/daytona-sdk-rust", rev = "73c9c458dd1a1d096afd3521175637af82afd8d8", package = "daytona-api-client" }
 sentry = { version = "0.35", default-features = false, features = ["backtrace", "contexts", "ureq", "rustls"] }
 fork = "0.2"
 exec = "0.3"

--- a/lib/components/fabro-sandbox/src/daytona/mod.rs
+++ b/lib/components/fabro-sandbox/src/daytona/mod.rs
@@ -3305,7 +3305,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn check_daytona_api_key_with_accepts_full_scopes() {
+    async fn check_daytona_api_key_with_accepts_full_scopes_and_new_scopes() {
         let server = MockServer::start_async().await;
         let auth = mock_auth_probe(&server, 200).await;
         let current_key = mock_current_key(&server, vec![
@@ -3313,6 +3313,9 @@ mod tests {
             "delete:snapshots",
             "write:sandboxes",
             "delete:sandboxes",
+            "manage:secrets",
+            "read:limits",
+            "manage:sso",
         ])
         .await;
 


### PR DESCRIPTION
## Summary

- update the Daytona SDK pin to brynary/daytona-sdk-rust#4
- allow Daytona API responses to include permission scopes added after the generated client
- cover the current manage:secrets, read:limits, and manage:sso scopes in Fabro credential validation

Fabro still checks for all four required snapshot and sandbox scopes. Request-side permission parsing remains strict.

## Dependency

- https://github.com/brynary/daytona-sdk-rust/pull/4
- pinned SDK commit: 73c9c458dd1a1d096afd3521175637af82afd8d8

## Tests

- cargo +nightly-2026-04-14 fmt --check --all
- cargo test --locked -p fabro-sandbox --all-features check_daytona_api_key_with_accepts_full_scopes_and_new_scopes
- cargo +nightly-2026-04-14 clippy --locked --workspace --all-targets -- -D warnings
- cargo nextest run --locked --workspace --status-level slow --profile ci (7,676 passed; 203 skipped)

## Security review

No findings. Unknown response scopes cannot satisfy any required Fabro permission check.