### PR TITLE
Remove the unused list_blobs API from fabro-store

### DIFF
--- a/lib/components/fabro-store/src/slate/blob_store.rs
+++ b/lib/components/fabro-store/src/slate/blob_store.rs
@@ -2,11 +2,9 @@ use std::sync::Arc;
 
 use bytes::Bytes;
 use fabro_types::BlobHash;
-use futures::StreamExt;
-use tracing::warn;
 
+use crate::Result;
 use crate::record::{RawBytesCodec, Record, Repository};
-use crate::{Error, Result};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Blob(pub Bytes);
@@ -65,22 +63,6 @@ impl BlobStore {
     pub async fn exists(&self, id: &BlobHash) -> Result<bool> {
         self.repo.exists(id).await
     }
-
-    pub(crate) async fn list(&self) -> Result<Vec<BlobHash>> {
-        let mut stream = self.repo.scan_ids_stream();
-        let mut ids = Vec::new();
-        while let Some(result) = stream.next().await {
-            match result {
-                Ok(id) => ids.push(id),
-                Err(Error::KeyParse(err)) => {
-                    warn!(error = %err, "Skipping malformed blob key during listing");
-                }
-                Err(err) => return Err(err),
-            }
-        }
-        ids.sort();
-        Ok(ids)
-    }
 }
 
 #[cfg(test)]
@@ -137,35 +119,6 @@ mod tests {
         let id = store.write(b"").await.unwrap();
 
         assert_eq!(store.read(&id).await.unwrap(), Some(Bytes::new()));
-    }
-
-    #[tokio::test]
-    async fn list_returns_sorted_ids_and_handles_empty_store() {
-        let store = store().await;
-        assert!(store.list().await.unwrap().is_empty());
-
-        let first_id = store.write(br#"{"z":1}"#).await.unwrap();
-        let second_id = store.write(br#"{"a":1}"#).await.unwrap();
-        let mut expected = vec![first_id, second_id];
-        expected.sort();
-
-        assert_eq!(store.list().await.unwrap(), expected);
-    }
-
-    #[tokio::test]
-    async fn list_skips_malformed_blob_ids() {
-        let (raw_db, store) = raw_store("blob-store-list-tests").await;
-        let id = store.write(b"valid").await.unwrap();
-
-        raw_db
-            .put(
-                SlateKey::new("blobs").with("sha256").with("not-a-blob-id"),
-                b"malformed",
-            )
-            .await
-            .unwrap();
-
-        assert_eq!(store.list().await.unwrap(), vec![id]);
     }
 
     #[tokio::test]

--- a/lib/components/fabro-store/src/slate/mod.rs
+++ b/lib/components/fabro-store/src/slate/mod.rs
@@ -862,8 +862,6 @@ mod tests {
             reader.read_blob(&blob_id).await.unwrap().as_deref(),
             Some(blob.as_slice())
         );
-        assert_eq!(reader.list_blobs().await.unwrap(), vec![blob_id]);
-
         let err = reader.write_blob(b"blocked").await.unwrap_err();
         assert!(matches!(err, Error::ReadOnly));
 

--- a/lib/components/fabro-store/src/slate/run_store.rs
+++ b/lib/components/fabro-store/src/slate/run_store.rs
@@ -565,10 +565,6 @@ impl RunDatabase {
         self.inner.blob_store.read(id).await
     }
 
-    pub async fn list_blobs(&self) -> Result<Vec<BlobHash>> {
-        self.inner.blob_store.list().await
-    }
-
     pub async fn state(&self) -> Result<RunProjection> {
         Ok(Arc::unwrap_or_clone(self.projected_state().await?))
     }
@@ -895,23 +891,6 @@ mod tests {
     use serde_json::json;
 
     use crate::{Database, Error, EventPayload, keys};
-
-    #[tokio::test]
-    async fn list_blobs_reads_global_cas_namespace() {
-        let object_store = Arc::new(InMemory::new());
-        let store = Database::new(object_store, "", Duration::from_millis(1), None);
-        let run_id = "01JT56VE4Z5NZ814GZN2JZD65A".parse().unwrap();
-        let run = store.create_run(&run_id).await.unwrap();
-        let first_blob = br#"{"a":1}"#;
-        let second_blob = br#"{"b":2}"#;
-
-        let first_id = run.write_blob(first_blob).await.unwrap();
-        let second_id = run.write_blob(second_blob).await.unwrap();
-        let mut blob_ids = run.list_blobs().await.unwrap();
-        blob_ids.sort();
-
-        assert_eq!(blob_ids, vec![first_id, second_id]);
-    }
 
     fn stage_prompt_payload(run_id: &RunId, idx: u32, node_id: Option<&str>) -> EventPayload {
         stage_prompt_payload_for_stage(run_id, idx, node_id, None)


### PR DESCRIPTION
## Summary

Remove `RunDatabase::list_blobs` and `BlobStore::list` from `fabro-store`, along with their tests. Neither has a production caller.

## Background

- `list_blobs` was introduced (as the rename of `list_artifact_values`) with a real consumer: the store-dump export loop that wrote every blob into a `blobs/` directory.
- Four days later, the blob-ref redesign switched dumps to hydrating only the blob refs actually referenced by run state, and the enumeration loop was deleted. `list_blobs` has been test-only ever since.
- The semantics have also gone stale: blobs now live in one content-addressed store shared across run handles, so `run.list_blobs()` on a *per-run* handle returned every blob from every run (its own test was named `list_blobs_reads_global_cas_namespace`). Re-adding a per-run caller shaped like the old dump loop would be a bug today, so the method was a footgun as well as dead weight.
- No in-flight branch adds a caller.

`Repository::scan_ids_stream` and `Error::KeyParse` are untouched; both have other users.

## Validation

- `cargo build --workspace`
- `cargo nextest run -p fabro-store` (244 passed)
- `cargo +nightly-2026-04-14 clippy -p fabro-store --all-targets -- -D warnings`
- `cargo +nightly-2026-04-14 fmt --check --all`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
