### PR TITLE
Download latest artifacts as a ZIP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -338,6 +338,7 @@ checksum = "e79b3f8a79cccc2898f31920fc69f304859b3bd567490f75ebf51ae1c792a9ac"
 dependencies = [
  "compression-codecs",
  "compression-core",
+ "futures-io",
  "pin-project-lite",
  "tokio",
 ]
@@ -408,6 +409,7 @@ version = "0.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d8c50d65ce1b0e0cb65a785ff615f78860d7754290647d3b983208daa4f85e6"
 dependencies = [
+ "async-compression",
  "crc32fast",
  "futures-lite",
  "pin-project",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -403,6 +403,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "async_zip"
+version = "0.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d8c50d65ce1b0e0cb65a785ff615f78860d7754290647d3b983208daa4f85e6"
+dependencies = [
+ "crc32fast",
+ "futures-lite",
+ "pin-project",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
 name = "atoi"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2992,6 +3006,7 @@ version = "0.311.0-nightly.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "async_zip",
  "axum",
  "axum-extra",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ dotenvy = "0.15"
 futures = "0.3"
 tokio-stream = "0.1"
 async-trait = "0.1"
-async_zip = { version = "0.0.18", features = ["tokio"] }
+async_zip = { version = "0.0.18", features = ["tokio", "deflate"] }
 fs2 = "0.4"
 base64 = "0.22"
 bytes = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ dotenvy = "0.15"
 futures = "0.3"
 tokio-stream = "0.1"
 async-trait = "0.1"
+async_zip = { version = "0.0.18", features = ["tokio"] }
 fs2 = "0.4"
 base64 = "0.22"
 bytes = "1"

--- a/apps/fabro-web/app/lib/api-client.test.ts
+++ b/apps/fabro-web/app/lib/api-client.test.ts
@@ -6,6 +6,7 @@ import {
   extractRequestId,
   fetchAllPages,
   generatedAxios,
+  runArtifactsDownloadUrl,
   stageArtifactDownloadUrl,
 } from "./api-client";
 
@@ -142,6 +143,14 @@ describe("stageArtifactDownloadUrl", () => {
       stageArtifactDownloadUrl("run 1", "stage@1", "logs/output.txt", 2),
     ).toBe(
       "/api/v1/runs/run%201/stages/stage%401/artifacts/download?filename=logs%2Foutput.txt&retry=2",
+    );
+  });
+});
+
+describe("runArtifactsDownloadUrl", () => {
+  test("builds the escaped ZIP download href", () => {
+    expect(runArtifactsDownloadUrl("run 1")).toBe(
+      "/api/v1/runs/run%201/artifacts/download",
     );
   });
 });

