### PR TITLE
Sanitize Bedrock tool identifiers during encoding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2766,6 +2766,7 @@ dependencies = [
  "rand 0.9.4",
  "serde",
  "serde_json",
+ "sha2 0.10.9",
  "strum 0.28.0",
  "thiserror 2.0.18",
  "tokio",

--- a/lib/components/fabro-llm/Cargo.toml
+++ b/lib/components/fabro-llm/Cargo.toml
@@ -21,6 +21,7 @@ anyhow.workspace = true
 thiserror.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+sha2.workspace = true
 strum.workspace = true
 tokio.workspace = true
 uuid.workspace = true

--- a/lib/components/fabro-llm/src/codec/bedrock_converse/decode.rs
+++ b/lib/components/fabro-llm/src/codec/bedrock_converse/decode.rs
@@ -280,6 +280,21 @@ mod tests {
     }
 
     #[test]
+    fn tool_use_names_are_preserved_verbatim() {
+        let block = serde_json::json!({
+            "toolUse": {
+                "toolUseId": "tool-1",
+                "name": "search???",
+                "input": {}
+            }
+        });
+        let Some(ContentPart::ToolCall(tool_call)) = decode_content_block(&block) else {
+            panic!("expected tool call");
+        };
+        assert_eq!(tool_call.name, "search???");
+    }
+
+    #[test]
     fn reasoning_text_block_round_trips_signature() {
         let block = serde_json::json!({
             "reasoningContent": {

--- a/lib/components/fabro-llm/src/codec/bedrock_converse/encode.rs
+++ b/lib/components/fabro-llm/src/codec/bedrock_converse/encode.rs
@@ -4,6 +4,7 @@ use base64::Engine;
 use base64::engine::general_purpose::STANDARD as BASE64;
 use serde_json::{Map, Value, json};
 
+use super::sanitize;
 use crate::codec::{CodecCtx, EncodedRequest, extract_system_prompt, merge_named_provider_options};
 use crate::error::Error;
 use crate::types::{ContentPart, Message, Request, Role, ToolChoice};
@@ -129,7 +130,7 @@ fn encode_message(message: &Message) -> Option<Value> {
             let text = message.text();
             blocks.push(json!({
                 "toolResult": {
-                    "toolUseId": tool_call_id,
+                    "toolUseId": sanitize::tool_use_id(tool_call_id),
                     "content": [{ "text": text }],
                 }
             }));
@@ -185,8 +186,8 @@ fn encode_content_part(part: &ContentPart) -> Option<Value> {
             };
             Some(json!({
                 "toolUse": {
-                    "toolUseId": tool_call.id,
-                    "name": tool_call.name,
+                    "toolUseId": sanitize::tool_use_id(&tool_call.id),
+                    "name": sanitize::tool_name(&tool_call.name),
                     "input": input,
                 }
             }))
@@ -197,7 +198,10 @@ fn encode_content_part(part: &ContentPart) -> Option<Value> {
                 other => json!([{ "json": other }]),
             };
             let mut block = Map::new();
-            block.insert("toolUseId".to_string(), json!(result.tool_call_id));
+            block.insert(
+                "toolUseId".to_string(),
+                json!(sanitize::tool_use_id(&result.tool_call_id)),
+            );
             block.insert("content".to_string(), content);
             if result.is_error {
                 block.insert("status".to_string(), json!("error"));
@@ -520,6 +524,119 @@ mod tests {
         assert_eq!(tool_use["toolUseId"], "tool-1");
         assert_eq!(tool_use["name"], "TaskList");
         assert_eq!(tool_use["input"], json!({}));
+    }
+
+    #[test]
+    fn historical_tool_names_are_sanitized_without_mutating_the_request() {
+        let mut request = base_request("claude");
+        request.messages = vec![Message {
+            role:         Role::Assistant,
+            content:      vec![ContentPart::ToolCall(ToolCall::new(
+                "tool-1",
+                "search???",
+                json!({}),
+            ))],
+            name:         None,
+            tool_call_id: None,
+        }];
+
+        let encoded = encode_with(&request);
+        let tool_use = &encoded.body["messages"][0]["content"][0]["toolUse"];
+        assert_eq!(tool_use["name"], "search___");
+
+        let ContentPart::ToolCall(original) = &request.messages[0].content[0] else {
+            panic!("expected original tool call");
+        };
+        assert_eq!(original.name, "search???");
+    }
+
+    #[test]
+    fn sanitized_tool_use_ids_remain_paired() {
+        for id in ["bad id!".to_string(), "x".repeat(100)] {
+            let mut request = base_request("claude");
+            request.messages = vec![
+                Message {
+                    role:         Role::Assistant,
+                    content:      vec![ContentPart::ToolCall(ToolCall::new(
+                        &id,
+                        "search",
+                        json!({}),
+                    ))],
+                    name:         None,
+                    tool_call_id: None,
+                },
+                Message {
+                    role:         Role::Tool,
+                    content:      vec![ContentPart::ToolResult(ToolResult::success(
+                        &id,
+                        json!("done"),
+                    ))],
+                    name:         None,
+                    tool_call_id: Some(id.clone()),
+                },
+            ];
+
+            let encoded = encode_with(&request);
+            let tool_use_id = &encoded.body["messages"][0]["content"][0]["toolUse"]["toolUseId"];
+            let tool_result_id =
+                &encoded.body["messages"][1]["content"][0]["toolResult"]["toolUseId"];
+            assert_eq!(tool_use_id, tool_result_id);
+            assert!(tool_use_id.as_str().is_some_and(|value| value.len() <= 64));
+        }
+    }
+
+    #[test]
+    fn tool_role_fallback_sanitizes_the_tool_use_id() {
+        let mut request = base_request("claude");
+        request.messages = vec![Message {
+            role:         Role::Tool,
+            content:      vec![],
+            name:         None,
+            tool_call_id: Some("bad id!".to_string()),
+        }];
+
+        let encoded = encode_with(&request);
+        assert_eq!(
+            encoded.body["messages"][0]["content"][0]["toolResult"]["toolUseId"],
+            "bad_id_"
+        );
+    }
+
+    #[test]
+    fn overlength_tool_names_encode_within_the_bedrock_limit() {
+        let mut request = base_request("claude");
+        request.messages = vec![Message {
+            role:         Role::Assistant,
+            content:      vec![ContentPart::ToolCall(ToolCall::new(
+                "tool-1",
+                "x".repeat(100),
+                json!({}),
+            ))],
+            name:         None,
+            tool_call_id: None,
+        }];
+
+        let encoded = encode_with(&request);
+        let name = encoded.body["messages"][0]["content"][0]["toolUse"]["name"]
+            .as_str()
+            .unwrap();
+        assert_eq!(name.len(), 64);
+    }
+
+    #[test]
+    fn tool_definition_names_remain_unsanitized() {
+        let mut request = base_request("claude");
+        request.tools = Some(vec![ToolDefinition::function(
+            "weird.name",
+            "Deliberately invalid for Bedrock",
+            json!({"type": "object"}),
+        )]);
+
+        let encoded = encode_with(&request);
+        assert_eq!(
+            encoded.body["toolConfig"]["tools"][0]["toolSpec"]["name"],
+            "weird.name"
+        );
     }
 
     #[test]

--- a/lib/components/fabro-llm/src/codec/bedrock_converse/encode.rs
+++ b/lib/components/fabro-llm/src/codec/bedrock_converse/encode.rs
@@ -128,12 +128,11 @@ fn encode_message(message: &Message) -> Option<Value> {
     if blocks.is_empty() && message.role == Role::Tool {
         if let Some(tool_call_id) = &message.tool_call_id {
             let text = message.text();
-            blocks.push(json!({
-                "toolResult": {
-                    "toolUseId": sanitize::tool_use_id(tool_call_id),
-                    "content": [{ "text": text }],
-                }
-            }));
+            blocks.push(tool_result_block(
+                tool_call_id,
+                json!([{ "text": text }]),
+                false,
+            ));
         }
     }
 
@@ -184,29 +183,18 @@ fn encode_content_part(part: &ContentPart) -> Option<Value> {
                 Value::Object(_) => tool_call.arguments.clone(),
                 _ => json!({}),
             };
-            Some(json!({
-                "toolUse": {
-                    "toolUseId": sanitize::tool_use_id(&tool_call.id),
-                    "name": sanitize::tool_name(&tool_call.name),
-                    "input": input,
-                }
-            }))
+            Some(tool_use_block(&tool_call.id, &tool_call.name, input))
         }
         ContentPart::ToolResult(result) => {
             let content = match &result.content {
                 Value::String(text) => json!([{ "text": text }]),
                 other => json!([{ "json": other }]),
             };
-            let mut block = Map::new();
-            block.insert(
-                "toolUseId".to_string(),
-                json!(sanitize::tool_use_id(&result.tool_call_id)),
-            );
-            block.insert("content".to_string(), content);
-            if result.is_error {
-                block.insert("status".to_string(), json!("error"));
-            }
-            Some(json!({ "toolResult": Value::Object(block) }))
+            Some(tool_result_block(
+                &result.tool_call_id,
+                content,
+                result.is_error,
+            ))
         }
         ContentPart::Thinking(thinking) => {
             if thinking.redacted {
@@ -228,6 +216,28 @@ fn encode_content_part(part: &ContentPart) -> Option<Value> {
         // Audio input and opaque foreign parts have no Converse encoding.
         ContentPart::Audio(_) | ContentPart::Other { .. } => None,
     }
+}
+
+/// Build a `toolUse` block. All tool blocks must be constructed through
+/// [`tool_use_block`] and [`tool_result_block`] so identifier sanitization
+/// keeps `toolUse` and `toolResult` paired on the wire.
+fn tool_use_block(id: &str, name: &str, input: Value) -> Value {
+    let mut block = Map::new();
+    block.insert("toolUseId".to_string(), json!(sanitize::tool_use_id(id)));
+    block.insert("name".to_string(), json!(sanitize::tool_name(name)));
+    block.insert("input".to_string(), input);
+    json!({ "toolUse": Value::Object(block) })
+}
+
+/// Build a `toolResult` block; see [`tool_use_block`] for the pairing contract.
+fn tool_result_block(id: &str, content: Value, is_error: bool) -> Value {
+    let mut block = Map::new();
+    block.insert("toolUseId".to_string(), json!(sanitize::tool_use_id(id)));
+    block.insert("content".to_string(), content);
+    if is_error {
+        block.insert("status".to_string(), json!("error"));
+    }
+    json!({ "toolResult": Value::Object(block) })
 }
 
 /// Convert common MIME types into Bedrock's media `format` enum values.
@@ -527,7 +537,7 @@ mod tests {
     }
 
     #[test]
-    fn historical_tool_names_are_sanitized_without_mutating_the_request() {
+    fn historical_tool_names_are_sanitized_on_the_wire() {
         let mut request = base_request("claude");
         request.messages = vec![Message {
             role:         Role::Assistant,
@@ -542,12 +552,7 @@ mod tests {
 
         let encoded = encode_with(&request);
         let tool_use = &encoded.body["messages"][0]["content"][0]["toolUse"];
-        assert_eq!(tool_use["name"], "search___");
-
-        let ContentPart::ToolCall(original) = &request.messages[0].content[0] else {
-            panic!("expected original tool call");
-        };
-        assert_eq!(original.name, "search???");
+        assert_eq!(tool_use["name"], sanitize::tool_name("search???"));
     }
 
     #[test]
@@ -598,7 +603,7 @@ mod tests {
         let encoded = encode_with(&request);
         assert_eq!(
             encoded.body["messages"][0]["content"][0]["toolResult"]["toolUseId"],
-            "bad_id_"
+            sanitize::tool_use_id("bad id!")
         );
     }
 

--- a/lib/components/fabro-llm/src/codec/bedrock_converse/mod.rs
+++ b/lib/components/fabro-llm/src/codec/bedrock_converse/mod.rs
@@ -12,6 +12,7 @@
 
 mod decode;
 mod encode;
+mod sanitize;
 mod stream;
 
 use crate::codec::{Codec, CodecCtx, EncodedRequest, StreamDecoder};

--- a/lib/components/fabro-llm/src/codec/bedrock_converse/sanitize.rs
+++ b/lib/components/fabro-llm/src/codec/bedrock_converse/sanitize.rs
@@ -3,10 +3,9 @@
 //! Tool names must match `[a-zA-Z0-9_-]+`; tool-use IDs additionally allow
 //! `.` and `:`. Both are limited to 64 characters. These helpers rewrite only
 //! the Bedrock wire view: the canonical transcript retains provider output
-//! verbatim. Every encoded tool-use ID site must use the same helper so
-//! `toolUse` and `toolResult` blocks remain paired.
-
-use std::borrow::Cow;
+//! verbatim. The encoder routes every tool block through its
+//! `tool_use_block`/`tool_result_block` constructors so `toolUse` and
+//! `toolResult` blocks remain paired.
 
 use sha2::{Digest, Sha256};
 
@@ -14,40 +13,35 @@ const MAX_LENGTH: usize = 64;
 const HASH_HEX_LENGTH: usize = 16;
 const PREFIX_LENGTH: usize = MAX_LENGTH - 1 - HASH_HEX_LENGTH;
 
-pub(super) fn tool_name(name: &str) -> Cow<'_, str> {
+pub(super) fn tool_name(name: &str) -> String {
     sanitize(name, "unknown_tool", is_tool_name_char)
 }
 
-pub(super) fn tool_use_id(id: &str) -> Cow<'_, str> {
+pub(super) fn tool_use_id(id: &str) -> String {
     sanitize(id, "unknown_tool_use_id", is_tool_use_id_char)
 }
 
-fn sanitize<'a>(
-    value: &'a str,
-    empty_fallback: &'static str,
-    is_allowed: fn(char) -> bool,
-) -> Cow<'a, str> {
+fn sanitize(value: &str, empty_fallback: &'static str, is_allowed: fn(char) -> bool) -> String {
     if value.is_empty() {
-        return Cow::Borrowed(empty_fallback);
-    }
-    if value.len() <= MAX_LENGTH && value.chars().all(is_allowed) {
-        return Cow::Borrowed(value);
+        return empty_fallback.to_string();
     }
 
-    let mut sanitized = String::with_capacity(value.len());
-    for character in value.chars() {
-        sanitized.push(if is_allowed(character) {
-            character
-        } else {
-            '_'
-        });
-    }
+    let sanitized: String = value
+        .chars()
+        .map(|character| {
+            if is_allowed(character) {
+                character
+            } else {
+                '_'
+            }
+        })
+        .collect();
 
     if sanitized.len() <= MAX_LENGTH {
-        return Cow::Owned(sanitized);
+        sanitized
+    } else {
+        truncate_with_hash(&sanitized, value)
     }
-
-    Cow::Owned(truncate_with_hash(&sanitized, value))
 }
 
 fn is_tool_name_char(character: char) -> bool {
@@ -74,22 +68,16 @@ mod tests {
     use super::*;
 
     #[test]
-    fn valid_values_are_returned_borrowed() {
+    fn valid_values_pass_through_unchanged() {
         for name in ["search", "TaskList", "a-b_c9"] {
-            assert!(matches!(tool_name(name), Cow::Borrowed(value) if value == name));
+            assert_eq!(tool_name(name), name);
         }
 
         let max_length = "a".repeat(64);
-        assert!(matches!(
-            tool_name(&max_length),
-            Cow::Borrowed(value) if value == max_length
-        ));
+        assert_eq!(tool_name(&max_length), max_length);
 
         let id = "functions.read_file:4";
-        assert!(matches!(
-            tool_use_id(id),
-            Cow::Borrowed(value) if value == id
-        ));
+        assert_eq!(tool_use_id(id), id);
         assert_eq!(tool_name(id), "functions_read_file_4");
     }
 
@@ -118,7 +106,6 @@ mod tests {
         let boundary = "a".repeat(65);
         let first = tool_name(&boundary);
         let second = tool_name(&boundary);
-        assert!(matches!(&first, Cow::Owned(_)));
         assert_eq!(first, second);
         assert_eq!(first.len(), 64);
         assert!(
@@ -128,8 +115,8 @@ mod tests {
         );
 
         let shared_prefix = "x".repeat(99);
-        let left = tool_name(&format!("{shared_prefix}a")).into_owned();
-        let right = tool_name(&format!("{shared_prefix}b")).into_owned();
+        let left = tool_name(&format!("{shared_prefix}a"));
+        let right = tool_name(&format!("{shared_prefix}b"));
         assert_ne!(left, right);
     }
 }

--- a/lib/components/fabro-llm/src/codec/bedrock_converse/sanitize.rs
+++ b/lib/components/fabro-llm/src/codec/bedrock_converse/sanitize.rs
@@ -1,0 +1,135 @@
+//! Bedrock Converse tool identifier sanitization.
+//!
+//! Tool names must match `[a-zA-Z0-9_-]+`; tool-use IDs additionally allow
+//! `.` and `:`. Both are limited to 64 characters. These helpers rewrite only
+//! the Bedrock wire view: the canonical transcript retains provider output
+//! verbatim. Every encoded tool-use ID site must use the same helper so
+//! `toolUse` and `toolResult` blocks remain paired.
+
+use std::borrow::Cow;
+
+use sha2::{Digest, Sha256};
+
+const MAX_LENGTH: usize = 64;
+const HASH_HEX_LENGTH: usize = 16;
+const PREFIX_LENGTH: usize = MAX_LENGTH - 1 - HASH_HEX_LENGTH;
+
+pub(super) fn tool_name(name: &str) -> Cow<'_, str> {
+    sanitize(name, "unknown_tool", is_tool_name_char)
+}
+
+pub(super) fn tool_use_id(id: &str) -> Cow<'_, str> {
+    sanitize(id, "unknown_tool_use_id", is_tool_use_id_char)
+}
+
+fn sanitize<'a>(
+    value: &'a str,
+    empty_fallback: &'static str,
+    is_allowed: fn(char) -> bool,
+) -> Cow<'a, str> {
+    if value.is_empty() {
+        return Cow::Borrowed(empty_fallback);
+    }
+    if value.len() <= MAX_LENGTH && value.chars().all(is_allowed) {
+        return Cow::Borrowed(value);
+    }
+
+    let mut sanitized = String::with_capacity(value.len());
+    for character in value.chars() {
+        sanitized.push(if is_allowed(character) {
+            character
+        } else {
+            '_'
+        });
+    }
+
+    if sanitized.len() <= MAX_LENGTH {
+        return Cow::Owned(sanitized);
+    }
+
+    Cow::Owned(truncate_with_hash(&sanitized, value))
+}
+
+fn is_tool_name_char(character: char) -> bool {
+    character.is_ascii_alphanumeric() || matches!(character, '_' | '-')
+}
+
+fn is_tool_use_id_char(character: char) -> bool {
+    is_tool_name_char(character) || matches!(character, '.' | ':')
+}
+
+fn truncate_with_hash(sanitized: &str, original: &str) -> String {
+    debug_assert!(sanitized.is_ascii());
+    let digest = Sha256::digest(original.as_bytes());
+    let digest_hex = format!("{digest:x}");
+    format!(
+        "{}-{}",
+        &sanitized[..PREFIX_LENGTH],
+        &digest_hex[..HASH_HEX_LENGTH]
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn valid_values_are_returned_borrowed() {
+        for name in ["search", "TaskList", "a-b_c9"] {
+            assert!(matches!(tool_name(name), Cow::Borrowed(value) if value == name));
+        }
+
+        let max_length = "a".repeat(64);
+        assert!(matches!(
+            tool_name(&max_length),
+            Cow::Borrowed(value) if value == max_length
+        ));
+
+        let id = "functions.read_file:4";
+        assert!(matches!(
+            tool_use_id(id),
+            Cow::Borrowed(value) if value == id
+        ));
+        assert_eq!(tool_name(id), "functions_read_file_4");
+    }
+
+    #[test]
+    fn invalid_characters_are_replaced() {
+        assert_eq!(tool_name("search???"), "search___");
+        assert_eq!(tool_name("bad name"), "bad_name");
+        assert_eq!(tool_use_id("bad id!"), "bad_id_");
+    }
+
+    #[test]
+    fn non_ascii_characters_become_single_underscores() {
+        let sanitized = tool_name("before🙂after");
+        assert_eq!(sanitized, "before_after");
+        assert!(sanitized.is_ascii());
+    }
+
+    #[test]
+    fn empty_values_use_nonempty_fallbacks() {
+        assert_eq!(tool_name(""), "unknown_tool");
+        assert_eq!(tool_use_id(""), "unknown_tool_use_id");
+    }
+
+    #[test]
+    fn overlength_values_use_deterministic_hash_suffixes() {
+        let boundary = "a".repeat(65);
+        let first = tool_name(&boundary);
+        let second = tool_name(&boundary);
+        assert!(matches!(&first, Cow::Owned(_)));
+        assert_eq!(first, second);
+        assert_eq!(first.len(), 64);
+        assert!(
+            first
+                .bytes()
+                .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-'))
+        );
+
+        let shared_prefix = "x".repeat(99);
+        let left = tool_name(&format!("{shared_prefix}a")).into_owned();
+        let right = tool_name(&format!("{shared_prefix}b")).into_owned();
+        assert_ne!(left, right);
+    }
+}

--- a/lib/components/fabro-llm/src/codec/bedrock_converse/stream.rs
+++ b/lib/components/fabro-llm/src/codec/bedrock_converse/stream.rs
@@ -407,6 +407,22 @@ mod tests {
     }
 
     #[test]
+    fn streamed_tool_use_names_are_preserved_verbatim() {
+        let mut d = decoder();
+        feed(&mut d, "messageStart", r#"{"role":"assistant"}"#);
+        feed(
+            &mut d,
+            "contentBlockStart",
+            r#"{"start":{"toolUse":{"toolUseId":"tool-1","name":"search???"}},"contentBlockIndex":0}"#,
+        );
+        let stop = feed(&mut d, "contentBlockStop", r#"{"contentBlockIndex":0}"#);
+        let StreamEvent::ToolCallEnd { tool_call } = &stop[0] else {
+            panic!("expected ToolCallEnd");
+        };
+        assert_eq!(tool_call.name, "search???");
+    }
+
+    #[test]
     fn tool_use_accumulates_string_input_fragments() {
         let mut d = decoder();
         feed(&mut d, "messageStart", r#"{"role":"assistant"}"#);


### PR DESCRIPTION
## Summary

- sanitize historical Bedrock Converse `toolUse.name` values to the provider's `[a-zA-Z0-9_-]+` grammar
- sanitize `toolUseId` values at every `toolUse` and `toolResult` encode site with one deterministic function, preserving call/result pairing
- replace invalid characters, provide non-empty fallbacks, and shorten over-length values to 64 characters with a stable SHA-256 suffix
- preserve already-valid identifiers without allocation

## Why

Bedrock can return a model-emitted tool name that its request validator would reject. Fabro previously stored that output verbatim and replayed it verbatim, so the next request failed with a validation error and the conversation could not continue. Cross-provider histories can hit the same failure with longer names or incompatible tool-call IDs.

Sanitization happens only while encoding the Bedrock wire request. Non-streaming and streaming decoders continue to preserve exactly what the provider emitted, keeping the canonical transcript useful for debugging and replay through providers with different identifier rules.

Tool definitions and named tool choices also remain unchanged. Silently renaming a registered tool would break dispatch without reverse-mapping machinery, so invalid definitions still fail through Bedrock's normal validation.

## Verification

- `cargo +nightly-2026-04-14 fmt --check --all`
- `cargo +nightly-2026-04-14 clippy --workspace --all-targets -- -D warnings`
- `cargo nextest run -p fabro-llm` — 681 passed, 24 skipped
- `cargo nextest run --workspace --status-level slow --profile ci` — 7,688 passed, 203 skipped, with ambient provider keys unset for hermetic credential tests


## How this compares to other open-source Bedrock adapters

This failure class ("model output is not replayable as input") is well documented across the ecosystem, and the approach here matches where other projects converged — while covering a couple of gaps they still have open.

**LiteLLM** is the only major adapter that ships a fix, and it arrived at the same shape over two years of incident-driven patches: a single deterministic sanitizer (invalid characters → `_`) applied at every Bedrock encode boundary — tool definitions first ([BerriAI/litellm#5138](https://github.com/BerriAI/litellm/pull/5138)), then message-history `toolUse` names and forced tool choice ([BerriAI/litellm#28874](https://github.com/BerriAI/litellm/pull/28874)). Two things it still doesn't cover that this PR does: the 64-character length limit (open as [BerriAI/litellm#26398](https://github.com/BerriAI/litellm/issues/26398)) and `toolUseId` sanitization with call/result pairing preserved (open as [BerriAI/litellm#28825](https://github.com/BerriAI/litellm/pull/28825)). One thing LiteLLM needs that this PR deliberately avoids: because it also renames tool *definitions*, it has to keep an in-memory reverse-map cache to restore original names in responses, and that cache is lossy (bounded size, TTL, per-process). Fabro sidesteps the whole problem by leaving definitions unsanitized (invalid definitions still fail loudly) and never mutating the stored transcript — there is nothing to restore.

**Vercel AI SDK** has the identical bug on file ([vercel/ai#10202](https://github.com/vercel/ai/issues/10202) — a model hallucinated `$READFILE` and the replayed history failed validation) and an unmerged community fix ([vercel/ai#10258](https://github.com/vercel/ai/pull/10258)) that uses the same replacement rule as this PR (`[^a-zA-Z0-9_-]` → `_`) on the history-replay path, but without length handling or ID coverage. Their provider already normalizes replayed tool-call *IDs* to a model-specific grammar for Mistral (`normalizeToolCallId`), which is the same normalize-on-the-wire pattern this PR applies.

**LangChain** (`ChatBedrockConverse`, Python and JS) passes names and IDs through verbatim with no fix on file; users hitting the constraint are directed to rename their tools at the source (e.g. [awslabs/mcp#3181](https://github.com/awslabs/mcp/issues/3181)).

Two ecosystem-consistent design points worth calling out for review:

- **Nobody sanitizes on decode.** Every adapter that solved this did it at request-encode time and kept internal history faithful to what the model emitted. This PR does the same: sanitization is a per-request rendering of the wire body, so the canonical transcript still replays the original identifiers through providers with different grammars.
- **Deterministic re-sanitization instead of stored mappings.** Like LiteLLM's sanitizer, the functions here are pure and stable across turns and processes, so a re-encoded history always agrees with itself — including `toolUse`/`toolResult` ID pairs, which are sanitized through one shared function. The hash-suffix truncation goes a step further than any of the above to keep distinct over-length identifiers distinct (relevant for MCP-style names sharing long namespace prefixes).

Fixes #578
