### PR TITLE
Remove legacy run-creation recovery paths

### DIFF
--- a/lib/components/fabro-store/src/error.rs
+++ b/lib/components/fabro-store/src/error.rs
@@ -21,8 +21,6 @@ pub enum Error {
     },
     #[error("Run not found: {0}")]
     RunNotFound(String),
-    #[error("Run already exists: {0}")]
-    RunAlreadyExists(String),
     #[error("Session not found: {0}")]
     SessionNotFound(String),
     #[error("Session already exists: {0}")]

--- a/lib/components/fabro-store/src/slate/mod.rs
+++ b/lib/components/fabro-store/src/slate/mod.rs
@@ -146,22 +146,6 @@ impl Database {
     pub async fn create_run(&self, run_id: &RunId) -> Result<RunDatabase> {
         self.warm_projection_cache().await?;
         let db = self.open_db().await?;
-        // Keep the active-writer miss and insert atomic. Otherwise concurrent
-        // callers can create independent writers with the same recovered seq.
-        let mut active_runs = self.active_runs.lock().await;
-
-        if let Some(active) = active_run_from(&active_runs, run_id) {
-            if !active.matches_run(run_id) {
-                return Err(Error::RunAlreadyExists(run_id.to_string()));
-            }
-            self.catalog_index().await?.add(run_id).await?;
-            return Ok(active);
-        }
-
-        let run_exists = RunDatabase::has_any_events(&db, run_id).await?;
-        if run_exists {
-            return Err(Error::RunAlreadyExists(run_id.to_string()));
-        }
 
         self.catalog_index().await?.add(run_id).await?;
         let run_store = RunDatabase::open_writer(
@@ -171,6 +155,7 @@ impl Database {
             Arc::clone(&self.run_summary_store),
         )
         .await?;
+        let mut active_runs = self.active_runs.lock().await;
         Self::cache_active_run(&mut active_runs, &run_store);
         Ok(run_store)
     }

--- a/lib/components/fabro-workflow/src/operations/create.rs
+++ b/lib/components/fabro-workflow/src/operations/create.rs
@@ -522,14 +522,10 @@ async fn persist_created_run(
     web_url: Option<String>,
 ) -> Result<(), Error> {
     let record = persisted.run_spec();
-    let run_store = match store.create_run(&record.run_id).await {
-        Ok(run_store) => run_store,
-        Err(err) => store
-            .open_run(&record.run_id)
-            .await
-            .map_err(|open_err| Error::engine(open_err.to_string()))
-            .map_err(|_| Error::engine(err.to_string()))?,
-    };
+    let run_store = store
+        .create_run(&record.run_id)
+        .await
+        .map_err(|err| Error::engine_with_source("failed to create run store", err))?;
     let manifest_blob = match submitted_manifest_bytes {
         Some(bytes) => Some(run_store.write_blob(bytes).await.map_err(store_error)?),
         None => None,


### PR DESCRIPTION
## Summary

- Remove active and durable duplicate-ID handling from `Database::create_run`.
- Delete the now-unused `fabro_store::Error::RunAlreadyExists` variant.
- Remove create persistence's catch-all `open_run` fallback while preserving genuine store failures in the workflow error source chain.

## Rationale

PR #712 removed client-selected run IDs. Supported creation paths now allocate fresh server-generated ULIDs or use isolated storage, so a repeated ID is not a retry, idempotency request, or other supported workflow. This PR removes the obsolete collision policy instead of replacing it with another one.

No migration is required. A run ID selects one event-log namespace rather than allowing two durable runs with the same ID. Since PR #685, a repeated `run.created` event is rejected before commit. Any older log already containing an invalid duplicate event was already malformed and is not made newly invalid here. Intentional access to existing runs continues through `open_run` and reader APIs.

## Scope

- No OpenAPI, generated-client, HTTP-status, event-schema, fork, retry, automation, or nested-run changes.
- No idempotency, collision retry, or replacement collision error.
- No collision-specific regression tests; existing positive creation coverage remains.

## Verification

- `cargo nextest run -p fabro-store -p fabro-workflow` — 1,584 passed
- `cargo nextest run --workspace --status-level slow --profile ci` — 7,764 passed
- `cargo +nightly-2026-04-14 fmt --check --all`
- `cargo +nightly-2026-04-14 clippy --workspace --all-targets -- -D warnings`
- `cargo dev docs check`