--- a/apps/fabro-web/app/lib/api-client.ts
+++ b/apps/fabro-web/app/lib/api-client.ts
@@ -422,3 +422,9 @@ export function stageArtifactDownloadUrl(
     encodeURIComponent(id)
   }/stages/${encodeURIComponent(stageId)}/artifacts/download?${searchParams}`;
 }
+
+export function runArtifactsDownloadUrl(id: string): string {
+  return `${generatedApiConfiguration.basePath ?? ""}/api/v1/runs/${
+    encodeURIComponent(id)
+  }/artifacts/download`;
+}

--- a/apps/fabro-web/app/lib/api-client.ts
+++ b/apps/fabro-web/app/lib/api-client.ts
@@ -408,6 +408,13 @@ export function requestSignalOptions(request?: Request): RawAxiosRequestConfig {
   return request?.signal ? { signal: request.signal } : {};
 }
 
+/** Absolute href for a path under a run, for links the browser follows itself. */
+function runApiPath(id: string, suffix: string): string {
+  return `${generatedApiConfiguration.basePath ?? ""}/api/v1/runs/${
+    encodeURIComponent(id)
+  }${suffix}`;
+}
+
 export function stageArtifactDownloadUrl(
   id: string,
   stageId: string,
@@ -418,13 +425,12 @@ export function stageArtifactDownloadUrl(
     filename,
     retry: String(retry),
   });
-  return `${generatedApiConfiguration.basePath ?? ""}/api/v1/runs/${
-    encodeURIComponent(id)
-  }/stages/${encodeURIComponent(stageId)}/artifacts/download?${searchParams}`;
+  return runApiPath(
+    id,
+    `/stages/${encodeURIComponent(stageId)}/artifacts/download?${searchParams}`,
+  );
 }
 
 export function runArtifactsDownloadUrl(id: string): string {
-  return `${generatedApiConfiguration.basePath ?? ""}/api/v1/runs/${
-    encodeURIComponent(id)
-  }/artifacts/download`;
+  return runApiPath(id, "/artifacts/download");
 }

--- a/apps/fabro-web/app/routes/run-artifacts.tsx
+++ b/apps/fabro-web/app/routes/run-artifacts.tsx
@@ -138,8 +138,7 @@ function ArtifactList({ runId, files }: { runId: string; files: readonly Artifac
           </span>
           <a
             href={runArtifactsDownloadUrl(runId)}
-            download={`fabro-artifacts-${runId}.zip`}
-            aria-label={`Download the latest version of all ${files.length} ${plural(files.length, "artifact", "artifacts")} as a ZIP file`}
+            aria-label={`Download all ${files.length} ${plural(files.length, "artifact", "artifacts")} as a ZIP file`}
             className="inline-flex min-h-11 shrink-0 items-center gap-1.5 rounded-md bg-overlay px-2.5 py-1 text-xs font-medium text-fg-2 outline-1 -outline-offset-1 outline-line-strong hover:bg-overlay-strong hover:text-fg focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-teal-500 sm:min-h-8"
           >
             <ArrowDownTrayIcon className="size-3.5 shrink-0" aria-hidden="true" />

--- a/apps/fabro-web/app/routes/run-artifacts.tsx
+++ b/apps/fabro-web/app/routes/run-artifacts.tsx
@@ -6,7 +6,10 @@ import type { RunArtifactEntry } from "@qltysh/fabro-api-client";
 
 import { EmptyState, ErrorState, LoadingState } from "../components/state";
 import { StageSidebar } from "../components/stage-sidebar";
-import { stageArtifactDownloadUrl } from "../lib/api-client";
+import {
+  runArtifactsDownloadUrl,
+  stageArtifactDownloadUrl,
+} from "../lib/api-client";
 import { formatBytes } from "../lib/format";
 import { plural } from "../lib/plural";
 import { useRunArtifacts, useRunStages } from "../lib/queries";
@@ -117,7 +120,7 @@ function ArtifactList({ runId, files }: { runId: string; files: readonly Artifac
 
   return (
     <div className="space-y-4">
-      <div className="flex flex-wrap items-baseline justify-between gap-4">
+      <div className="flex flex-wrap items-center justify-between gap-3">
         <h2 className="text-sm font-medium text-fg">
           {files.length} {plural(files.length, "file", "files")}
           {versioned && (
@@ -127,11 +130,22 @@ function ArtifactList({ runId, files }: { runId: string; files: readonly Artifac
             </span>
           )}
         </h2>
-        <span className="text-xs text-fg-muted tabular-nums">
-          {versioned
-            ? `${formatBytes(latestBytes)} latest · ${formatBytes(storedBytes)} stored`
-            : `${formatBytes(latestBytes)} total`}
-        </span>
+        <div className="ml-auto flex max-w-full flex-wrap items-center justify-end gap-3">
+          <span className="text-xs text-fg-muted tabular-nums">
+            {versioned
+              ? `${formatBytes(latestBytes)} latest · ${formatBytes(storedBytes)} stored`
+              : `${formatBytes(latestBytes)} total`}
+          </span>
+          <a
+            href={runArtifactsDownloadUrl(runId)}
+            download={`fabro-artifacts-${runId}.zip`}
+            aria-label={`Download the latest version of all ${files.length} ${plural(files.length, "artifact", "artifacts")} as a ZIP file`}
+            className="inline-flex min-h-11 shrink-0 items-center gap-1.5 rounded-md bg-overlay px-2.5 py-1 text-xs font-medium text-fg-2 outline-1 -outline-offset-1 outline-line-strong hover:bg-overlay-strong hover:text-fg focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-teal-500 sm:min-h-8"
+          >
+            <ArrowDownTrayIcon className="size-3.5 shrink-0" aria-hidden="true" />
+            Download all
+          </a>
+        </div>
       </div>
 
       <section className="overflow-hidden rounded-md border border-line bg-panel-alt">

--- a/docs/public/api-reference/fabro-api.yaml
+++ b/docs/public/api-reference/fabro-api.yaml
@@ -3289,8 +3289,8 @@ paths:
       summary: Download Run Artifacts
       description: |
         Streams a ZIP archive with the latest captured version of each artifact path.
-        Stage order and retry number determine the latest version, matching the artifacts page.
-        Captures from the `start` and `exit` control nodes are excluded.
+        Stage order, retry number, and then stage ID determine the latest version, matching the artifacts page.
+        Captures from the graph's boundary nodes are excluded, identified by their `start` and `exit` handler type rather than by node name.
 
         The archive streams, so the response status is sent before the first artifact is read.
         A failure after that point aborts the transfer rather than returning `500`.

--- a/docs/public/api-reference/fabro-api.yaml
+++ b/docs/public/api-reference/fabro-api.yaml
@@ -3289,8 +3289,12 @@ paths:
       summary: Download Run Artifacts
       description: |
         Streams a ZIP archive with the latest captured version of each artifact path.
-        Stage order, retry number, and stage ID determine the latest version, matching the artifacts page.
+        Stage order and retry number determine the latest version, matching the artifacts page.
         Captures from the `start` and `exit` control nodes are excluded.
+
+        The archive streams, so the response status is sent before the first artifact is read.
+        A failure after that point aborts the transfer rather than returning `500`.
+        The ZIP central directory is written last, so a truncated download does not open as a valid archive.
       parameters:
         - $ref: "#/components/parameters/RunId"
       responses:

--- a/docs/public/api-reference/fabro-api.yaml
+++ b/docs/public/api-reference/fabro-api.yaml
@@ -3282,6 +3282,49 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
 
+  /api/v1/runs/{id}/artifacts/download:
+    get:
+      operationId: downloadRunArtifacts
+      tags: [Run Internals]
+      summary: Download Run Artifacts
+      description: |
+        Streams a ZIP archive with the latest captured version of each artifact path.
+        Stage order, retry number, and stage ID determine the latest version, matching the artifacts page.
+        Captures from the `start` and `exit` control nodes are excluded.
+      parameters:
+        - $ref: "#/components/parameters/RunId"
+      responses:
+        "200":
+          description: ZIP archive containing the latest artifact files
+          headers:
+            Content-Disposition:
+              description: Attachment filename for the ZIP archive
+              schema:
+                type: string
+          content:
+            application/zip:
+              schema:
+                type: string
+                format: binary
+        "404":
+          description: Run not found
+          headers:
+            x-request-id:
+              $ref: "#/components/headers/XRequestId"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Artifact archive could not be prepared
+          headers:
+            x-request-id:
+              $ref: "#/components/headers/XRequestId"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
   /api/v1/runs/{id}/files:
     get:
       operationId: listRunFiles

--- a/lib/apps/fabro-server/Cargo.toml
+++ b/lib/apps/fabro-server/Cargo.toml
@@ -75,6 +75,7 @@ serde_json.workspace = true
 serde_yaml = "0.9"
 anyhow.workspace = true
 async-trait.workspace = true
+async_zip.workspace = true
 clap.workspace = true
 toml.workspace = true
 toml_edit.workspace = true

--- a/lib/apps/fabro-server/src/server.rs
+++ b/lib/apps/fabro-server/src/server.rs
@@ -137,6 +137,7 @@ use tokio_stream::StreamExt;
 use tokio_stream::wrappers::{BroadcastStream, UnboundedReceiverStream};
 use tokio_util::sync::CancellationToken;
 use tower::{ServiceExt, service_fn};
+use tower_http::compression::predicate::{DefaultPredicate, NotForContentType, Predicate};
 use tower_http::compression::{CompressionLayer, CompressionLevel};
 use tracing::{Instrument, debug, error, info, warn};
 use ulid::Ulid;
@@ -1922,12 +1923,14 @@ pub fn build_router_with_options(
 /// Response-compression layer shared by the main and install-mode routers.
 ///
 /// The default predicate skips streaming SSE (`text/event-stream`), gRPC,
-/// images, and tiny bodies. The quality is pinned because tower-http's
-/// default defers to each codec's own default, and brotli's is quality 11 —
-/// seconds of CPU on a multi-megabyte asset. Level 4 keeps both codecs fast
-/// at a near-optimal ratio.
-pub(crate) fn compression_layer() -> CompressionLayer {
-    CompressionLayer::new().quality(CompressionLevel::Precise(4))
+/// images, ZIP archives, and tiny bodies. The quality is pinned because
+/// tower-http's default defers to each codec's own default, and brotli's is
+/// quality 11 — seconds of CPU on a multi-megabyte asset. Level 4 keeps both
+/// codecs fast at a near-optimal ratio.
+pub(crate) fn compression_layer() -> CompressionLayer<impl Predicate> {
+    CompressionLayer::new()
+        .quality(CompressionLevel::Precise(4))
+        .compress_when(DefaultPredicate::new().and(NotForContentType::const_new("application/zip")))
 }
 
 async fn http_log_middleware(mut req: axum_extract::Request, next: Next) -> Response {

--- a/lib/apps/fabro-server/src/server/handler/artifacts.rs
+++ b/lib/apps/fabro-server/src/server/handler/artifacts.rs
@@ -5,7 +5,9 @@ use async_zip::base::write::ZipFileWriter;
 use async_zip::error::ZipError;
 use async_zip::{Compression, ZipEntryBuilder};
 use axum::http::HeaderValue;
-use fabro_store::{ArtifactStore, Error as StoreError, RunProjection};
+use fabro_store::{ArtifactStore, Error as StoreError};
+use fabro_types::RunProjection;
+use fabro_util::error::collect_chain;
 use futures_util::SinkExt as _;
 use futures_util::io::AsyncWriteExt as _;
 use tokio::io::AsyncWrite;
@@ -171,61 +173,60 @@ enum ArtifactArchiveError {
     Io(#[from] io::Error),
     #[error("artifact read failed: {0}")]
     Store(#[from] StoreError),
-    #[error("artifact disappeared while the archive was being created")]
-    MissingArtifact,
+    #[error("artifact {0} disappeared while the archive was being created")]
+    MissingArtifact(String),
     #[error("ZIP write failed: {0}")]
     Zip(#[from] ZipError),
 }
 
-fn validate_artifact_archive_path(path: &str) -> Result<(), StoreError> {
-    ArtifactStore::validate_relative_path(path)?;
-    let bytes = path.as_bytes();
-    let has_windows_drive_prefix =
-        bytes.first().is_some_and(u8::is_ascii_alphabetic) && bytes.get(1) == Some(&b':');
-    if path.contains('\0') || has_windows_drive_prefix {
-        return Err(StoreError::Other(
-            "artifact path is not safe for a ZIP archive".to_string(),
-        ));
-    }
-    Ok(())
-}
-
+/// One entry per artifact path, holding the newest capture of that path.
+///
+/// Newest means latest stage, then latest retry. Stages the projection does not
+/// know about sort oldest (`None` < `Some`), which is what the artifacts page
+/// does too. Boundary stages are dropped: they run no work, so anything they
+/// captured was already in the workspace.
+///
+/// Paths are re-checked here rather than trusted: a path stored before a
+/// validation rule existed would otherwise be written straight into a ZIP that
+/// somebody extracts. An unsafe path is skipped, not fatal — one bad path must
+/// not cost the caller every other artifact.
 fn latest_run_artifacts(
     entries: Vec<NodeArtifact>,
     projection: &RunProjection,
-) -> Result<Vec<NodeArtifact>, StoreError> {
+) -> Vec<NodeArtifact> {
     let stage_order = projection
         .iter_stages()
         .enumerate()
         .map(|(order, (stage_id, _))| (stage_id.clone(), order))
         .collect::<HashMap<_, _>>();
-    let mut latest_by_path: HashMap<String, (Option<usize>, NodeArtifact)> = HashMap::new();
+    let capture_rank =
+        |artifact: &NodeArtifact| (stage_order.get(&artifact.node).copied(), artifact.retry);
+    let mut latest_by_path: HashMap<String, NodeArtifact> = HashMap::new();
 
     for artifact in entries {
-        if matches!(artifact.node.node_id(), "start" | "exit") {
+        if projection.is_boundary_stage(artifact.node.node_id()) {
             continue;
         }
-        validate_artifact_archive_path(&artifact.filename)?;
+        if let Err(error) = ArtifactStore::validate_relative_path(&artifact.filename) {
+            warn!(
+                path = %artifact.filename,
+                %error,
+                "skipping artifact with an unsafe path"
+            );
+            continue;
+        }
 
-        let order = stage_order.get(&artifact.node).copied();
-        let replace =
-            latest_by_path
-                .get(&artifact.filename)
-                .is_none_or(|(existing_order, existing)| {
-                    (order, artifact.retry, &artifact.node)
-                        > (*existing_order, existing.retry, &existing.node)
-                });
-        if replace {
-            latest_by_path.insert(artifact.filename.clone(), (order, artifact));
+        match latest_by_path.get(&artifact.filename) {
+            Some(existing) if capture_rank(existing) >= capture_rank(&artifact) => {}
+            _ => {
+                latest_by_path.insert(artifact.filename.clone(), artifact);
+            }
         }
     }
 
-    let mut latest = latest_by_path
-        .into_values()
-        .map(|(_, artifact)| artifact)
-        .collect::<Vec<_>>();
+    let mut latest = latest_by_path.into_values().collect::<Vec<_>>();
     latest.sort_by(|left, right| left.filename.cmp(&right.filename));
-    Ok(latest)
+    latest
 }
 
 async fn write_artifact_archive<W>(
@@ -241,9 +242,15 @@ where
     for artifact in artifacts {
         let key = ArtifactKey::new(artifact.node, artifact.retry, artifact.filename.clone());
         let Some(mut source) = artifact_store.get_stream(&run_id, &key).await? else {
-            return Err(ArtifactArchiveError::MissingArtifact);
+            return Err(ArtifactArchiveError::MissingArtifact(artifact.filename));
         };
-        let entry = ZipEntryBuilder::new(artifact.filename.into(), Compression::Stored);
+        // Deflate, not Stored: artifacts are mostly logs and reports, and the
+        // response is excluded from transfer compression precisely because the
+        // archive already carries its own.
+        let entry = ZipEntryBuilder::new(artifact.filename.into(), Compression::Deflate);
+        // `destination` is a futures-io writer from async_zip, while `writer` at
+        // the end of this function is a tokio one, so both `AsyncWriteExt`
+        // traits are in scope and each call resolves to a different one.
         let mut destination = archive.write_entry_stream(entry).await?;
         while let Some(chunk) = source.next().await {
             destination.write_all(&chunk?).await?;
@@ -260,6 +267,12 @@ fn artifact_archive_body(
     run_id: RunId,
     artifacts: Vec<NodeArtifact>,
 ) -> Body {
+    // A channel of `Result`, rather than `tokio::io::duplex`, so a failure
+    // partway through can poison the body. Dropping a duplex writer ends the
+    // response with a clean EOF, which would hand the caller a truncated ZIP
+    // that looks like a complete download. Sending an `Err` aborts the chunked
+    // body instead, so the caller sees a transfer error. Do not "simplify" this
+    // to a duplex without replacing that signal.
     let (sender, receiver) =
         mpsc::channel::<Result<Bytes, io::Error>>(ARCHIVE_STREAM_CHANNEL_CAPACITY);
     let error_sender = sender.clone();
@@ -273,10 +286,17 @@ fn artifact_archive_body(
     tokio::spawn(async move {
         if let Err(error) = write_artifact_archive(writer, artifact_store, run_id, artifacts).await
         {
-            let body_error = io::Error::other("artifact archive stream failed");
-            if error_sender.send(Err(body_error)).await.is_ok() {
-                warn!(%run_id, %error, "artifact archive stream failed");
-            }
+            // Log before signalling: the send fails when the caller has already
+            // gone away, and that is exactly when this log is the only record
+            // that the archive failed. The 200 went out long ago.
+            warn!(
+                %run_id,
+                error = %collect_chain(&error).join(": "),
+                "artifact archive stream failed"
+            );
+            let _ = error_sender
+                .send(Err(io::Error::other("artifact archive stream failed")))
+                .await;
         }
     });
 
@@ -307,19 +327,9 @@ async fn download_run_artifacts(
             .into_response();
         }
     };
-    let artifacts = match latest_run_artifacts(entries, &cached.projection) {
-        Ok(artifacts) => artifacts,
-        Err(error) => {
-            warn!(run_id = %id, %error, "failed to select artifacts for ZIP download");
-            return ApiError::new(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "Artifact archive could not be prepared.",
-            )
-            .into_response();
-        }
-    };
+    let artifacts = latest_run_artifacts(entries, &cached.projection);
 
-    let filename = format!("attachment; filename=\"fabro-artifacts-{id}.zip\"");
+    let content_disposition = format!("attachment; filename=\"fabro-artifacts-{id}.zip\"");
     let body = artifact_archive_body(state.artifact_store.clone(), id, artifacts);
     let mut response = body.into_response();
     response.headers_mut().insert(
@@ -328,7 +338,8 @@ async fn download_run_artifacts(
     );
     response.headers_mut().insert(
         header::CONTENT_DISPOSITION,
-        HeaderValue::from_str(&filename).expect("run IDs produce valid attachment filenames"),
+        HeaderValue::from_str(&content_disposition)
+            .expect("run IDs produce valid attachment filenames"),
     );
     response.headers_mut().insert(
         header::CACHE_CONTROL,
@@ -835,28 +846,5 @@ async fn get_stage_artifact(
         Err(err) => {
             ApiError::new(StatusCode::INTERNAL_SERVER_ERROR, err.to_string()).into_response()
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::validate_artifact_archive_path;
-
-    #[test]
-    fn archive_paths_reject_cross_platform_absolute_forms() {
-        for path in [
-            "/escape.txt",
-            "../escape.txt",
-            r"..\escape.txt",
-            "C:/escape.txt",
-            "c:escape.txt",
-            "bad\0name",
-        ] {
-            assert!(
-                validate_artifact_archive_path(path).is_err(),
-                "accepted unsafe archive path: {path:?}"
-            );
-        }
-        assert!(validate_artifact_archive_path("nested/result.txt").is_ok());
     }
 }

--- a/lib/apps/fabro-server/src/server/handler/artifacts.rs
+++ b/lib/apps/fabro-server/src/server/handler/artifacts.rs
@@ -10,7 +10,7 @@ use fabro_types::RunProjection;
 use fabro_util::error::collect_chain;
 use futures_util::SinkExt as _;
 use futures_util::io::AsyncWriteExt as _;
-use tokio::io::AsyncWrite;
+use tokio::io::{AsyncWrite, BufWriter};
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
 use tokio_util::io::{CopyToBytes, SinkWriter};
@@ -167,14 +167,17 @@ async fn list_run_artifacts(
 
 const ARCHIVE_STREAM_CHANNEL_CAPACITY: usize = 8;
 
+/// Deflate flushes its output in 8 KiB blocks, and every write below becomes
+/// its own allocation, channel send, and HTTP body frame. Batching to 64 KiB
+/// cuts all three by eight without meaningfully delaying the stream.
+const ARCHIVE_WRITE_BUFFER_BYTES: usize = 64 * 1024;
+
 #[derive(Debug, thiserror::Error)]
 enum ArtifactArchiveError {
     #[error("archive output failed: {0}")]
     Io(#[from] io::Error),
     #[error("artifact read failed: {0}")]
     Store(#[from] StoreError),
-    #[error("artifact {0} disappeared while the archive was being created")]
-    MissingArtifact(String),
     #[error("ZIP write failed: {0}")]
     Zip(#[from] ZipError),
 }
@@ -242,7 +245,11 @@ where
     for artifact in artifacts {
         let key = ArtifactKey::new(artifact.node, artifact.retry, artifact.filename.clone());
         let Some(mut source) = artifact_store.get_stream(&run_id, &key).await? else {
-            return Err(ArtifactArchiveError::MissingArtifact(artifact.filename));
+            // Deleted between the listing and this read, which in practice means
+            // the run was pruned mid-download. Leave it out and keep going: an
+            // archive missing one file beats a truncated one missing the rest.
+            warn!(%run_id, path = %artifact.filename, "artifact vanished while archiving");
+            continue;
         };
         // Deflate, not Stored: artifacts are mostly logs and reports, and the
         // response is excluded from transfer compression precisely because the
@@ -281,7 +288,10 @@ fn artifact_archive_body(
         .with(|chunk: Bytes| {
             std::future::ready(Ok::<Result<Bytes, io::Error>, io::Error>(Ok(chunk)))
         });
-    let writer = SinkWriter::new(CopyToBytes::new(sink));
+    let writer = BufWriter::with_capacity(
+        ARCHIVE_WRITE_BUFFER_BYTES,
+        SinkWriter::new(CopyToBytes::new(sink)),
+    );
 
     tokio::spawn(async move {
         if let Err(error) = write_artifact_archive(writer, artifact_store, run_id, artifacts).await

--- a/lib/apps/fabro-server/src/server/handler/artifacts.rs
+++ b/lib/apps/fabro-server/src/server/handler/artifacts.rs
@@ -1,4 +1,19 @@
+use std::io;
 use std::sync::Arc;
+
+use async_zip::base::write::ZipFileWriter;
+use async_zip::error::ZipError;
+use async_zip::{Compression, ZipEntryBuilder};
+use axum::http::HeaderValue;
+use fabro_store::{ArtifactStore, Error as StoreError, RunProjection};
+use futures_util::SinkExt as _;
+use futures_util::io::AsyncWriteExt as _;
+use tokio::io::AsyncWrite;
+use tokio::sync::mpsc;
+use tokio_stream::wrappers::ReceiverStream;
+use tokio_util::io::{CopyToBytes, SinkWriter};
+use tokio_util::sync::PollSender;
+use tracing::warn;
 
 use super::super::{
     ApiError, AppState, ArtifactEntry, ArtifactKey, ArtifactListResponse, AsyncWriteExt, Body,
@@ -17,6 +32,7 @@ pub(super) fn routes() -> Router<Arc<AppState>> {
         .route("/runs/{id}/blobs", post(write_run_blob))
         .route("/runs/{id}/blobs/{blobId}", get(read_run_blob))
         .route("/runs/{id}/artifacts", get(list_run_artifacts))
+        .route("/runs/{id}/artifacts/download", get(download_run_artifacts))
         .route(
             "/runs/{id}/stages/{stageId}/artifacts",
             get(list_stage_artifacts)
@@ -145,6 +161,180 @@ async fn list_run_artifacts(
             ApiError::new(StatusCode::INTERNAL_SERVER_ERROR, err.to_string()).into_response()
         }
     }
+}
+
+const ARCHIVE_STREAM_CHANNEL_CAPACITY: usize = 8;
+
+#[derive(Debug, thiserror::Error)]
+enum ArtifactArchiveError {
+    #[error("archive output failed: {0}")]
+    Io(#[from] io::Error),
+    #[error("artifact read failed: {0}")]
+    Store(#[from] StoreError),
+    #[error("artifact disappeared while the archive was being created")]
+    MissingArtifact,
+    #[error("ZIP write failed: {0}")]
+    Zip(#[from] ZipError),
+}
+
+fn validate_artifact_archive_path(path: &str) -> Result<(), StoreError> {
+    ArtifactStore::validate_relative_path(path)?;
+    let bytes = path.as_bytes();
+    let has_windows_drive_prefix =
+        bytes.first().is_some_and(u8::is_ascii_alphabetic) && bytes.get(1) == Some(&b':');
+    if path.contains('\0') || has_windows_drive_prefix {
+        return Err(StoreError::Other(
+            "artifact path is not safe for a ZIP archive".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn latest_run_artifacts(
+    entries: Vec<NodeArtifact>,
+    projection: &RunProjection,
+) -> Result<Vec<NodeArtifact>, StoreError> {
+    let stage_order = projection
+        .iter_stages()
+        .enumerate()
+        .map(|(order, (stage_id, _))| (stage_id.clone(), order))
+        .collect::<HashMap<_, _>>();
+    let mut latest_by_path: HashMap<String, (Option<usize>, NodeArtifact)> = HashMap::new();
+
+    for artifact in entries {
+        if matches!(artifact.node.node_id(), "start" | "exit") {
+            continue;
+        }
+        validate_artifact_archive_path(&artifact.filename)?;
+
+        let order = stage_order.get(&artifact.node).copied();
+        let replace =
+            latest_by_path
+                .get(&artifact.filename)
+                .is_none_or(|(existing_order, existing)| {
+                    (order, artifact.retry, &artifact.node)
+                        > (*existing_order, existing.retry, &existing.node)
+                });
+        if replace {
+            latest_by_path.insert(artifact.filename.clone(), (order, artifact));
+        }
+    }
+
+    let mut latest = latest_by_path
+        .into_values()
+        .map(|(_, artifact)| artifact)
+        .collect::<Vec<_>>();
+    latest.sort_by(|left, right| left.filename.cmp(&right.filename));
+    Ok(latest)
+}
+
+async fn write_artifact_archive<W>(
+    writer: W,
+    artifact_store: ArtifactStore,
+    run_id: RunId,
+    artifacts: Vec<NodeArtifact>,
+) -> Result<(), ArtifactArchiveError>
+where
+    W: AsyncWrite + Unpin,
+{
+    let mut archive = ZipFileWriter::with_tokio(writer);
+    for artifact in artifacts {
+        let key = ArtifactKey::new(artifact.node, artifact.retry, artifact.filename.clone());
+        let Some(mut source) = artifact_store.get_stream(&run_id, &key).await? else {
+            return Err(ArtifactArchiveError::MissingArtifact);
+        };
+        let entry = ZipEntryBuilder::new(artifact.filename.into(), Compression::Stored);
+        let mut destination = archive.write_entry_stream(entry).await?;
+        while let Some(chunk) = source.next().await {
+            destination.write_all(&chunk?).await?;
+        }
+        destination.close().await?;
+    }
+    let mut writer = archive.close().await?.into_inner();
+    writer.shutdown().await?;
+    Ok(())
+}
+
+fn artifact_archive_body(
+    artifact_store: ArtifactStore,
+    run_id: RunId,
+    artifacts: Vec<NodeArtifact>,
+) -> Body {
+    let (sender, receiver) =
+        mpsc::channel::<Result<Bytes, io::Error>>(ARCHIVE_STREAM_CHANNEL_CAPACITY);
+    let error_sender = sender.clone();
+    let sink = PollSender::new(sender)
+        .sink_map_err(|_| io::Error::from(io::ErrorKind::BrokenPipe))
+        .with(|chunk: Bytes| {
+            std::future::ready(Ok::<Result<Bytes, io::Error>, io::Error>(Ok(chunk)))
+        });
+    let writer = SinkWriter::new(CopyToBytes::new(sink));
+
+    tokio::spawn(async move {
+        if let Err(error) = write_artifact_archive(writer, artifact_store, run_id, artifacts).await
+        {
+            let body_error = io::Error::other("artifact archive stream failed");
+            if error_sender.send(Err(body_error)).await.is_ok() {
+                warn!(%run_id, %error, "artifact archive stream failed");
+            }
+        }
+    });
+
+    Body::from_stream(ReceiverStream::new(receiver))
+}
+
+async fn download_run_artifacts(
+    _auth: RequiredUser,
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<String>,
+) -> Response {
+    let id = match parse_run_id_path(&id) {
+        Ok(id) => id,
+        Err(response) => return response,
+    };
+    let cached = match state.cached_run(&id).await {
+        Ok(cached) => cached,
+        Err(error) => return error.into_response(),
+    };
+    let entries = match state.artifact_store.list_for_run(&id).await {
+        Ok(entries) => entries,
+        Err(error) => {
+            warn!(run_id = %id, %error, "failed to list artifacts for ZIP download");
+            return ApiError::new(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Artifact archive could not be prepared.",
+            )
+            .into_response();
+        }
+    };
+    let artifacts = match latest_run_artifacts(entries, &cached.projection) {
+        Ok(artifacts) => artifacts,
+        Err(error) => {
+            warn!(run_id = %id, %error, "failed to select artifacts for ZIP download");
+            return ApiError::new(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Artifact archive could not be prepared.",
+            )
+            .into_response();
+        }
+    };
+
+    let filename = format!("attachment; filename=\"fabro-artifacts-{id}.zip\"");
+    let body = artifact_archive_body(state.artifact_store.clone(), id, artifacts);
+    let mut response = body.into_response();
+    response.headers_mut().insert(
+        header::CONTENT_TYPE,
+        HeaderValue::from_static("application/zip"),
+    );
+    response.headers_mut().insert(
+        header::CONTENT_DISPOSITION,
+        HeaderValue::from_str(&filename).expect("run IDs produce valid attachment filenames"),
+    );
+    response.headers_mut().insert(
+        header::CACHE_CONTROL,
+        HeaderValue::from_static("private, no-store"),
+    );
+    response
 }
 
 fn run_artifact_entry_from(entry: NodeArtifact) -> RunArtifactEntry {
@@ -645,5 +835,28 @@ async fn get_stage_artifact(
         Err(err) => {
             ApiError::new(StatusCode::INTERNAL_SERVER_ERROR, err.to_string()).into_response()
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::validate_artifact_archive_path;
+
+    #[test]
+    fn archive_paths_reject_cross_platform_absolute_forms() {
+        for path in [
+            "/escape.txt",
+            "../escape.txt",
+            r"..\escape.txt",
+            "C:/escape.txt",
+            "c:escape.txt",
+            "bad\0name",
+        ] {
+            assert!(
+                validate_artifact_archive_path(path).is_err(),
+                "accepted unsafe archive path: {path:?}"
+            );
+        }
+        assert!(validate_artifact_archive_path("nested/result.txt").is_ok());
     }
 }

--- a/lib/apps/fabro-server/src/server/handler/artifacts.rs
+++ b/lib/apps/fabro-server/src/server/handler/artifacts.rs
@@ -184,9 +184,12 @@ enum ArtifactArchiveError {
 
 /// One entry per artifact path, holding the newest capture of that path.
 ///
-/// Newest means latest stage, then latest retry. Stages the projection does not
-/// know about sort oldest (`None` < `Some`), which is what the artifacts page
-/// does too. Boundary stages are dropped: they run no work, so anything they
+/// Newest means latest stage, then latest retry, then highest stage ID. That
+/// last tiebreaker only decides between two stages the projection does not know
+/// about, which both sort oldest (`None` < `Some`); it is here so the winner
+/// does not depend on the order the store happens to list objects in. All three
+/// keys mirror the artifacts page, which sorts on the same triple and takes the
+/// last entry. Boundary stages are dropped: they run no work, so anything they
 /// captured was already in the workspace.
 ///
 /// Paths are re-checked here rather than trusted: a path stored before a
@@ -202,8 +205,16 @@ fn latest_run_artifacts(
         .enumerate()
         .map(|(order, (stage_id, _))| (stage_id.clone(), order))
         .collect::<HashMap<_, _>>();
-    let capture_rank =
-        |artifact: &NodeArtifact| (stage_order.get(&artifact.node).copied(), artifact.retry);
+    // The stage ID compares as its serialized `node@visit` form, matching the
+    // string the artifacts page sorts on rather than `StageId`'s own ordering,
+    // which compares the visit numerically and would disagree.
+    let capture_rank = |artifact: &NodeArtifact| {
+        (
+            stage_order.get(&artifact.node).copied(),
+            artifact.retry,
+            artifact.node.to_string(),
+        )
+    };
     let mut latest_by_path: HashMap<String, NodeArtifact> = HashMap::new();
 
     for artifact in entries {

--- a/lib/apps/fabro-server/src/server/handler/billing.rs
+++ b/lib/apps/fabro-server/src/server/handler/billing.rs
@@ -170,7 +170,7 @@ fn live_billing_rows(projection: &RunProjection, now: DateTime<Utc>) -> Vec<Live
 
     for (stage_id, stage) in projection.iter_stages() {
         let node_id = stage_id.node_id();
-        if is_boundary_stage(projection, node_id) || !stage_has_billing_row(stage) {
+        if projection.is_boundary_stage(node_id) || !stage_has_billing_row(stage) {
             continue;
         }
 
@@ -204,13 +204,4 @@ fn stage_has_billing_row(stage: &StageProjection) -> bool {
         || stage.timing.is_some()
         || !stage.usage.is_zero()
         || stage.started_at.is_some()
-}
-
-fn is_boundary_stage(projection: &RunProjection, node_id: &str) -> bool {
-    projection
-        .spec()
-        .graph()
-        .nodes
-        .get(node_id)
-        .is_some_and(|node| matches!(node.handler_type(), Some("start" | "exit")))
 }

--- a/lib/apps/fabro-server/src/server/handler/mod.rs
+++ b/lib/apps/fabro-server/src/server/handler/mod.rs
@@ -116,6 +116,7 @@ pub(super) fn demo_routes() -> Router<Arc<AppState>> {
         .route("/runs/{id}/graph/source", get(demo::get_run_graph_source))
         .route("/runs/{id}/stages", get(demo::get_run_stages))
         .route("/runs/{id}/artifacts", get(demo::list_run_artifacts_stub))
+        .route("/runs/{id}/artifacts/download", get(not_implemented))
         .route("/runs/{id}/files", get(demo::list_run_files_stub))
         .route("/runs/{id}/commits", get(demo::list_run_commits_stub))
         .route(

--- a/lib/apps/fabro-server/src/server/tests.rs
+++ b/lib/apps/fabro-server/src/server/tests.rs
@@ -10692,7 +10692,6 @@ async fn run_artifacts_download_streams_latest_files_as_zip() {
         )
         .await
         .unwrap();
-    assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
         response
             .headers()
@@ -10717,15 +10716,7 @@ async fn run_artifacts_download_streams_latest_files_as_zip() {
     assert!(response.headers().get(header::CONTENT_ENCODING).is_none());
 
     let bytes = response_bytes!(response, StatusCode::OK).await;
-    let archive = ZipFileReader::new(bytes.clone())
-        .await
-        .unwrap_or_else(|error| {
-            panic!(
-                "ZIP parse failed for {} bytes (tail {:?}): {error}",
-                bytes.len(),
-                &bytes[bytes.len().saturating_sub(48)..]
-            )
-        });
+    let archive = ZipFileReader::new(bytes).await.unwrap();
     let names = archive
         .file()
         .entries()
@@ -10743,6 +10734,12 @@ async fn run_artifacts_download_streams_latest_files_as_zip() {
     }
     assert_eq!(contents_by_name["logs/run.txt"], b"build log");
     assert_eq!(contents_by_name["reports/result.txt"], b"latest verify");
+}
+
+#[tokio::test]
+async fn run_artifacts_download_returns_not_found_for_unknown_run() {
+    let state = test_app_state();
+    let app = crate::test_support::build_test_router(Arc::clone(&state));
 
     let response = app
         .oneshot(

--- a/lib/apps/fabro-server/src/server/tests.rs
+++ b/lib/apps/fabro-server/src/server/tests.rs
@@ -10672,6 +10672,21 @@ async fn run_artifacts_download_streams_latest_files_as_zip() {
             "control-exit.txt",
             &b"excluded"[..],
         ),
+        // Neither stage reached the projection, so both rank equally on stage
+        // order and retry. The serialized stage ID breaks the tie the same way
+        // the artifacts page does: "unknown@2" sorts above "unknown@10".
+        (
+            StageId::new("unknown", 10),
+            1,
+            "orphan.txt",
+            &b"visit ten"[..],
+        ),
+        (
+            StageId::new("unknown", 2),
+            1,
+            "orphan.txt",
+            &b"visit two"[..],
+        ),
     ] {
         state
             .artifact_store
@@ -10723,7 +10738,11 @@ async fn run_artifacts_download_streams_latest_files_as_zip() {
         .iter()
         .map(|entry| entry.filename().as_str().unwrap().to_string())
         .collect::<Vec<_>>();
-    assert_eq!(names, vec!["logs/run.txt", "reports/result.txt"]);
+    assert_eq!(names, vec![
+        "logs/run.txt",
+        "orphan.txt",
+        "reports/result.txt"
+    ]);
 
     let mut contents_by_name = HashMap::new();
     for (index, name) in names.into_iter().enumerate() {
@@ -10734,6 +10753,7 @@ async fn run_artifacts_download_streams_latest_files_as_zip() {
     }
     assert_eq!(contents_by_name["logs/run.txt"], b"build log");
     assert_eq!(contents_by_name["reports/result.txt"], b"latest verify");
+    assert_eq!(contents_by_name["orphan.txt"], b"visit two");
 }
 
 #[tokio::test]

--- a/lib/apps/fabro-server/src/server/tests.rs
+++ b/lib/apps/fabro-server/src/server/tests.rs
@@ -7,6 +7,7 @@ use std::process::Stdio;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc as StdArc, Mutex as StdMutex};
 
+use async_zip::base::read::mem::ZipFileReader;
 use axum::body::Body;
 use axum::http::{Method, Request, header};
 use chrono::{Duration as ChronoDuration, Utc};
@@ -10590,6 +10591,173 @@ async fn stage_artifacts_keep_same_filename_per_retry() {
 }
 
 #[tokio::test]
+async fn run_artifacts_download_streams_latest_files_as_zip() {
+    let state = test_app_state();
+    let app = crate::test_support::build_test_router(Arc::clone(&state));
+    let run_id = create_run(&app, MINIMAL_DOT)
+        .await
+        .parse::<RunId>()
+        .unwrap();
+
+    let run_store = state.stores.runs.open_run(&run_id).await.unwrap();
+    for event in [
+        workflow_event::Event::RunRunnable {
+            source: fabro_types::RunRunnableSource::StartRequested,
+            actor:  None,
+        },
+        workflow_event::Event::RunStarting,
+        workflow_event::Event::RunRunning,
+    ] {
+        workflow_event::append_event(&run_store, &run_id, &event)
+            .await
+            .unwrap();
+    }
+    append_scoped_stage_event(
+        &state,
+        run_id,
+        "build",
+        1,
+        &stage_started_event("build", "command"),
+    )
+    .await;
+    append_scoped_stage_event(
+        &state,
+        run_id,
+        "verify",
+        1,
+        &stage_started_event("verify", "command"),
+    )
+    .await;
+
+    for (stage_id, retry, path, contents) in [
+        (
+            StageId::new("unknown", 1),
+            99,
+            "reports/result.txt",
+            &b"unknown stage"[..],
+        ),
+        (
+            StageId::new("build", 1),
+            1,
+            "reports/result.txt",
+            &b"build result"[..],
+        ),
+        (
+            StageId::new("verify", 1),
+            1,
+            "reports/result.txt",
+            &b"first verify"[..],
+        ),
+        (
+            StageId::new("verify", 1),
+            2,
+            "reports/result.txt",
+            &b"latest verify"[..],
+        ),
+        (
+            StageId::new("build", 1),
+            1,
+            "logs/run.txt",
+            &b"build log"[..],
+        ),
+        (
+            StageId::new("start", 1),
+            1,
+            "control-start.txt",
+            &b"excluded"[..],
+        ),
+        (
+            StageId::new("exit", 1),
+            1,
+            "control-exit.txt",
+            &b"excluded"[..],
+        ),
+    ] {
+        state
+            .artifact_store
+            .put(&run_id, &ArtifactKey::new(stage_id, retry, path), contents)
+            .await
+            .unwrap();
+    }
+
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri(api(&format!("/runs/{run_id}/artifacts/download")))
+                .header(header::ACCEPT_ENCODING, "gzip")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(
+        response
+            .headers()
+            .get(header::CONTENT_TYPE)
+            .and_then(|value| value.to_str().ok()),
+        Some("application/zip")
+    );
+    assert_eq!(
+        response
+            .headers()
+            .get(header::CONTENT_DISPOSITION)
+            .and_then(|value| value.to_str().ok()),
+        Some(format!("attachment; filename=\"fabro-artifacts-{run_id}.zip\"").as_str())
+    );
+    assert_eq!(
+        response
+            .headers()
+            .get(header::CACHE_CONTROL)
+            .and_then(|value| value.to_str().ok()),
+        Some("private, no-store")
+    );
+    assert!(response.headers().get(header::CONTENT_ENCODING).is_none());
+
+    let bytes = response_bytes!(response, StatusCode::OK).await;
+    let archive = ZipFileReader::new(bytes.clone())
+        .await
+        .unwrap_or_else(|error| {
+            panic!(
+                "ZIP parse failed for {} bytes (tail {:?}): {error}",
+                bytes.len(),
+                &bytes[bytes.len().saturating_sub(48)..]
+            )
+        });
+    let names = archive
+        .file()
+        .entries()
+        .iter()
+        .map(|entry| entry.filename().as_str().unwrap().to_string())
+        .collect::<Vec<_>>();
+    assert_eq!(names, vec!["logs/run.txt", "reports/result.txt"]);
+
+    let mut contents_by_name = HashMap::new();
+    for (index, name) in names.into_iter().enumerate() {
+        let mut entry = archive.reader_with_entry(index).await.unwrap();
+        let mut contents = Vec::new();
+        entry.read_to_end_checked(&mut contents).await.unwrap();
+        contents_by_name.insert(name, contents);
+    }
+    assert_eq!(contents_by_name["logs/run.txt"], b"build log");
+    assert_eq!(contents_by_name["reports/result.txt"], b"latest verify");
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri(api(&format!("/runs/{}/artifacts/download", RunId::new())))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_status!(response, StatusCode::NOT_FOUND).await;
+}
+
+#[tokio::test]
 async fn create_run_persists_run_spec() {
     let state = test_app_state();
     let app = crate::test_support::build_test_router(Arc::clone(&state));
@@ -11316,6 +11484,7 @@ async fn worker_token_is_rejected_on_user_only_routes() {
         (Method::GET, format!("/runs/{run_id}/graph/source")),
         (Method::GET, format!("/runs/{run_id}/stages")),
         (Method::GET, format!("/runs/{run_id}/artifacts")),
+        (Method::GET, format!("/runs/{run_id}/artifacts/download")),
         (Method::GET, format!("/runs/{run_id}/files")),
         (
             Method::GET,

--- a/lib/components/fabro-store/src/artifact_store.rs
+++ b/lib/components/fabro-store/src/artifact_store.rs
@@ -4,6 +4,7 @@ use bytes::Bytes;
 use chrono::Utc;
 use fabro_types::RunId;
 use futures::StreamExt;
+use futures::stream::BoxStream;
 use object_store::ObjectStore;
 use object_store::buffered::BufWriter;
 use object_store::path::Path as ObjectPath;
@@ -120,6 +121,28 @@ impl ArtifactStore {
             Err(object_store::Error::NotFound { .. }) => Ok(None),
             Err(err) => Err(err.into()),
         }
+    }
+
+    pub async fn get_stream(
+        &self,
+        run_id: &RunId,
+        key: &ArtifactKey,
+    ) -> Result<Option<BoxStream<'static, Result<Bytes>>>> {
+        let path = self.artifact_path(run_id, key)?;
+        match self.object_store.get(&path).await {
+            Ok(result) => Ok(Some(
+                result
+                    .into_stream()
+                    .map(|chunk| chunk.map_err(Error::from))
+                    .boxed(),
+            )),
+            Err(object_store::Error::NotFound { .. }) => Ok(None),
+            Err(err) => Err(err.into()),
+        }
+    }
+
+    pub fn validate_relative_path(relative_path: &str) -> Result<()> {
+        validate_filename_segments(relative_path).map(drop)
     }
 
     pub async fn list_for_run(&self, run_id: &RunId) -> Result<Vec<NodeArtifact>> {
@@ -458,6 +481,22 @@ mod tests {
             store.get(&run_id, &key).await.unwrap(),
             Some(Bytes::from_static(b"hello world"))
         );
+    }
+
+    #[tokio::test]
+    async fn get_stream_round_trips_chunked_reads() {
+        let store = test_store();
+        let run_id = fixtures::RUN_1;
+        let key = ArtifactKey::new(StageId::new("build", 2), 1, "logs/output.txt");
+        store.put(&run_id, &key, b"hello world").await.unwrap();
+
+        let mut stream = store.get_stream(&run_id, &key).await.unwrap().unwrap();
+        let mut bytes = Vec::new();
+        while let Some(chunk) = stream.next().await {
+            bytes.extend_from_slice(&chunk.unwrap());
+        }
+
+        assert_eq!(bytes, b"hello world");
     }
 
     #[tokio::test]

--- a/lib/components/fabro-store/src/artifact_store.rs
+++ b/lib/components/fabro-store/src/artifact_store.rs
@@ -141,6 +141,11 @@ impl ArtifactStore {
         }
     }
 
+    /// Check a path against the same rules `put` enforces, without writing.
+    ///
+    /// Readers that hand artifact paths back to a client — the ZIP download,
+    /// for one — use this to re-check paths that were stored before a rule
+    /// existed.
     pub fn validate_relative_path(relative_path: &str) -> Result<()> {
         validate_filename_segments(relative_path).map(drop)
     }
@@ -243,10 +248,25 @@ impl ArtifactStore {
     }
 }
 
+/// Artifact filenames end up as paths on someone else's disk — extracted from a
+/// ZIP, written by a worker — so they must stay relative and portable. The
+/// backslash, NUL, and drive-letter rules are what make the path safe on
+/// Windows as well as Unix.
 fn validate_filename_segments(filename: &str) -> Result<Vec<&str>> {
     if filename.contains('\\') {
         return Err(Error::Other(
             "artifact filename must not contain backslashes".to_string(),
+        ));
+    }
+    if filename.contains('\0') {
+        return Err(Error::Other(
+            "artifact filename must not contain NUL bytes".to_string(),
+        ));
+    }
+    let bytes = filename.as_bytes();
+    if bytes.first().is_some_and(u8::is_ascii_alphabetic) && bytes.get(1) == Some(&b':') {
+        return Err(Error::Other(
+            "artifact filename must not start with a drive letter".to_string(),
         ));
     }
     let segments = filename.split('/').collect::<Vec<_>>();
@@ -507,15 +527,25 @@ mod tests {
 
         for filename in [
             "",
+            "/escape.txt",
             "../escape.txt",
             "logs//output.txt",
             "logs/./output.txt",
             r"logs\output.txt",
+            "C:/escape.txt",
+            "c:escape.txt",
+            "bad\0name.txt",
         ] {
             let key = ArtifactKey::new(node.clone(), 1, filename);
             let err = store.put(&run_id, &key, b"boom").await.unwrap_err();
-            assert!(err.to_string().contains("artifact filename"));
+            assert!(
+                err.to_string().contains("artifact filename"),
+                "accepted unsafe artifact filename: {filename:?}"
+            );
+            assert!(ArtifactStore::validate_relative_path(filename).is_err());
         }
+
+        assert!(ArtifactStore::validate_relative_path("nested/result.txt").is_ok());
     }
 
     #[tokio::test]

--- a/lib/components/fabro-store/src/run_state.rs
+++ b/lib/components/fabro-store/src/run_state.rs
@@ -1363,20 +1363,11 @@ pub(crate) fn projected_billing(state: &RunProjection) -> BilledTokenCounts {
 
     let mut billing = BilledTokenCounts::default();
     for (stage_id, stage) in state.iter_stages() {
-        if !is_boundary_stage(state, stage_id.node_id()) {
+        if !state.is_boundary_stage(stage_id.node_id()) {
             billing.add_counts(&stage.usage);
         }
     }
     billing
-}
-
-fn is_boundary_stage(projection: &RunProjection, node_id: &str) -> bool {
-    projection
-        .spec()
-        .graph()
-        .nodes
-        .get(node_id)
-        .is_some_and(|node| matches!(node.handler_type(), Some("start" | "exit")))
 }
 
 fn run_models(state: &RunProjection) -> Vec<RunModel> {

--- a/lib/components/fabro-workflow/src/billing_rollup.rs
+++ b/lib/components/fabro-workflow/src/billing_rollup.rs
@@ -52,7 +52,7 @@ pub fn billing_rollup_from_projection(
     let mut billed_visit_count = 0_usize;
 
     for (stage_id, stage) in projection.iter_stages() {
-        if is_boundary_stage(projection, stage_id.node_id()) {
+        if projection.is_boundary_stage(stage_id.node_id()) {
             continue;
         }
         let usage = stage.billed_usage(catalog);
@@ -122,15 +122,6 @@ pub fn billing_rollup_from_projection(
         timing: run_timing,
         billed_visit_count,
     }
-}
-
-fn is_boundary_stage(projection: &RunProjection, node_id: &str) -> bool {
-    projection
-        .spec()
-        .graph()
-        .nodes
-        .get(node_id)
-        .is_some_and(|node| matches!(node.handler_type(), Some("start" | "exit")))
 }
 
 #[cfg(test)]

--- a/lib/foundation/fabro-types/src/run_projection.rs
+++ b/lib/foundation/fabro-types/src/run_projection.rs
@@ -962,6 +962,20 @@ impl RunProjection {
         &self.spec
     }
 
+    /// Whether a graph node is one of the `start`/`exit` boundaries.
+    ///
+    /// Boundary nodes run no work, so callers that report what a run *did* —
+    /// billing, stage listings, artifact downloads — leave them out. The test
+    /// is the node's handler type, not its name: a node may be named
+    /// `start` and still do real work.
+    pub fn is_boundary_stage(&self, node_id: &str) -> bool {
+        self.spec()
+            .graph()
+            .nodes
+            .get(node_id)
+            .is_some_and(|node| matches!(node.handler_type(), Some("start" | "exit")))
+    }
+
     pub fn status(&self) -> RunStatus {
         self.status
     }

--- a/lib/packages/fabro-api-client/src/api/run-internals-api.ts
+++ b/lib/packages/fabro-api-client/src/api/run-internals-api.ts
@@ -147,7 +147,7 @@ export const RunInternalsApiAxiosParamCreator = function (configuration?: Config
             };
         },
         /**
-         * Streams a ZIP archive with the latest captured version of each artifact path. Stage order, retry number, and stage ID determine the latest version, matching the artifacts page. Captures from the `start` and `exit` control nodes are excluded.
+         * Streams a ZIP archive with the latest captured version of each artifact path. Stage order and retry number determine the latest version, matching the artifacts page. Captures from the `start` and `exit` control nodes are excluded.  The archive streams, so the response status is sent before the first artifact is read. A failure after that point aborts the transfer rather than returning `500`. The ZIP central directory is written last, so a truncated download does not open as a valid archive.
          * @summary Download Run Artifacts
          * @param {string} id Unique run identifier (ULID).
          * @param {*} [options] Override http request option.
@@ -987,7 +987,7 @@ export const RunInternalsApiFp = function(configuration?: Configuration) {
             return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
         },
         /**
-         * Streams a ZIP archive with the latest captured version of each artifact path. Stage order, retry number, and stage ID determine the latest version, matching the artifacts page. Captures from the `start` and `exit` control nodes are excluded.
+         * Streams a ZIP archive with the latest captured version of each artifact path. Stage order and retry number determine the latest version, matching the artifacts page. Captures from the `start` and `exit` control nodes are excluded.  The archive streams, so the response status is sent before the first artifact is read. A failure after that point aborts the transfer rather than returning `500`. The ZIP central directory is written last, so a truncated download does not open as a valid archive.
          * @summary Download Run Artifacts
          * @param {string} id Unique run identifier (ULID).
          * @param {*} [options] Override http request option.
@@ -1264,7 +1264,7 @@ export const RunInternalsApiFactory = function (configuration?: Configuration, b
             return localVarFp.attachRunEvents(id, sinceSeq, options).then((request) => request(axios, basePath));
         },
         /**
-         * Streams a ZIP archive with the latest captured version of each artifact path. Stage order, retry number, and stage ID determine the latest version, matching the artifacts page. Captures from the `start` and `exit` control nodes are excluded.
+         * Streams a ZIP archive with the latest captured version of each artifact path. Stage order and retry number determine the latest version, matching the artifacts page. Captures from the `start` and `exit` control nodes are excluded.  The archive streams, so the response status is sent before the first artifact is read. A failure after that point aborts the transfer rather than returning `500`. The ZIP central directory is written last, so a truncated download does not open as a valid archive.
          * @summary Download Run Artifacts
          * @param {string} id Unique run identifier (ULID).
          * @param {*} [options] Override http request option.
@@ -1490,7 +1490,7 @@ export class RunInternalsApi extends BaseAPI {
     }
 
     /**
-     * Streams a ZIP archive with the latest captured version of each artifact path. Stage order, retry number, and stage ID determine the latest version, matching the artifacts page. Captures from the `start` and `exit` control nodes are excluded.
+     * Streams a ZIP archive with the latest captured version of each artifact path. Stage order and retry number determine the latest version, matching the artifacts page. Captures from the `start` and `exit` control nodes are excluded.  The archive streams, so the response status is sent before the first artifact is read. A failure after that point aborts the transfer rather than returning `500`. The ZIP central directory is written last, so a truncated download does not open as a valid archive.
      * @summary Download Run Artifacts
      * @param {string} id Unique run identifier (ULID).
      * @param {*} [options] Override http request option.

--- a/lib/packages/fabro-api-client/src/api/run-internals-api.ts
+++ b/lib/packages/fabro-api-client/src/api/run-internals-api.ts
@@ -147,6 +147,46 @@ export const RunInternalsApiAxiosParamCreator = function (configuration?: Config
             };
         },
         /**
+         * Streams a ZIP archive with the latest captured version of each artifact path. Stage order, retry number, and stage ID determine the latest version, matching the artifacts page. Captures from the `start` and `exit` control nodes are excluded.
+         * @summary Download Run Artifacts
+         * @param {string} id Unique run identifier (ULID).
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        downloadRunArtifacts: async (id: string, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            // verify required parameter 'id' is not null or undefined
+            assertParamExists('downloadRunArtifacts', 'id', id)
+            const localVarPath = `/api/v1/runs/{id}/artifacts/download`
+                .replace(`{${"id"}}`, encodeURIComponent(String(id)));
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            // authentication SessionCookie required
+
+            // authentication BearerAuth required
+            // http bearer authentication required
+            await setBearerAuthToObject(localVarHeaderParameter, configuration)
+
+            localVarHeaderParameter['Accept'] = 'application/zip,application/json';
+
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
          * Returns one stored run event by source event sequence with content fields separated and truncated.
          * @summary Get Run Event Detail
          * @param {string} id Unique run identifier (ULID).
@@ -947,6 +987,19 @@ export const RunInternalsApiFp = function(configuration?: Configuration) {
             return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
         },
         /**
+         * Streams a ZIP archive with the latest captured version of each artifact path. Stage order, retry number, and stage ID determine the latest version, matching the artifacts page. Captures from the `start` and `exit` control nodes are excluded.
+         * @summary Download Run Artifacts
+         * @param {string} id Unique run identifier (ULID).
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async downloadRunArtifacts(id: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<File>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.downloadRunArtifacts(id, options);
+            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+            const localVarOperationServerBasePath = operationServerMap['RunInternalsApi.downloadRunArtifacts']?.[localVarOperationServerIndex]?.url;
+            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
+        },
+        /**
          * Returns one stored run event by source event sequence with content fields separated and truncated.
          * @summary Get Run Event Detail
          * @param {string} id Unique run identifier (ULID).
@@ -1211,6 +1264,16 @@ export const RunInternalsApiFactory = function (configuration?: Configuration, b
             return localVarFp.attachRunEvents(id, sinceSeq, options).then((request) => request(axios, basePath));
         },
         /**
+         * Streams a ZIP archive with the latest captured version of each artifact path. Stage order, retry number, and stage ID determine the latest version, matching the artifacts page. Captures from the `start` and `exit` control nodes are excluded.
+         * @summary Download Run Artifacts
+         * @param {string} id Unique run identifier (ULID).
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        downloadRunArtifacts(id: string, options?: RawAxiosRequestConfig): AxiosPromise<File> {
+            return localVarFp.downloadRunArtifacts(id, options).then((request) => request(axios, basePath));
+        },
+        /**
          * Returns one stored run event by source event sequence with content fields separated and truncated.
          * @summary Get Run Event Detail
          * @param {string} id Unique run identifier (ULID).
@@ -1424,6 +1487,17 @@ export class RunInternalsApi extends BaseAPI {
      */
     public attachRunEvents(id: string, sinceSeq?: number, options?: RawAxiosRequestConfig) {
         return RunInternalsApiFp(this.configuration).attachRunEvents(id, sinceSeq, options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * Streams a ZIP archive with the latest captured version of each artifact path. Stage order, retry number, and stage ID determine the latest version, matching the artifacts page. Captures from the `start` and `exit` control nodes are excluded.
+     * @summary Download Run Artifacts
+     * @param {string} id Unique run identifier (ULID).
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     */
+    public downloadRunArtifacts(id: string, options?: RawAxiosRequestConfig) {
+        return RunInternalsApiFp(this.configuration).downloadRunArtifacts(id, options).then((request) => request(this.axios, this.basePath));
     }
 
     /**

--- a/lib/packages/fabro-api-client/src/api/run-internals-api.ts
+++ b/lib/packages/fabro-api-client/src/api/run-internals-api.ts
@@ -147,7 +147,7 @@ export const RunInternalsApiAxiosParamCreator = function (configuration?: Config
             };
         },
         /**
-         * Streams a ZIP archive with the latest captured version of each artifact path. Stage order and retry number determine the latest version, matching the artifacts page. Captures from the `start` and `exit` control nodes are excluded.  The archive streams, so the response status is sent before the first artifact is read. A failure after that point aborts the transfer rather than returning `500`. The ZIP central directory is written last, so a truncated download does not open as a valid archive.
+         * Streams a ZIP archive with the latest captured version of each artifact path. Stage order, retry number, and then stage ID determine the latest version, matching the artifacts page. Captures from the graph\'s boundary nodes are excluded, identified by their `start` and `exit` handler type rather than by node name.  The archive streams, so the response status is sent before the first artifact is read. A failure after that point aborts the transfer rather than returning `500`. The ZIP central directory is written last, so a truncated download does not open as a valid archive.
          * @summary Download Run Artifacts
          * @param {string} id Unique run identifier (ULID).
          * @param {*} [options] Override http request option.
@@ -987,7 +987,7 @@ export const RunInternalsApiFp = function(configuration?: Configuration) {
             return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
         },
         /**
-         * Streams a ZIP archive with the latest captured version of each artifact path. Stage order and retry number determine the latest version, matching the artifacts page. Captures from the `start` and `exit` control nodes are excluded.  The archive streams, so the response status is sent before the first artifact is read. A failure after that point aborts the transfer rather than returning `500`. The ZIP central directory is written last, so a truncated download does not open as a valid archive.
+         * Streams a ZIP archive with the latest captured version of each artifact path. Stage order, retry number, and then stage ID determine the latest version, matching the artifacts page. Captures from the graph\'s boundary nodes are excluded, identified by their `start` and `exit` handler type rather than by node name.  The archive streams, so the response status is sent before the first artifact is read. A failure after that point aborts the transfer rather than returning `500`. The ZIP central directory is written last, so a truncated download does not open as a valid archive.
          * @summary Download Run Artifacts
          * @param {string} id Unique run identifier (ULID).
          * @param {*} [options] Override http request option.
@@ -1264,7 +1264,7 @@ export const RunInternalsApiFactory = function (configuration?: Configuration, b
             return localVarFp.attachRunEvents(id, sinceSeq, options).then((request) => request(axios, basePath));
         },
         /**
-         * Streams a ZIP archive with the latest captured version of each artifact path. Stage order and retry number determine the latest version, matching the artifacts page. Captures from the `start` and `exit` control nodes are excluded.  The archive streams, so the response status is sent before the first artifact is read. A failure after that point aborts the transfer rather than returning `500`. The ZIP central directory is written last, so a truncated download does not open as a valid archive.
+         * Streams a ZIP archive with the latest captured version of each artifact path. Stage order, retry number, and then stage ID determine the latest version, matching the artifacts page. Captures from the graph\'s boundary nodes are excluded, identified by their `start` and `exit` handler type rather than by node name.  The archive streams, so the response status is sent before the first artifact is read. A failure after that point aborts the transfer rather than returning `500`. The ZIP central directory is written last, so a truncated download does not open as a valid archive.
          * @summary Download Run Artifacts
          * @param {string} id Unique run identifier (ULID).
          * @param {*} [options] Override http request option.
@@ -1490,7 +1490,7 @@ export class RunInternalsApi extends BaseAPI {
     }
 
     /**
-     * Streams a ZIP archive with the latest captured version of each artifact path. Stage order and retry number determine the latest version, matching the artifacts page. Captures from the `start` and `exit` control nodes are excluded.  The archive streams, so the response status is sent before the first artifact is read. A failure after that point aborts the transfer rather than returning `500`. The ZIP central directory is written last, so a truncated download does not open as a valid archive.
+     * Streams a ZIP archive with the latest captured version of each artifact path. Stage order, retry number, and then stage ID determine the latest version, matching the artifacts page. Captures from the graph\'s boundary nodes are excluded, identified by their `start` and `exit` handler type rather than by node name.  The archive streams, so the response status is sent before the first artifact is read. A failure after that point aborts the transfer rather than returning `500`. The ZIP central directory is written last, so a truncated download does not open as a valid archive.
      * @summary Download Run Artifacts
      * @param {string} id Unique run identifier (ULID).
      * @param {*} [options] Override http request option.


### PR DESCRIPTION
## Summary

- add a **Download all** action to the run artifacts page
- stream a ZIP that contains the latest version of each visible artifact path
- validate archive paths and avoid buffering artifact contents in memory
- document the endpoint and regenerate the API client

## Test plan

- `cargo nextest run -p fabro-server`
- `cargo nextest run -p fabro-store`
- `cargo nextest run -p fabro-server --features test-support all_spec_routes_are_routable`
- `cargo +nightly-2026-04-14 clippy -p fabro-store -p fabro-server --all-targets -- -D warnings`
- `cargo +nightly-2026-04-14 fmt --check --all`
- `cd apps/fabro-web && bun run test`
- `cd apps/fabro-web && bun run typecheck`
- `cd apps/fabro-web && bun run build`
- `cd lib/packages/fabro-api-client && bun run typecheck`
