### PR TITLE
Collapse the steering bar by default and expand it on bar click

### DIFF
--- a/apps/fabro-web/app/components/run-dock.test.tsx
+++ b/apps/fabro-web/app/components/run-dock.test.tsx
@@ -9,7 +9,7 @@ import {
 import TestRenderer, { act } from "react-test-renderer";
 
 import { setupReactTestEnv } from "../lib/test-utils";
-import { DockComposer } from "./run-dock";
+import { DockComposer, RunDockShell } from "./run-dock";
 
 const mountedRenderers: TestRenderer.ReactTestRenderer[] = [];
 let teardownReactEnv: (() => void) | undefined;
@@ -24,6 +24,60 @@ afterEach(() => {
   }
   teardownReactEnv?.();
   teardownReactEnv = undefined;
+});
+
+describe("RunDockShell", () => {
+  function mountShell(
+    collapsed: boolean,
+    onCollapsedChange: (collapsed: boolean) => void,
+  ) {
+    let renderer!: TestRenderer.ReactTestRenderer;
+    act(() => {
+      renderer = TestRenderer.create(
+        <RunDockShell
+          label="Steer running agent"
+          tone="idle"
+          status="Steering"
+          collapsed={collapsed}
+          onCollapsedChange={onCollapsedChange}
+          actions={<div />}
+        />,
+      );
+    });
+    mountedRenderers.push(renderer);
+    return renderer;
+  }
+
+  function clickableDivs(renderer: TestRenderer.ReactTestRenderer) {
+    return renderer.root.findAll(
+      (node) => node.type === "div" && node.props.onClick !== undefined,
+    );
+  }
+
+  test("the whole collapsed bar is a click target that expands it", () => {
+    const onCollapsedChange = mock((_collapsed: boolean) => undefined);
+    const renderer = mountShell(true, onCollapsedChange);
+
+    const [header] = clickableDivs(renderer);
+    expect(header).toBeDefined();
+    act(() => header.props.onClick({ target: { closest: () => null } }));
+    expect(onCollapsedChange).toHaveBeenCalledWith(false);
+  });
+
+  test("clicks on header buttons do not also expand the bar", () => {
+    const onCollapsedChange = mock((_collapsed: boolean) => undefined);
+    const renderer = mountShell(true, onCollapsedChange);
+
+    const [header] = clickableDivs(renderer);
+    act(() => header.props.onClick({ target: { closest: () => ({}) } }));
+    expect(onCollapsedChange).not.toHaveBeenCalled();
+  });
+
+  test("the expanded header is not a click target", () => {
+    const onCollapsedChange = mock((_collapsed: boolean) => undefined);
+    const renderer = mountShell(false, onCollapsedChange);
+    expect(clickableDivs(renderer)).toHaveLength(0);
+  });
 });
 
 describe("DockComposer", () => {

--- a/apps/fabro-web/app/components/run-dock.test.tsx
+++ b/apps/fabro-web/app/components/run-dock.test.tsx
@@ -73,6 +73,15 @@ describe("RunDockShell", () => {
     expect(onCollapsedChange).not.toHaveBeenCalled();
   });
 
+  test("clicks with a non-element target still expand the bar", () => {
+    const onCollapsedChange = mock((_collapsed: boolean) => undefined);
+    const renderer = mountShell(true, onCollapsedChange);
+
+    const [header] = clickableDivs(renderer);
+    act(() => header.props.onClick({ target: {} }));
+    expect(onCollapsedChange).toHaveBeenCalledWith(false);
+  });
+
   test("the expanded header is not a click target", () => {
     const onCollapsedChange = mock((_collapsed: boolean) => undefined);
     const renderer = mountShell(false, onCollapsedChange);

--- a/apps/fabro-web/app/components/run-dock.tsx
+++ b/apps/fabro-web/app/components/run-dock.tsx
@@ -99,7 +99,23 @@ export function RunDockShell({
         className,
       )}
     >
-      <div className="flex shrink-0 items-center gap-2.5 px-5 py-2 sm:px-6">
+      {/* While collapsed, the whole bar expands on click. Clicks that land on
+          a button (Interrupt, the chevron) keep their own behavior. The
+          chevron button stays the keyboard/assistive-tech toggle. */}
+      <div
+        className={classNames(
+          "flex shrink-0 items-center gap-2.5 px-5 py-2 sm:px-6",
+          collapsed && "cursor-pointer",
+        )}
+        onClick={
+          collapsed
+            ? (event) => {
+                if ((event.target as HTMLElement).closest("button")) return;
+                onCollapsedChange(false);
+              }
+            : undefined
+        }
+      >
         <StatusDot tone={tone} />
         {/* A live region: the dock changing to a state that needs the
             operator has to reach assistive tech, not only the eye. */}

--- a/apps/fabro-web/app/components/run-dock.tsx
+++ b/apps/fabro-web/app/components/run-dock.tsx
@@ -110,7 +110,9 @@ export function RunDockShell({
         onClick={
           collapsed
             ? (event) => {
-                if ((event.target as HTMLElement).closest("button")) return;
+                if ((event.target as HTMLElement | null)?.closest?.("button")) {
+                  return;
+                }
                 onCollapsedChange(false);
               }
             : undefined

--- a/apps/fabro-web/app/components/steer-bar.test.tsx
+++ b/apps/fabro-web/app/components/steer-bar.test.tsx
@@ -98,11 +98,7 @@ describe("SteerBar", () => {
     });
     mountedRenderers.push(renderer);
 
-    act(() => {
-      renderer.root
-        .findByProps({ "aria-label": "Collapse Steer running agent" })
-        .props.onClick();
-    });
+    // The dock starts collapsed by default.
     expect(
       renderer.root.findByProps({
         "aria-label": "Expand Steer running agent",

--- a/apps/fabro-web/app/components/steer-bar.tsx
+++ b/apps/fabro-web/app/components/steer-bar.tsx
@@ -57,7 +57,9 @@ export function SteerBar({
   ref,
 }: SteerBarProps) {
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
-  const [collapsePreferred, setCollapsePreferred] = useState(false);
+  // Steering is an occasional control, so the dock starts collapsed and
+  // stays out of the way until the operator opens it.
+  const [collapsePreferred, setCollapsePreferred] = useState(true);
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
   const steer = useSteerRun(runId);
   const interrupt = useInterruptRun(runId);


### PR DESCRIPTION
## Summary
- The steering dock on run detail pages now starts collapsed. A run that is interrupted and waiting for steering still forces the dock open, so a blocked run cannot hide behind the collapsed bar.
- While collapsed, the whole dock header is a click target that expands it. Clicks on buttons inside the bar (Interrupt, the chevron) keep their own behavior, and the chevron button remains the keyboard/screen-reader toggle.
- The interview question dock shares `RunDockShell`, so it gets the same click-to-open behavior for consistency.

## Test plan
- [x] `bun test run-dock steer-bar` — updated the steer-bar focus test for the new default; added `RunDockShell` tests for the collapsed click target, the button-click exclusion, and the expanded header not being clickable
- [x] `bun run typecheck`
- [x] Full `bun test` suite: same 13 pre-existing failures as clean main (build-version, import-chunk, run-files); no new failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)