### PR TITLE
Add Qwen3.8 Max to OpenRouter

### DIFF
--- a/lib/foundation/fabro-model/src/catalog.rs
+++ b/lib/foundation/fabro-model/src/catalog.rs
@@ -3721,6 +3721,82 @@ enabled = true
     }
 
     #[test]
+    fn builtin_openrouter_includes_qwen3_8_max_when_enabled() {
+        let catalog = Catalog::from_builtin_with_overrides(&minimal_settings(
+            r"
+[providers.openrouter]
+enabled = true
+",
+        ))
+        .expect("enabled OpenRouter override should build from the built-in provider settings");
+
+        let model = catalog
+            .get_on_provider(&ProviderId::new("openrouter"), "qwen3.8-max")
+            .expect("OpenRouter Qwen3.8 Max should be present");
+        insta::assert_debug_snapshot!(model, @r#"
+        Model {
+            id: "qwen3.8-max",
+            provider: openrouter,
+            family: "qwen3",
+            display_name: "Qwen3.8 Max",
+            limits: ModelLimits {
+                context_window: 1000000,
+                max_output: Some(
+                    131072,
+                ),
+            },
+            training: None,
+            knowledge_cutoff: None,
+            features: ModelFeatures {
+                tools: true,
+                vision: true,
+                reasoning: true,
+                reasoning_effort: Levels,
+                prompt_cache: true,
+                cache_control_breakpoints: false,
+                sampling_params: true,
+            },
+            controls: ModelControls {
+                reasoning_effort: [
+                    Low,
+                    Medium,
+                    High,
+                    XHigh,
+                ],
+            },
+            costs: ModelCosts {
+                input_cost_per_mtok: Some(
+                    2.0,
+                ),
+                output_cost_per_mtok: Some(
+                    6.0,
+                ),
+                cache_input_cost_per_mtok: Some(
+                    0.25,
+                ),
+            },
+            estimated_output_tps: None,
+            aliases: [],
+            default: false,
+            small_default: false,
+            configured: false,
+        }
+        "#);
+
+        let settings = catalog
+            .model_settings_on_provider(&ProviderId::new("openrouter"), "qwen3.8-max")
+            .expect("OpenRouter Qwen3.8 Max settings should be present");
+        assert_eq!(settings.api_id, "qwen/qwen3.8-max");
+        assert!(settings.reasoning_by_default);
+        assert_eq!(settings.controls.reasoning_effort, vec![
+            ReasoningEffort::Low,
+            ReasoningEffort::Medium,
+            ReasoningEffort::High,
+            ReasoningEffort::XHigh,
+        ]);
+    }
+
+    #[test]
     fn builtin_modal_provider_is_opt_in() {
         let modal = ProviderId::new("modal");
         let builtin = Catalog::builtin();

--- a/lib/foundation/fabro-model/src/catalog/providers/openrouter.toml
+++ b/lib/foundation/fabro-model/src/catalog/providers/openrouter.toml
@@ -595,6 +595,30 @@ reasoning = false
 input_cost_per_mtok = 0.1875
 output_cost_per_mtok = 1.125
 
+[providers.openrouter.models."qwen3.8-max"]
+api_id = "qwen/qwen3.8-max"
+display_name = "Qwen3.8 Max"
+family = "qwen3"
+
+[providers.openrouter.models."qwen3.8-max".limits]
+context_window = 1000000
+max_output = 131072
+
+[providers.openrouter.models."qwen3.8-max".features]
+tools = true
+vision = true
+reasoning = true
+reasoning_effort = "levels"
+prompt_cache = true
+
+[providers.openrouter.models."qwen3.8-max".controls]
+reasoning_effort = ["low", "medium", "high", "xhigh"]
+
+[providers.openrouter.models."qwen3.8-max".costs]
+input_cost_per_mtok = 2.0
+output_cost_per_mtok = 6.0
+cache_input_cost_per_mtok = 0.25
+
 [providers.openrouter.models."glm-5.2"]
 api_id = "z-ai/glm-5.2"
 display_name = "GLM 5.2 (via OpenRouter)"


### PR DESCRIPTION
## Summary

- add Qwen3.8 Max to the built-in OpenRouter model catalog
- record its context and output limits, multimodal and reasoning capabilities, prompt-cache pricing, and supported reasoning levels
- add a focused catalog snapshot test

## Sources

- https://qwen.ai/blog?id=qwen3.8
- https://openrouter.ai/qwen/qwen3.8-max

## Testing

- cargo +nightly-2026-04-14 fmt --check --all
- cargo nextest run -p fabro-model
- cargo +nightly-2026-04-14 clippy -p fabro-model --all-targets -- -D warnings
- git diff --check