### PR TITLE
fix(cli): raise doctor health check timeout to 1s

### DIFF
--- a/lib/apps/fabro-cli/src/server_client.rs
+++ b/lib/apps/fabro-cli/src/server_client.rs
@@ -443,7 +443,7 @@ mod tests {
 
         let target = ServerTarget::http_url(format!("http://{addr}")).unwrap();
         let client = connect_target_api_client_bundle(&target).await.unwrap();
-        let result = time::timeout(Duration::from_millis(750), client.get_health()).await;
+        let result = time::timeout(Duration::from_secs(5), client.get_health()).await;
 
         server.abort();
         assert!(

--- a/lib/foundation/fabro-client/src/client.rs
+++ b/lib/foundation/fabro-client/src/client.rs
@@ -37,7 +37,7 @@ use crate::{AuthEntry, OAuthEntry, StoredSubject, sse};
 
 const DEFAULT_CONTROL_PLANE_REQUEST_TIMEOUT: std::time::Duration =
     std::time::Duration::from_secs(30);
-const DEFAULT_HEALTH_REQUEST_TIMEOUT: std::time::Duration = std::time::Duration::from_millis(250);
+const DEFAULT_HEALTH_REQUEST_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(1);
 
 type TransportFuture = BoxFuture<'static, Result<(fabro_http::HttpClient, String)>>;
 


### PR DESCRIPTION
## What

- Raise `DEFAULT_HEALTH_REQUEST_TIMEOUT` in `fabro-client` from 250ms to 1s (the timeout `fabro doctor` uses via `Client::get_health`).
- Bump the outer guard in `http_target_transport_times_out_when_peer_accepts_without_http_response` from 750ms to 5s so it stays longer than the inner timeout it is asserting on.

## Why

250ms was too aggressive. A server that was reachable but slightly slow to answer `/health` made `fabro doctor` report a failed health check instead of a healthy server.

## Design decisions

- Only the shared client health timeout changed. The CLI's local readiness probes (`SERVER_HEALTH_PROBE_TIMEOUT`, `SERVER_START_HEALTH_PROBE_TIMEOUT`) still use 250ms — they poll loopback in a retry loop, where a short per-attempt timeout is correct.
- Not made configurable. There is no evidence yet that 1s is wrong for anyone; a flag can be added when a real case needs one.
- The test guard had to move: it wraps `get_health()` in an outer timeout and asserts the *inner* timeout is what fires. With the inner at 1s, the old 750ms guard would fire first and fail the test for the wrong reason.


🤖 Generated with [Claude Code](https://claude.com/claude-code)