### PR TITLE
Add bounded GitHub repository reads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2665,11 +2665,11 @@ dependencies = [
  "jsonwebtoken",
  "serde",
  "serde_json",
+ "strum 0.28.0",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
  "tracing-subscriber",
- "url",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2669,6 +2669,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "url",
 ]
 
 [[package]]

--- a/lib/apps/fabro-server/src/server/tests.rs
+++ b/lib/apps/fabro-server/src/server/tests.rs
@@ -7028,6 +7028,8 @@ async fn pr_test_app_with_completed_run(
     (state, app, run_id)
 }
 
+const COMPLETED_RUN_FINAL_SHA: &str = "0123456789abcdef0123456789abcdef01234567";
+
 async fn create_run_with_pull_request_record(
     state: &Arc<AppState>,
     run_id: RunId,
@@ -7134,7 +7136,7 @@ async fn create_completed_run_ready_for_pull_request(
             status:               "succeeded".to_string(),
             reason:               SuccessReason::Completed,
             total_usd_micros:     None,
-            final_git_commit_sha: Some("final-sha".to_string()),
+            final_git_commit_sha: Some(COMPLETED_RUN_FINAL_SHA.to_string()),
             final_patch:          Some(final_patch.to_string()),
             diff_summary:         None,
             billing:              None,
@@ -9726,11 +9728,12 @@ async fn create_run_pull_request_creates_and_persists_record() {
     let github = MockServer::start();
     let branch_mock = github.mock(|when, then| {
         when.method("GET")
-            .path("/repos/acme/widgets/branches/fabro/run/42")
+            .path("/repos/acme/widgets/commits/heads%2Ffabro%2Frun%2F42")
+            .header("accept", "application/vnd.github.sha")
             .header("authorization", "Bearer ghu_test");
         then.status(200)
-            .header("content-type", "application/json")
-            .body(json!({ "commit": { "sha": "final-sha" } }).to_string());
+            .header("content-type", "application/vnd.github.sha")
+            .body(COMPLETED_RUN_FINAL_SHA);
     });
     let create_mock = github.mock(|when, then| {
         when.method("POST")
@@ -9930,11 +9933,12 @@ async fn create_run_pull_request_persists_generation_failure() {
     let github = MockServer::start();
     let branch_mock = github.mock(|when, then| {
         when.method("GET")
-            .path("/repos/acme/widgets/branches/fabro/run/42")
+            .path("/repos/acme/widgets/commits/heads%2Ffabro%2Frun%2F42")
+            .header("accept", "application/vnd.github.sha")
             .header("authorization", "Bearer ghu_test");
         then.status(200)
-            .header("content-type", "application/json")
-            .body(json!({ "commit": { "sha": "final-sha" } }).to_string());
+            .header("content-type", "application/vnd.github.sha")
+            .body(COMPLETED_RUN_FINAL_SHA);
     });
     let find_mock = github.mock(|when, then| {
         when.method("GET")

--- a/lib/components/fabro-github/Cargo.toml
+++ b/lib/components/fabro-github/Cargo.toml
@@ -26,7 +26,7 @@ tracing.workspace = true
 tokio = { workspace = true }
 base64.workspace = true
 thiserror.workspace = true
-url.workspace = true
+strum.workspace = true
 
 [dev-dependencies]
 fabro-macros = { path = "../../foundation/fabro-macros" }

--- a/lib/components/fabro-github/Cargo.toml
+++ b/lib/components/fabro-github/Cargo.toml
@@ -26,6 +26,7 @@ tracing.workspace = true
 tokio = { workspace = true }
 base64.workspace = true
 thiserror.workspace = true
+url.workspace = true
 
 [dev-dependencies]
 fabro-macros = { path = "../../foundation/fabro-macros" }

--- a/lib/components/fabro-github/src/lib.rs
+++ b/lib/components/fabro-github/src/lib.rs
@@ -4,8 +4,8 @@ use base64::engine::general_purpose::STANDARD;
 use chrono::{DateTime, Utc};
 use fabro_redact::DisplaySafeUrl;
 use fabro_static::EnvVars;
+use fabro_types::PullRequestGithubDetail;
 use fabro_types::settings::run::MergeStrategy;
-use fabro_types::{GitHubRepositorySlug, PullRequestGithubDetail};
 use serde::Deserialize;
 use tokio::process::Command;
 
@@ -990,29 +990,6 @@ fn normalize_https_host_path(url: &str) -> String {
             format!("https://{host}/{path}")
         }
         _ => url.to_string(),
-    }
-}
-
-/// Return the commit SHA at the head of a GitHub branch.
-///
-/// Returns `None` when GitHub responds with 404. GitHub also uses 404 to hide
-/// some private resources from credentials that cannot access them, so `None`
-/// means the branch was not observable rather than proving it does not exist.
-pub async fn branch_head_sha(
-    ctx: &GitHubContext<'_>,
-    owner: &str,
-    repo: &str,
-    branch: &str,
-) -> anyhow::Result<Option<String>> {
-    let repository = GitHubRepositorySlug::try_new(&format!("{owner}/{repo}"))
-        .ok_or_else(|| anyhow!("Invalid GitHub repository coordinate"))?;
-    let reader = GitHubRepositoryReader::open(ctx, &repository)
-        .await
-        .context("Failed to read remote branch head")?;
-    match reader.resolve_commit(&format!("heads/{branch}")).await {
-        Ok(sha) => Ok(Some(sha)),
-        Err(RepositoryReadError::NotFound { .. }) => Ok(None),
-        Err(error) => Err(anyhow::Error::new(error).context("Failed to read remote branch head")),
     }
 }
 

--- a/lib/components/fabro-github/src/lib.rs
+++ b/lib/components/fabro-github/src/lib.rs
@@ -4,10 +4,14 @@ use base64::engine::general_purpose::STANDARD;
 use chrono::{DateTime, Utc};
 use fabro_redact::DisplaySafeUrl;
 use fabro_static::EnvVars;
-use fabro_types::PullRequestGithubDetail;
 use fabro_types::settings::run::MergeStrategy;
+use fabro_types::{GitHubRepositorySlug, PullRequestGithubDetail};
 use serde::Deserialize;
 use tokio::process::Command;
+
+mod repository_reader;
+
+pub use repository_reader::{GitHubRepositoryReader, RepositoryReadError};
 
 pub const GITHUB_API_BASE_URL: &str = "https://api.github.com";
 
@@ -991,61 +995,24 @@ fn normalize_https_host_path(url: &str) -> String {
 
 /// Return the commit SHA at the head of a GitHub branch.
 ///
-/// Returns `None` when the branch does not exist.
+/// Returns `None` when GitHub responds with 404. GitHub also uses 404 to hide
+/// some private resources from credentials that cannot access them, so `None`
+/// means the branch was not observable rather than proving it does not exist.
 pub async fn branch_head_sha(
     ctx: &GitHubContext<'_>,
     owner: &str,
     repo: &str,
     branch: &str,
 ) -> anyhow::Result<Option<String>> {
-    let client = ctx.http_client()?;
-    branch_head_sha_with_client(&client, ctx, owner, repo, branch).await
-}
-
-async fn branch_head_sha_with_client(
-    client: &impl HttpClient,
-    ctx: &GitHubContext<'_>,
-    owner: &str,
-    repo: &str,
-    branch: &str,
-) -> anyhow::Result<Option<String>> {
-    #[derive(Deserialize)]
-    struct BranchResponse {
-        commit: BranchCommit,
-    }
-
-    #[derive(Deserialize)]
-    struct BranchCommit {
-        sha: String,
-    }
-
-    let token = ctx
-        .creds
-        .resolve_bearer_token(
-            client,
-            owner,
-            repo,
-            ctx.base_url,
-            serde_json::json!({ "contents": "read" }),
-        )
-        .await?;
-
-    let url = format!("{}/repos/{owner}/{repo}/branches/{branch}", ctx.base_url);
-    let auth = format!("Bearer {token}");
-    let resp = client
-        .request(HttpMethod::Get, &url, &github_headers(&auth), None)
+    let repository = GitHubRepositorySlug::try_new(&format!("{owner}/{repo}"))
+        .ok_or_else(|| anyhow!("Invalid GitHub repository coordinate"))?;
+    let reader = GitHubRepositoryReader::open(ctx, &repository)
         .await
         .context("Failed to read remote branch head")?;
-
-    match resp.status {
-        200 => {
-            let branch: BranchResponse = resp
-                .json()
-                .context("Failed to parse remote branch response")?;
-            Ok(Some(branch.commit.sha))
-        }
-        404 => Ok(None),
-        status => bail!("Unexpected status {status} reading branch '{branch}'"),
+    match reader.resolve_commit(&format!("heads/{branch}")).await {
+        Ok(sha) => Ok(Some(sha)),
+        Err(RepositoryReadError::RevisionNotFound) => Ok(None),
+        Err(error) => Err(anyhow::Error::new(error).context("Failed to read remote branch head")),
     }
 }
 
@@ -2089,126 +2056,6 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(token, "ghs_pr_token");
-    }
-
-    // -----------------------------------------------------------------------
-    // branch_head_sha
-    // -----------------------------------------------------------------------
-
-    fn app_creds() -> GitHubCredentials {
-        GitHubCredentials::App(GitHubAppCredentials {
-            app_id:          "test".to_string(),
-            private_key_pem: test_rsa_key().to_string(),
-            slug:            None,
-        })
-    }
-
-    /// Mock the installation-token exchange every App-credentialed call makes
-    /// before it reaches the endpoint under test.
-    fn mock_with_installation_token() -> MockHttpClient {
-        MockHttpClient::new()
-            .on(
-                HttpMethod::Get,
-                "/repos/owner/repo/installation",
-                200,
-                r#"{"id": 1}"#,
-            )
-            .on(
-                HttpMethod::Post,
-                "/app/installations/1/access_tokens",
-                201,
-                r#"{"token": "ghs_test", "expires_at": "2099-01-01T00:00:00Z"}"#,
-            )
-    }
-
-    #[tokio::test]
-    async fn branch_head_sha_returns_commit_on_200() {
-        let mock = mock_with_installation_token().on(
-            HttpMethod::Get,
-            "/repos/owner/repo/branches/my-branch",
-            200,
-            r#"{"name": "my-branch", "commit": {"sha": "abc123"}}"#,
-        );
-
-        let creds = app_creds();
-        let result = branch_head_sha_with_client(
-            &mock,
-            &GitHubContext::new(&creds, ""),
-            "owner",
-            "repo",
-            "my-branch",
-        )
-        .await;
-
-        assert_eq!(result.unwrap(), Some("abc123".to_string()));
-    }
-
-    #[tokio::test]
-    async fn branch_head_sha_returns_none_on_404() {
-        let mock = mock_with_installation_token().on(
-            HttpMethod::Get,
-            "/repos/owner/repo/branches/no-such-branch",
-            404,
-            "",
-        );
-
-        let creds = app_creds();
-        let result = branch_head_sha_with_client(
-            &mock,
-            &GitHubContext::new(&creds, ""),
-            "owner",
-            "repo",
-            "no-such-branch",
-        )
-        .await;
-
-        assert_eq!(result.unwrap(), None);
-    }
-
-    #[tokio::test]
-    async fn branch_head_sha_returns_error_on_500() {
-        let mock = mock_with_installation_token().on(
-            HttpMethod::Get,
-            "/repos/owner/repo/branches/broken",
-            500,
-            "",
-        );
-
-        let creds = app_creds();
-        let result = branch_head_sha_with_client(
-            &mock,
-            &GitHubContext::new(&creds, ""),
-            "owner",
-            "repo",
-            "broken",
-        )
-        .await;
-
-        assert!(result.is_err());
-    }
-
-    #[tokio::test]
-    async fn branch_head_sha_with_token_uses_direct_bearer_token() {
-        let mock = MockHttpClient::new()
-            .on(
-                HttpMethod::Get,
-                "/repos/owner/repo/branches/my-branch",
-                200,
-                r#"{"name": "my-branch", "commit": {"sha": "abc123"}}"#,
-            )
-            .with_req_header("Authorization", "Bearer ghu_test");
-
-        let creds = GitHubCredentials::Pat("ghu_test".to_string());
-        let result = branch_head_sha_with_client(
-            &mock,
-            &GitHubContext::new(&creds, ""),
-            "owner",
-            "repo",
-            "my-branch",
-        )
-        .await;
-
-        assert_eq!(result.unwrap(), Some("abc123".to_string()));
     }
 
     // -----------------------------------------------------------------------

--- a/lib/components/fabro-github/src/lib.rs
+++ b/lib/components/fabro-github/src/lib.rs
@@ -11,7 +11,7 @@ use tokio::process::Command;
 
 mod repository_reader;
 
-pub use repository_reader::{GitHubRepositoryReader, RepositoryReadError};
+pub use repository_reader::{GitHubRepositoryReader, Operation, RepositoryReadError};
 
 pub const GITHUB_API_BASE_URL: &str = "https://api.github.com";
 
@@ -1011,7 +1011,7 @@ pub async fn branch_head_sha(
         .context("Failed to read remote branch head")?;
     match reader.resolve_commit(&format!("heads/{branch}")).await {
         Ok(sha) => Ok(Some(sha)),
-        Err(RepositoryReadError::RevisionNotFound) => Ok(None),
+        Err(RepositoryReadError::NotFound { .. }) => Ok(None),
         Err(error) => Err(anyhow::Error::new(error).context("Failed to read remote branch head")),
     }
 }

--- a/lib/components/fabro-github/src/repository_reader.rs
+++ b/lib/components/fabro-github/src/repository_reader.rs
@@ -1,10 +1,6 @@
-#![expect(
-    clippy::disallowed_types,
-    reason = "Validated URL values are used only for request construction and are never logged or included in errors."
-)]
-
 use fabro_http::header::{ACCEPT, CONTENT_TYPE, RETRY_AFTER, USER_AGENT};
-use fabro_http::{HeaderMap, HttpClient, Response, StatusCode, Url};
+use fabro_http::{HeaderMap, HttpClient, Response, StatusCode};
+use fabro_redact::{DisplaySafeUrl, DisplaySafeUrlError};
 use fabro_types::{GitHubRepositorySlug, repository};
 
 use crate::GitHubContext;
@@ -13,14 +9,24 @@ const SHA_MEDIA_TYPE: &str = "application/vnd.github.sha";
 const RAW_CONTENT_MEDIA_TYPE: &str = "application/vnd.github.raw+json";
 const MAX_SHA_RESPONSE_BYTES: usize = 128;
 
+/// Which repository read a failure came from. Carried on the errors that can
+/// arise from either, so one status classification serves both.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, strum::Display)]
+#[strum(serialize_all = "lowercase")]
+pub enum Operation {
+    Revision,
+    Content,
+}
+
 /// Failures while opening or using a repository-scoped GitHub reader.
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum RepositoryReadError {
     #[error("invalid GitHub API base URL ({reason})")]
     InvalidApiBaseUrl {
         reason: &'static str,
         #[source]
-        source: Option<url::ParseError>,
+        source: Option<DisplaySafeUrlError>,
     },
     #[error("invalid GitHub ref selector")]
     InvalidRefSelector,
@@ -44,28 +50,26 @@ pub enum RepositoryReadError {
     PermissionDenied,
     #[error("GitHub rate limit reached (status {status})")]
     RateLimited { status: u16 },
-    /// GitHub returned 404 while resolving a revision. GitHub may also use
-    /// 404 to hide a private resource that these credentials cannot access.
-    #[error("GitHub revision was not observable")]
-    RevisionNotFound,
-    /// GitHub returned 404 while reading content. GitHub may also use 404 to
-    /// hide a private resource that these credentials cannot access.
-    #[error("GitHub repository content was not observable")]
-    ContentNotFound,
+    /// GitHub returned 404. GitHub may also use 404 to hide a private resource
+    /// that these credentials cannot access, so this means "not observable"
+    /// rather than "does not exist".
+    #[error("GitHub {operation} was not observable")]
+    NotFound { operation: Operation },
     #[error("GitHub repository content is not a file")]
     ContentNotFile,
-    #[error("GitHub revision is unavailable (status {status})")]
-    RevisionUnavailable { status: u16 },
-    #[error("GitHub repository content is unavailable (status {status})")]
-    ContentUnavailable { status: u16 },
+    #[error("GitHub {operation} is unavailable (status {status})")]
+    Unavailable {
+        operation: Operation,
+        status:    u16,
+    },
     #[error("GitHub {operation} service is unavailable (status {status})")]
     UpstreamUnavailable {
-        operation: &'static str,
+        operation: Operation,
         status:    u16,
     },
     #[error("unexpected GitHub {operation} status {status}")]
     UnexpectedStatus {
-        operation: &'static str,
+        operation: Operation,
         status:    u16,
     },
     #[error("GitHub response exceeded the {max_bytes}-byte limit")]
@@ -80,26 +84,13 @@ pub enum RepositoryReadError {
 }
 
 /// An authenticated read session scoped to one GitHub repository.
+///
+/// Opening resolves credentials once; every read reuses that token.
 pub struct GitHubRepositoryReader {
-    client:       HttpClient,
-    api_base:     Url,
-    repository:   GitHubRepositorySlug,
-    bearer_token: String,
-}
-
-#[derive(Clone, Copy)]
-enum Operation {
-    Revision,
-    Content,
-}
-
-impl Operation {
-    const fn name(self) -> &'static str {
-        match self {
-            Self::Revision => "revision lookup",
-            Self::Content => "content read",
-        }
-    }
+    client:          HttpClient,
+    /// `{api_base}/repos/{owner}/{repo}`, validated and built once at open.
+    repository_base: DisplaySafeUrl,
+    bearer_token:    String,
 }
 
 impl GitHubRepositoryReader {
@@ -111,14 +102,14 @@ impl GitHubRepositoryReader {
         let client = ctx
             .http_client()
             .map_err(|source| RepositoryReadError::RequestTransport { source })?;
-        let (api_base, normalized_base) = parse_api_base(ctx.base_url)?;
+        let api_base = parse_api_base(ctx.base_url)?;
         let bearer_token = ctx
             .creds
             .resolve_bearer_token(
                 &client,
                 repository.owner(),
                 repository.repo(),
-                &normalized_base,
+                api_base.as_str().trim_end_matches('/'),
                 serde_json::json!({ "contents": "read" }),
             )
             .await
@@ -126,8 +117,7 @@ impl GitHubRepositoryReader {
 
         Ok(Self {
             client,
-            api_base,
-            repository: repository.clone(),
+            repository_base: repository_base(&api_base, repository),
             bearer_token,
         })
     }
@@ -138,19 +128,9 @@ impl GitHubRepositoryReader {
             return Err(RepositoryReadError::InvalidRefSelector);
         }
 
-        let url = commit_url(&self.api_base, &self.repository, selector)?;
         let response = self
-            .client
-            .get(url)
-            .bearer_auth(&self.bearer_token)
-            .header(USER_AGENT, "fabro")
-            .header(ACCEPT, SHA_MEDIA_TYPE)
-            .send()
-            .await
-            .map_err(|source| RepositoryReadError::RequestTransport {
-                source: anyhow::Error::new(source.without_url()),
-            })?;
-
+            .send(&self.commit_url(selector), SHA_MEDIA_TYPE)
+            .await?;
         classify_status(response.status(), response.headers(), Operation::Revision)?;
         let bytes = collect_bounded(response, MAX_SHA_RESPONSE_BYTES).await?;
         parse_resolved_commit_sha(bytes)
@@ -168,24 +148,8 @@ impl GitHubRepositoryReader {
         }
         validate_repository_path(canonical_repo_path)?;
 
-        let url = content_url(
-            &self.api_base,
-            &self.repository,
-            commit_sha,
-            canonical_repo_path,
-        )?;
-        let response = self
-            .client
-            .get(url)
-            .bearer_auth(&self.bearer_token)
-            .header(USER_AGENT, "fabro")
-            .header(ACCEPT, RAW_CONTENT_MEDIA_TYPE)
-            .send()
-            .await
-            .map_err(|source| RepositoryReadError::RequestTransport {
-                source: anyhow::Error::new(source.without_url()),
-            })?;
-
+        let url = self.content_url(commit_sha, canonical_repo_path);
+        let response = self.send(&url, RAW_CONTENT_MEDIA_TYPE).await?;
         classify_status(response.status(), response.headers(), Operation::Content)?;
         if !has_raw_content_media_type(response.headers()) {
             return Err(RepositoryReadError::ContentNotFile);
@@ -195,14 +159,61 @@ impl GitHubRepositoryReader {
             source: source.utf8_error(),
         })
     }
+
+    /// `{repository_base}/commits/{selector}`, with the selector's slashes
+    /// escaped so a `heads/a/b` ref stays one path segment.
+    fn commit_url(&self, selector: &str) -> DisplaySafeUrl {
+        let mut url = self.repository_base.clone();
+        url.path_segments_mut()
+            .expect("repository base is a hierarchical URL")
+            .push("commits")
+            .push(selector);
+        url
+    }
+
+    /// `{repository_base}/contents/{path}?ref={commit_sha}`, with each path
+    /// component escaped individually so separators survive as separators.
+    fn content_url(&self, commit_sha: &str, path: &str) -> DisplaySafeUrl {
+        let mut url = self.repository_base.clone();
+        {
+            let mut segments = url
+                .path_segments_mut()
+                .expect("repository base is a hierarchical URL");
+            segments.push("contents");
+            for component in path.split('/') {
+                segments.push(component);
+            }
+        }
+        url.query_pairs_mut().append_pair("ref", commit_sha);
+        url
+    }
+
+    /// Issues one authenticated GET asking for exactly `media_type`.
+    async fn send(
+        &self,
+        url: &DisplaySafeUrl,
+        media_type: &str,
+    ) -> Result<Response, RepositoryReadError> {
+        self.client
+            .get(url.raw_string())
+            .bearer_auth(&self.bearer_token)
+            .header(USER_AGENT, "fabro")
+            .header(ACCEPT, media_type)
+            .send()
+            .await
+            .map_err(|source| RepositoryReadError::RequestTransport {
+                source: anyhow::Error::new(source.without_url()),
+            })
+    }
 }
 
-fn parse_api_base(base_url: &str) -> Result<(Url, String), RepositoryReadError> {
-    let mut url =
-        Url::parse(base_url).map_err(|source| RepositoryReadError::InvalidApiBaseUrl {
+fn parse_api_base(base_url: &str) -> Result<DisplaySafeUrl, RepositoryReadError> {
+    let mut url = DisplaySafeUrl::parse(base_url).map_err(|source| {
+        RepositoryReadError::InvalidApiBaseUrl {
             reason: "parse",
             source: Some(source),
-        })?;
+        }
+    })?;
     if url.cannot_be_a_base() {
         return Err(invalid_base("cannot be a base"));
     }
@@ -222,14 +233,10 @@ fn parse_api_base(base_url: &str) -> Result<(Url, String), RepositoryReadError> 
         return Err(invalid_base("fragment"));
     }
 
-    let mut segments = url
-        .path_segments_mut()
-        .map_err(|()| invalid_base("cannot be a base"))?;
-    segments.pop_if_empty();
-    drop(segments);
-
-    let normalized = url.as_str().trim_end_matches('/').to_string();
-    Ok((url, normalized))
+    url.path_segments_mut()
+        .map_err(|()| invalid_base("cannot be a base"))?
+        .pop_if_empty();
+    Ok(url)
 }
 
 const fn invalid_base(reason: &'static str) -> RepositoryReadError {
@@ -239,62 +246,30 @@ const fn invalid_base(reason: &'static str) -> RepositoryReadError {
     }
 }
 
-fn commit_url(
-    base: &Url,
-    repository: &GitHubRepositorySlug,
-    selector: &str,
-) -> Result<Url, RepositoryReadError> {
-    let mut url = base.clone();
-    let mut segments = url
-        .path_segments_mut()
-        .map_err(|()| invalid_base("cannot be a base"))?;
-    segments
+/// `{api_base}/repos/{owner}/{repo}`, the prefix every read extends.
+///
+/// Infallible: `parse_api_base` has already rejected cannot-be-a-base URLs.
+fn repository_base(api_base: &DisplaySafeUrl, repository: &GitHubRepositorySlug) -> DisplaySafeUrl {
+    let mut url = api_base.clone();
+    url.path_segments_mut()
+        .expect("api base is a hierarchical URL")
         .pop_if_empty()
         .push("repos")
         .push(repository.owner())
-        .push(repository.repo())
-        .push("commits")
-        .push(selector);
-    drop(segments);
-    Ok(url)
-}
-
-fn content_url(
-    base: &Url,
-    repository: &GitHubRepositorySlug,
-    commit_sha: &str,
-    path: &str,
-) -> Result<Url, RepositoryReadError> {
-    let mut url = base.clone();
-    let mut segments = url
-        .path_segments_mut()
-        .map_err(|()| invalid_base("cannot be a base"))?;
-    segments
-        .pop_if_empty()
-        .push("repos")
-        .push(repository.owner())
-        .push(repository.repo())
-        .push("contents");
-    for component in path.split('/') {
-        segments.push(component);
-    }
-    drop(segments);
-    url.query_pairs_mut().append_pair("ref", commit_sha);
-    Ok(url)
+        .push(repository.repo());
+    url
 }
 
 fn is_exact_commit_sha(bytes: &[u8]) -> bool {
     bytes.len() == 40 && bytes.iter().all(u8::is_ascii_hexdigit)
 }
 
-fn parse_resolved_commit_sha(bytes: Vec<u8>) -> Result<String, RepositoryReadError> {
+fn parse_resolved_commit_sha(mut bytes: Vec<u8>) -> Result<String, RepositoryReadError> {
     if !is_exact_commit_sha(&bytes) {
         return Err(RepositoryReadError::MalformedCommitSha);
     }
-    Ok(bytes
-        .into_iter()
-        .map(|byte| char::from(byte.to_ascii_lowercase()))
-        .collect())
+    bytes.make_ascii_lowercase();
+    String::from_utf8(bytes).map_err(|_| RepositoryReadError::MalformedCommitSha)
 }
 
 fn validate_repository_path(path: &str) -> Result<(), RepositoryReadError> {
@@ -343,31 +318,32 @@ fn classify_status(
         return Ok(());
     }
 
-    let code = status.as_u16();
-    match status {
-        StatusCode::UNAUTHORIZED => Err(RepositoryReadError::AuthenticationRejected),
-        StatusCode::FORBIDDEN if is_rate_limited(headers) => {
-            Err(RepositoryReadError::RateLimited { status: code })
+    let status_code = status.as_u16();
+    Err(match status {
+        StatusCode::UNAUTHORIZED => RepositoryReadError::AuthenticationRejected,
+        StatusCode::FORBIDDEN if is_rate_limited(headers) => RepositoryReadError::RateLimited {
+            status: status_code,
+        },
+        StatusCode::FORBIDDEN => RepositoryReadError::PermissionDenied,
+        StatusCode::TOO_MANY_REQUESTS => RepositoryReadError::RateLimited {
+            status: status_code,
+        },
+        StatusCode::NOT_FOUND => RepositoryReadError::NotFound { operation },
+        StatusCode::CONFLICT | StatusCode::UNPROCESSABLE_ENTITY => {
+            RepositoryReadError::Unavailable {
+                operation,
+                status: status_code,
+            }
         }
-        StatusCode::FORBIDDEN => Err(RepositoryReadError::PermissionDenied),
-        StatusCode::TOO_MANY_REQUESTS => Err(RepositoryReadError::RateLimited { status: code }),
-        StatusCode::NOT_FOUND => match operation {
-            Operation::Revision => Err(RepositoryReadError::RevisionNotFound),
-            Operation::Content => Err(RepositoryReadError::ContentNotFound),
+        status if status.is_server_error() => RepositoryReadError::UpstreamUnavailable {
+            operation,
+            status: status_code,
         },
-        StatusCode::CONFLICT | StatusCode::UNPROCESSABLE_ENTITY => match operation {
-            Operation::Revision => Err(RepositoryReadError::RevisionUnavailable { status: code }),
-            Operation::Content => Err(RepositoryReadError::ContentUnavailable { status: code }),
+        _ => RepositoryReadError::UnexpectedStatus {
+            operation,
+            status: status_code,
         },
-        status if status.is_server_error() => Err(RepositoryReadError::UpstreamUnavailable {
-            operation: operation.name(),
-            status:    code,
-        }),
-        _ => Err(RepositoryReadError::UnexpectedStatus {
-            operation: operation.name(),
-            status:    code,
-        }),
-    }
+    })
 }
 
 fn is_rate_limited(headers: &HeaderMap) -> bool {
@@ -400,14 +376,18 @@ async fn collect_bounded(
     mut response: Response,
     max_bytes: usize,
 ) -> Result<Vec<u8>, RepositoryReadError> {
-    if response
-        .content_length()
-        .is_some_and(|length| length > max_bytes as u64)
-    {
-        return Err(RepositoryReadError::BodyTooLarge { max_bytes });
-    }
+    // A declared length over the cap fails before any body is read; otherwise it
+    // sizes the buffer exactly. Chunked responses start empty and grow under the
+    // same bound, enforced per chunk below.
+    let capacity = match response.content_length() {
+        Some(length) => usize::try_from(length)
+            .ok()
+            .filter(|length| *length <= max_bytes)
+            .ok_or(RepositoryReadError::BodyTooLarge { max_bytes })?,
+        None => 0,
+    };
 
-    let mut bytes = Vec::new();
+    let mut bytes = Vec::with_capacity(capacity);
     while let Some(chunk) =
         response
             .chunk()
@@ -436,13 +416,19 @@ mod tests {
 
     #[test]
     fn api_base_preserves_prefix_and_normalizes_trailing_slash() {
-        let (base, normalized) = parse_api_base("https://ghe.example/api/v3/").unwrap();
+        let base = parse_api_base("https://ghe.example/api/v3/").unwrap();
         assert_eq!(base.as_str(), "https://ghe.example/api/v3");
-        assert_eq!(normalized, "https://ghe.example/api/v3");
+        assert_eq!(
+            base.as_str().trim_end_matches('/'),
+            "https://ghe.example/api/v3"
+        );
 
-        let (root, normalized) = parse_api_base("https://api.github.com/").unwrap();
+        let root = parse_api_base("https://api.github.com/").unwrap();
         assert_eq!(root.as_str(), "https://api.github.com/");
-        assert_eq!(normalized, "https://api.github.com");
+        assert_eq!(
+            root.as_str().trim_end_matches('/'),
+            "https://api.github.com"
+        );
     }
 
     #[test]
@@ -480,16 +466,26 @@ mod tests {
         assert!(error.source().is_some());
     }
 
+    /// Builds the URL a read would request without issuing it.
+    fn reader_at(base_url: &str) -> GitHubRepositoryReader {
+        let api_base = parse_api_base(base_url).unwrap();
+        GitHubRepositoryReader {
+            client:          fabro_http::test_http_client().unwrap(),
+            repository_base: repository_base(&api_base, &repository()),
+            bearer_token:    "sentinel-token".to_string(),
+        }
+    }
+
     #[test]
     fn url_builders_encode_selectors_and_paths_once() {
-        let (base, _) = parse_api_base("https://ghe.example/api/v3").unwrap();
-        let commit = commit_url(&base, &repository(), "heads/fabro/run/123").unwrap();
+        let reader = reader_at("https://ghe.example/api/v3");
+        let commit = reader.commit_url("heads/fabro/run/123");
         assert_eq!(
             commit.as_str(),
             "https://ghe.example/api/v3/repos/owner/repo/commits/heads%2Ffabro%2Frun%2F123"
         );
 
-        let content = content_url(&base, &repository(), SHA, "dir/a b/%2F/#?é.toml").unwrap();
+        let content = reader.content_url(SHA, "dir/a b/%2F/#?é.toml");
         assert_eq!(
             content.as_str(),
             "https://ghe.example/api/v3/repos/owner/repo/contents/dir/a%20b/%252F/%23%3F%C3%A9.toml?ref=0123456789abcdef0123456789abcdef01234567"
@@ -498,12 +494,7 @@ mod tests {
 
     #[tokio::test]
     async fn method_inputs_are_rejected_before_network_access() {
-        let reader = GitHubRepositoryReader {
-            client:       fabro_http::test_http_client().unwrap(),
-            api_base:     Url::parse("http://127.0.0.1:1").unwrap(),
-            repository:   repository(),
-            bearer_token: "sentinel-token".to_string(),
-        };
+        let reader = reader_at("http://127.0.0.1:1");
 
         for invalid in ["", " main", "heads//main", "tags/v1.lock"] {
             assert!(matches!(
@@ -519,10 +510,15 @@ mod tests {
 
     #[test]
     fn canonical_ref_selectors_reach_url_construction() {
-        let (base, _) = parse_api_base("https://api.github.com").unwrap();
+        let reader = reader_at("https://api.github.com");
         for selector in ["main", "heads/fabro/run/123", "tags/v1.0.0", SHA] {
             assert!(repository::is_valid_github_ref_selector(selector));
-            assert!(commit_url(&base, &repository(), selector).is_ok());
+            assert!(
+                reader
+                    .commit_url(selector)
+                    .as_str()
+                    .starts_with("https://api.github.com/repos/owner/repo/commits/")
+            );
         }
     }
 
@@ -610,11 +606,15 @@ mod tests {
         ));
         assert!(matches!(
             classify_status(StatusCode::NOT_FOUND, &empty, Operation::Revision),
-            Err(RepositoryReadError::RevisionNotFound)
+            Err(RepositoryReadError::NotFound {
+                operation: Operation::Revision,
+            })
         ));
         assert!(matches!(
             classify_status(StatusCode::NOT_FOUND, &empty, Operation::Content),
-            Err(RepositoryReadError::ContentNotFound)
+            Err(RepositoryReadError::NotFound {
+                operation: Operation::Content,
+            })
         ));
         assert!(matches!(
             classify_status(StatusCode::FORBIDDEN, &empty, Operation::Content),
@@ -638,44 +638,31 @@ mod tests {
             classify_status(StatusCode::TOO_MANY_REQUESTS, &empty, Operation::Content),
             Err(RepositoryReadError::RateLimited { status: 429 })
         ));
-        for operation in [Operation::Revision, Operation::Content] {
-            let conflict = classify_status(StatusCode::CONFLICT, &empty, operation);
-            let unprocessable =
-                classify_status(StatusCode::UNPROCESSABLE_ENTITY, &empty, operation);
-            match operation {
-                Operation::Revision => {
-                    assert!(matches!(
-                        conflict,
-                        Err(RepositoryReadError::RevisionUnavailable { status: 409 })
-                    ));
-                    assert!(matches!(
-                        unprocessable,
-                        Err(RepositoryReadError::RevisionUnavailable { status: 422 })
-                    ));
-                }
-                Operation::Content => {
-                    assert!(matches!(
-                        conflict,
-                        Err(RepositoryReadError::ContentUnavailable { status: 409 })
-                    ));
-                    assert!(matches!(
-                        unprocessable,
-                        Err(RepositoryReadError::ContentUnavailable { status: 422 })
-                    ));
-                }
-            }
-        }
+        assert!(matches!(
+            classify_status(StatusCode::CONFLICT, &empty, Operation::Revision),
+            Err(RepositoryReadError::Unavailable {
+                operation: Operation::Revision,
+                status:    409,
+            })
+        ));
+        assert!(matches!(
+            classify_status(StatusCode::UNPROCESSABLE_ENTITY, &empty, Operation::Content),
+            Err(RepositoryReadError::Unavailable {
+                operation: Operation::Content,
+                status:    422,
+            })
+        ));
         assert!(matches!(
             classify_status(StatusCode::BAD_GATEWAY, &empty, Operation::Content),
             Err(RepositoryReadError::UpstreamUnavailable {
-                operation: "content read",
+                operation: Operation::Content,
                 status:    502,
             })
         ));
         assert!(matches!(
             classify_status(StatusCode::IM_A_TEAPOT, &empty, Operation::Revision),
             Err(RepositoryReadError::UnexpectedStatus {
-                operation: "revision lookup",
+                operation: Operation::Revision,
                 status:    418,
             })
         ));

--- a/lib/components/fabro-github/src/repository_reader.rs
+++ b/lib/components/fabro-github/src/repository_reader.rs
@@ -1,0 +1,725 @@
+#![expect(
+    clippy::disallowed_types,
+    reason = "Validated URL values are used only for request construction and are never logged or included in errors."
+)]
+
+use fabro_http::header::{ACCEPT, CONTENT_TYPE, RETRY_AFTER, USER_AGENT};
+use fabro_http::{HeaderMap, HttpClient, Response, StatusCode, Url};
+use fabro_types::{GitHubRepositorySlug, repository};
+
+use crate::GitHubContext;
+
+const SHA_MEDIA_TYPE: &str = "application/vnd.github.sha";
+const RAW_CONTENT_MEDIA_TYPE: &str = "application/vnd.github.raw+json";
+const MAX_SHA_RESPONSE_BYTES: usize = 128;
+
+/// Failures while opening or using a repository-scoped GitHub reader.
+#[derive(Debug, thiserror::Error)]
+pub enum RepositoryReadError {
+    #[error("invalid GitHub API base URL ({reason})")]
+    InvalidApiBaseUrl {
+        reason: &'static str,
+        #[source]
+        source: Option<url::ParseError>,
+    },
+    #[error("invalid GitHub ref selector")]
+    InvalidRefSelector,
+    #[error("invalid Git commit SHA")]
+    InvalidCommitSha,
+    #[error("invalid repository path ({reason})")]
+    InvalidRepositoryPath { reason: &'static str },
+    #[error("failed to resolve GitHub repository credentials")]
+    CredentialResolution {
+        #[source]
+        source: anyhow::Error,
+    },
+    #[error("GitHub repository request failed")]
+    RequestTransport {
+        #[source]
+        source: anyhow::Error,
+    },
+    #[error("GitHub authentication was rejected")]
+    AuthenticationRejected,
+    #[error("GitHub repository permission was denied")]
+    PermissionDenied,
+    #[error("GitHub rate limit reached (status {status})")]
+    RateLimited { status: u16 },
+    /// GitHub returned 404 while resolving a revision. GitHub may also use
+    /// 404 to hide a private resource that these credentials cannot access.
+    #[error("GitHub revision was not observable")]
+    RevisionNotFound,
+    /// GitHub returned 404 while reading content. GitHub may also use 404 to
+    /// hide a private resource that these credentials cannot access.
+    #[error("GitHub repository content was not observable")]
+    ContentNotFound,
+    #[error("GitHub repository content is not a file")]
+    ContentNotFile,
+    #[error("GitHub revision is unavailable (status {status})")]
+    RevisionUnavailable { status: u16 },
+    #[error("GitHub repository content is unavailable (status {status})")]
+    ContentUnavailable { status: u16 },
+    #[error("GitHub {operation} service is unavailable (status {status})")]
+    UpstreamUnavailable {
+        operation: &'static str,
+        status:    u16,
+    },
+    #[error("unexpected GitHub {operation} status {status}")]
+    UnexpectedStatus {
+        operation: &'static str,
+        status:    u16,
+    },
+    #[error("GitHub response exceeded the {max_bytes}-byte limit")]
+    BodyTooLarge { max_bytes: usize },
+    #[error("GitHub returned a malformed commit SHA")]
+    MalformedCommitSha,
+    #[error("GitHub repository content is not valid UTF-8")]
+    InvalidUtf8 {
+        #[source]
+        source: std::str::Utf8Error,
+    },
+}
+
+/// An authenticated read session scoped to one GitHub repository.
+pub struct GitHubRepositoryReader {
+    client:       HttpClient,
+    api_base:     Url,
+    repository:   GitHubRepositorySlug,
+    bearer_token: String,
+}
+
+#[derive(Clone, Copy)]
+enum Operation {
+    Revision,
+    Content,
+}
+
+impl Operation {
+    const fn name(self) -> &'static str {
+        match self {
+            Self::Revision => "revision lookup",
+            Self::Content => "content read",
+        }
+    }
+}
+
+impl GitHubRepositoryReader {
+    /// Opens an authenticated read session for one repository.
+    pub async fn open(
+        ctx: &GitHubContext<'_>,
+        repository: &GitHubRepositorySlug,
+    ) -> Result<Self, RepositoryReadError> {
+        let client = ctx
+            .http_client()
+            .map_err(|source| RepositoryReadError::RequestTransport { source })?;
+        let (api_base, normalized_base) = parse_api_base(ctx.base_url)?;
+        let bearer_token = ctx
+            .creds
+            .resolve_bearer_token(
+                &client,
+                repository.owner(),
+                repository.repo(),
+                &normalized_base,
+                serde_json::json!({ "contents": "read" }),
+            )
+            .await
+            .map_err(|source| RepositoryReadError::CredentialResolution { source })?;
+
+        Ok(Self {
+            client,
+            api_base,
+            repository: repository.clone(),
+            bearer_token,
+        })
+    }
+
+    /// Resolves a validated ref selector to an exact lowercase commit SHA.
+    pub async fn resolve_commit(&self, selector: &str) -> Result<String, RepositoryReadError> {
+        if !repository::is_valid_github_ref_selector(selector) {
+            return Err(RepositoryReadError::InvalidRefSelector);
+        }
+
+        let url = commit_url(&self.api_base, &self.repository, selector)?;
+        let response = self
+            .client
+            .get(url)
+            .bearer_auth(&self.bearer_token)
+            .header(USER_AGENT, "fabro")
+            .header(ACCEPT, SHA_MEDIA_TYPE)
+            .send()
+            .await
+            .map_err(|source| RepositoryReadError::RequestTransport {
+                source: anyhow::Error::new(source.without_url()),
+            })?;
+
+        classify_status(response.status(), response.headers(), Operation::Revision)?;
+        let bytes = collect_bounded(response, MAX_SHA_RESPONSE_BYTES).await?;
+        parse_resolved_commit_sha(bytes)
+    }
+
+    /// Reads one UTF-8 file at an explicitly supplied exact commit SHA.
+    pub async fn read_utf8_file_at(
+        &self,
+        commit_sha: &str,
+        canonical_repo_path: &str,
+        max_bytes: usize,
+    ) -> Result<String, RepositoryReadError> {
+        if !is_exact_commit_sha(commit_sha.as_bytes()) {
+            return Err(RepositoryReadError::InvalidCommitSha);
+        }
+        validate_repository_path(canonical_repo_path)?;
+
+        let url = content_url(
+            &self.api_base,
+            &self.repository,
+            commit_sha,
+            canonical_repo_path,
+        )?;
+        let response = self
+            .client
+            .get(url)
+            .bearer_auth(&self.bearer_token)
+            .header(USER_AGENT, "fabro")
+            .header(ACCEPT, RAW_CONTENT_MEDIA_TYPE)
+            .send()
+            .await
+            .map_err(|source| RepositoryReadError::RequestTransport {
+                source: anyhow::Error::new(source.without_url()),
+            })?;
+
+        classify_status(response.status(), response.headers(), Operation::Content)?;
+        if !has_raw_content_media_type(response.headers()) {
+            return Err(RepositoryReadError::ContentNotFile);
+        }
+        let bytes = collect_bounded(response, max_bytes).await?;
+        String::from_utf8(bytes).map_err(|source| RepositoryReadError::InvalidUtf8 {
+            source: source.utf8_error(),
+        })
+    }
+}
+
+fn parse_api_base(base_url: &str) -> Result<(Url, String), RepositoryReadError> {
+    let mut url =
+        Url::parse(base_url).map_err(|source| RepositoryReadError::InvalidApiBaseUrl {
+            reason: "parse",
+            source: Some(source),
+        })?;
+    if url.cannot_be_a_base() {
+        return Err(invalid_base("cannot be a base"));
+    }
+    if url.host_str().is_none() {
+        return Err(invalid_base("host"));
+    }
+    if !matches!(url.scheme(), "http" | "https") {
+        return Err(invalid_base("scheme"));
+    }
+    if !url.username().is_empty() || url.password().is_some() {
+        return Err(invalid_base("credentials"));
+    }
+    if url.query().is_some() {
+        return Err(invalid_base("query"));
+    }
+    if url.fragment().is_some() {
+        return Err(invalid_base("fragment"));
+    }
+
+    let mut segments = url
+        .path_segments_mut()
+        .map_err(|()| invalid_base("cannot be a base"))?;
+    segments.pop_if_empty();
+    drop(segments);
+
+    let normalized = url.as_str().trim_end_matches('/').to_string();
+    Ok((url, normalized))
+}
+
+const fn invalid_base(reason: &'static str) -> RepositoryReadError {
+    RepositoryReadError::InvalidApiBaseUrl {
+        reason,
+        source: None,
+    }
+}
+
+fn commit_url(
+    base: &Url,
+    repository: &GitHubRepositorySlug,
+    selector: &str,
+) -> Result<Url, RepositoryReadError> {
+    let mut url = base.clone();
+    let mut segments = url
+        .path_segments_mut()
+        .map_err(|()| invalid_base("cannot be a base"))?;
+    segments
+        .pop_if_empty()
+        .push("repos")
+        .push(repository.owner())
+        .push(repository.repo())
+        .push("commits")
+        .push(selector);
+    drop(segments);
+    Ok(url)
+}
+
+fn content_url(
+    base: &Url,
+    repository: &GitHubRepositorySlug,
+    commit_sha: &str,
+    path: &str,
+) -> Result<Url, RepositoryReadError> {
+    let mut url = base.clone();
+    let mut segments = url
+        .path_segments_mut()
+        .map_err(|()| invalid_base("cannot be a base"))?;
+    segments
+        .pop_if_empty()
+        .push("repos")
+        .push(repository.owner())
+        .push(repository.repo())
+        .push("contents");
+    for component in path.split('/') {
+        segments.push(component);
+    }
+    drop(segments);
+    url.query_pairs_mut().append_pair("ref", commit_sha);
+    Ok(url)
+}
+
+fn is_exact_commit_sha(bytes: &[u8]) -> bool {
+    bytes.len() == 40 && bytes.iter().all(u8::is_ascii_hexdigit)
+}
+
+fn parse_resolved_commit_sha(bytes: Vec<u8>) -> Result<String, RepositoryReadError> {
+    if !is_exact_commit_sha(&bytes) {
+        return Err(RepositoryReadError::MalformedCommitSha);
+    }
+    Ok(bytes
+        .into_iter()
+        .map(|byte| char::from(byte.to_ascii_lowercase()))
+        .collect())
+}
+
+fn validate_repository_path(path: &str) -> Result<(), RepositoryReadError> {
+    if path.is_empty() {
+        return Err(invalid_path("empty"));
+    }
+    if path.len() > 4096 {
+        return Err(invalid_path("too long"));
+    }
+    if path.split('/').count() > 256 {
+        return Err(invalid_path("too many components"));
+    }
+    let bytes = path.as_bytes();
+    let windows_drive = bytes.len() >= 2 && bytes[0].is_ascii_alphabetic() && bytes[1] == b':';
+    if path.starts_with(['/', '~']) || windows_drive {
+        return Err(invalid_path("absolute"));
+    }
+    if path.contains('\\') {
+        return Err(invalid_path("backslash"));
+    }
+    if path.chars().any(char::is_control) {
+        return Err(invalid_path("control character"));
+    }
+    if path.ends_with('/') || path.contains("//") {
+        return Err(invalid_path("empty component"));
+    }
+    if path
+        .split('/')
+        .any(|component| matches!(component, "." | ".."))
+    {
+        return Err(invalid_path("dot segment"));
+    }
+    Ok(())
+}
+
+const fn invalid_path(reason: &'static str) -> RepositoryReadError {
+    RepositoryReadError::InvalidRepositoryPath { reason }
+}
+
+fn classify_status(
+    status: StatusCode,
+    headers: &HeaderMap,
+    operation: Operation,
+) -> Result<(), RepositoryReadError> {
+    if status == StatusCode::OK {
+        return Ok(());
+    }
+
+    let code = status.as_u16();
+    match status {
+        StatusCode::UNAUTHORIZED => Err(RepositoryReadError::AuthenticationRejected),
+        StatusCode::FORBIDDEN if is_rate_limited(headers) => {
+            Err(RepositoryReadError::RateLimited { status: code })
+        }
+        StatusCode::FORBIDDEN => Err(RepositoryReadError::PermissionDenied),
+        StatusCode::TOO_MANY_REQUESTS => Err(RepositoryReadError::RateLimited { status: code }),
+        StatusCode::NOT_FOUND => match operation {
+            Operation::Revision => Err(RepositoryReadError::RevisionNotFound),
+            Operation::Content => Err(RepositoryReadError::ContentNotFound),
+        },
+        StatusCode::CONFLICT | StatusCode::UNPROCESSABLE_ENTITY => match operation {
+            Operation::Revision => Err(RepositoryReadError::RevisionUnavailable { status: code }),
+            Operation::Content => Err(RepositoryReadError::ContentUnavailable { status: code }),
+        },
+        status if status.is_server_error() => Err(RepositoryReadError::UpstreamUnavailable {
+            operation: operation.name(),
+            status:    code,
+        }),
+        _ => Err(RepositoryReadError::UnexpectedStatus {
+            operation: operation.name(),
+            status:    code,
+        }),
+    }
+}
+
+fn is_rate_limited(headers: &HeaderMap) -> bool {
+    headers
+        .get("x-ratelimit-remaining")
+        .is_some_and(|value| value.as_bytes() == b"0")
+        || headers.contains_key(RETRY_AFTER)
+}
+
+fn has_raw_content_media_type(headers: &HeaderMap) -> bool {
+    headers
+        .get(CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.split(';').next())
+        .is_some_and(|value| value.trim().eq_ignore_ascii_case(RAW_CONTENT_MEDIA_TYPE))
+}
+
+fn checked_body_len(
+    current: usize,
+    chunk: usize,
+    max_bytes: usize,
+) -> Result<usize, RepositoryReadError> {
+    current
+        .checked_add(chunk)
+        .filter(|length| *length <= max_bytes)
+        .ok_or(RepositoryReadError::BodyTooLarge { max_bytes })
+}
+
+async fn collect_bounded(
+    mut response: Response,
+    max_bytes: usize,
+) -> Result<Vec<u8>, RepositoryReadError> {
+    if response
+        .content_length()
+        .is_some_and(|length| length > max_bytes as u64)
+    {
+        return Err(RepositoryReadError::BodyTooLarge { max_bytes });
+    }
+
+    let mut bytes = Vec::new();
+    while let Some(chunk) =
+        response
+            .chunk()
+            .await
+            .map_err(|source| RepositoryReadError::RequestTransport {
+                source: anyhow::Error::new(source.without_url()),
+            })?
+    {
+        checked_body_len(bytes.len(), chunk.len(), max_bytes)?;
+        bytes.extend_from_slice(&chunk);
+    }
+    Ok(bytes)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::error::Error as _;
+
+    use super::*;
+
+    const SHA: &str = "0123456789abcdef0123456789abcdef01234567";
+
+    fn repository() -> GitHubRepositorySlug {
+        GitHubRepositorySlug::try_new("owner/repo").unwrap()
+    }
+
+    #[test]
+    fn api_base_preserves_prefix_and_normalizes_trailing_slash() {
+        let (base, normalized) = parse_api_base("https://ghe.example/api/v3/").unwrap();
+        assert_eq!(base.as_str(), "https://ghe.example/api/v3");
+        assert_eq!(normalized, "https://ghe.example/api/v3");
+
+        let (root, normalized) = parse_api_base("https://api.github.com/").unwrap();
+        assert_eq!(root.as_str(), "https://api.github.com/");
+        assert_eq!(normalized, "https://api.github.com");
+    }
+
+    #[test]
+    fn api_base_rejects_unsafe_shapes_without_echoing_input() {
+        let cases = [
+            ("ftp://example.test/api", "scheme"),
+            ("mailto:test@example.test", "cannot be a base"),
+            ("file:///api", "host"),
+            ("https://user:password@example.test/api", "credentials"),
+            ("https://example.test/api?token=sentinel", "query"),
+            ("https://example.test/api#sentinel", "fragment"),
+        ];
+        for (input, reason) in cases {
+            let error = parse_api_base(input).unwrap_err();
+            assert!(matches!(
+                error,
+                RepositoryReadError::InvalidApiBaseUrl {
+                    reason: actual,
+                    source: None,
+                } if actual == reason
+            ));
+            assert!(!format!("{error}").contains(input));
+            assert!(!format!("{error:?}").contains(input));
+            assert!(error.source().is_none());
+        }
+    }
+
+    #[test]
+    fn syntactically_invalid_api_base_preserves_parse_source() {
+        let error = parse_api_base("not an absolute URL").unwrap_err();
+        assert!(matches!(error, RepositoryReadError::InvalidApiBaseUrl {
+            reason: "parse",
+            source: Some(_),
+        }));
+        assert!(error.source().is_some());
+    }
+
+    #[test]
+    fn url_builders_encode_selectors_and_paths_once() {
+        let (base, _) = parse_api_base("https://ghe.example/api/v3").unwrap();
+        let commit = commit_url(&base, &repository(), "heads/fabro/run/123").unwrap();
+        assert_eq!(
+            commit.as_str(),
+            "https://ghe.example/api/v3/repos/owner/repo/commits/heads%2Ffabro%2Frun%2F123"
+        );
+
+        let content = content_url(&base, &repository(), SHA, "dir/a b/%2F/#?é.toml").unwrap();
+        assert_eq!(
+            content.as_str(),
+            "https://ghe.example/api/v3/repos/owner/repo/contents/dir/a%20b/%252F/%23%3F%C3%A9.toml?ref=0123456789abcdef0123456789abcdef01234567"
+        );
+    }
+
+    #[tokio::test]
+    async fn method_inputs_are_rejected_before_network_access() {
+        let reader = GitHubRepositoryReader {
+            client:       fabro_http::test_http_client().unwrap(),
+            api_base:     Url::parse("http://127.0.0.1:1").unwrap(),
+            repository:   repository(),
+            bearer_token: "sentinel-token".to_string(),
+        };
+
+        for invalid in ["", " main", "heads//main", "tags/v1.lock"] {
+            assert!(matches!(
+                reader.resolve_commit(invalid).await,
+                Err(RepositoryReadError::InvalidRefSelector)
+            ));
+        }
+        assert!(matches!(
+            reader.read_utf8_file_at("not-a-sha", "../bad", 1).await,
+            Err(RepositoryReadError::InvalidCommitSha)
+        ));
+    }
+
+    #[test]
+    fn canonical_ref_selectors_reach_url_construction() {
+        let (base, _) = parse_api_base("https://api.github.com").unwrap();
+        for selector in ["main", "heads/fabro/run/123", "tags/v1.0.0", SHA] {
+            assert!(repository::is_valid_github_ref_selector(selector));
+            assert!(commit_url(&base, &repository(), selector).is_ok());
+        }
+    }
+
+    #[test]
+    fn repository_path_validation_enforces_boundaries() {
+        assert!(validate_repository_path("a b/%/é.toml").is_ok());
+        assert!(validate_repository_path(&"a".repeat(4096)).is_ok());
+        assert!(validate_repository_path(&vec!["a"; 256].join("/")).is_ok());
+
+        let too_many = vec!["a"; 257].join("/");
+        let cases = [
+            ("", "empty"),
+            ("/a", "absolute"),
+            ("~a", "absolute"),
+            ("C:/a", "absolute"),
+            ("a\\b", "backslash"),
+            ("a\nb", "control character"),
+            ("a/", "empty component"),
+            ("a//b", "empty component"),
+            ("a/./b", "dot segment"),
+            ("a/../b", "dot segment"),
+            (&too_many, "too many components"),
+        ];
+        for (path, reason) in cases {
+            assert!(matches!(
+                validate_repository_path(path),
+                Err(RepositoryReadError::InvalidRepositoryPath { reason: actual })
+                    if actual == reason
+            ));
+        }
+        assert!(matches!(
+            validate_repository_path(&"a".repeat(4097)),
+            Err(RepositoryReadError::InvalidRepositoryPath { reason: "too long" })
+        ));
+    }
+
+    #[test]
+    fn commit_sha_validation_is_exact() {
+        assert!(is_exact_commit_sha(SHA.as_bytes()));
+        assert!(is_exact_commit_sha(SHA.to_ascii_uppercase().as_bytes()));
+        for invalid in [
+            &SHA[..39],
+            "0123456789abcdef0123456789abcdef012345678",
+            "g123456789abcdef0123456789abcdef01234567",
+            " 123456789abcdef0123456789abcdef01234567",
+        ] {
+            assert!(!is_exact_commit_sha(invalid.as_bytes()));
+        }
+    }
+
+    #[test]
+    fn resolved_commit_sha_is_exact_and_normalized() {
+        assert_eq!(
+            parse_resolved_commit_sha(SHA.as_bytes().to_vec()).unwrap(),
+            SHA
+        );
+        assert_eq!(
+            parse_resolved_commit_sha(SHA.to_ascii_uppercase().into_bytes()).unwrap(),
+            SHA
+        );
+        let mut newline = SHA.as_bytes().to_vec();
+        newline.push(b'\n');
+        for invalid in [
+            SHA.as_bytes()[..39].to_vec(),
+            b"0123456789abcdef0123456789abcdef012345678".to_vec(),
+            b"g123456789abcdef0123456789abcdef01234567".to_vec(),
+            b" 123456789abcdef0123456789abcdef01234567".to_vec(),
+            format!("\"{SHA}\"").into_bytes(),
+            newline,
+            format!("{SHA}suffix").into_bytes(),
+        ] {
+            assert!(matches!(
+                parse_resolved_commit_sha(invalid),
+                Err(RepositoryReadError::MalformedCommitSha)
+            ));
+        }
+    }
+
+    #[test]
+    fn status_classification_keeps_operations_and_rate_limits_distinct() {
+        let empty = HeaderMap::new();
+        assert!(matches!(
+            classify_status(StatusCode::UNAUTHORIZED, &empty, Operation::Revision),
+            Err(RepositoryReadError::AuthenticationRejected)
+        ));
+        assert!(matches!(
+            classify_status(StatusCode::NOT_FOUND, &empty, Operation::Revision),
+            Err(RepositoryReadError::RevisionNotFound)
+        ));
+        assert!(matches!(
+            classify_status(StatusCode::NOT_FOUND, &empty, Operation::Content),
+            Err(RepositoryReadError::ContentNotFound)
+        ));
+        assert!(matches!(
+            classify_status(StatusCode::FORBIDDEN, &empty, Operation::Content),
+            Err(RepositoryReadError::PermissionDenied)
+        ));
+
+        let mut remaining = HeaderMap::new();
+        remaining.insert("x-ratelimit-remaining", "0".parse().unwrap());
+        assert!(matches!(
+            classify_status(StatusCode::FORBIDDEN, &remaining, Operation::Content),
+            Err(RepositoryReadError::RateLimited { status: 403 })
+        ));
+
+        let mut retry_after = HeaderMap::new();
+        retry_after.insert(RETRY_AFTER, "60".parse().unwrap());
+        assert!(matches!(
+            classify_status(StatusCode::FORBIDDEN, &retry_after, Operation::Content),
+            Err(RepositoryReadError::RateLimited { status: 403 })
+        ));
+        assert!(matches!(
+            classify_status(StatusCode::TOO_MANY_REQUESTS, &empty, Operation::Content),
+            Err(RepositoryReadError::RateLimited { status: 429 })
+        ));
+        for operation in [Operation::Revision, Operation::Content] {
+            let conflict = classify_status(StatusCode::CONFLICT, &empty, operation);
+            let unprocessable =
+                classify_status(StatusCode::UNPROCESSABLE_ENTITY, &empty, operation);
+            match operation {
+                Operation::Revision => {
+                    assert!(matches!(
+                        conflict,
+                        Err(RepositoryReadError::RevisionUnavailable { status: 409 })
+                    ));
+                    assert!(matches!(
+                        unprocessable,
+                        Err(RepositoryReadError::RevisionUnavailable { status: 422 })
+                    ));
+                }
+                Operation::Content => {
+                    assert!(matches!(
+                        conflict,
+                        Err(RepositoryReadError::ContentUnavailable { status: 409 })
+                    ));
+                    assert!(matches!(
+                        unprocessable,
+                        Err(RepositoryReadError::ContentUnavailable { status: 422 })
+                    ));
+                }
+            }
+        }
+        assert!(matches!(
+            classify_status(StatusCode::BAD_GATEWAY, &empty, Operation::Content),
+            Err(RepositoryReadError::UpstreamUnavailable {
+                operation: "content read",
+                status:    502,
+            })
+        ));
+        assert!(matches!(
+            classify_status(StatusCode::IM_A_TEAPOT, &empty, Operation::Revision),
+            Err(RepositoryReadError::UnexpectedStatus {
+                operation: "revision lookup",
+                status:    418,
+            })
+        ));
+    }
+
+    #[test]
+    fn raw_content_media_type_ignores_case_and_parameters() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            CONTENT_TYPE,
+            "Application/Vnd.Github.Raw+Json; charset=utf-8"
+                .parse()
+                .unwrap(),
+        );
+        assert!(has_raw_content_media_type(&headers));
+        headers.insert(CONTENT_TYPE, "application/json".parse().unwrap());
+        assert!(!has_raw_content_media_type(&headers));
+    }
+
+    #[test]
+    fn body_length_check_is_inclusive_and_overflow_safe() {
+        assert_eq!(checked_body_len(2, 3, 5).unwrap(), 5);
+        assert!(matches!(
+            checked_body_len(2, 4, 5),
+            Err(RepositoryReadError::BodyTooLarge { max_bytes: 5 })
+        ));
+        assert!(matches!(
+            checked_body_len(usize::MAX, 1, usize::MAX),
+            Err(RepositoryReadError::BodyTooLarge {
+                max_bytes: usize::MAX,
+            })
+        ));
+    }
+
+    #[test]
+    fn invalid_utf8_source_does_not_own_repository_bytes() {
+        let sentinel = b"private-file-contents";
+        let mut bytes = sentinel.to_vec();
+        bytes.push(0xff);
+        let source = String::from_utf8(bytes).unwrap_err().utf8_error();
+        let error = RepositoryReadError::InvalidUtf8 { source };
+        assert!(error.source().is_some());
+        let rendered = format!("{error:?}");
+        assert!(!rendered.contains("private-file-contents"));
+        assert!(!format!("{:?}", error.source()).contains("private-file-contents"));
+    }
+}

--- a/lib/components/fabro-github/tests/integration.rs
+++ b/lib/components/fabro-github/tests/integration.rs
@@ -1,12 +1,19 @@
+use std::error::Error as _;
+
 use fabro_github::{
-    GitHubAppCredentials, GitHubContext, GitHubCredentials, close_pull_request,
+    GitHubAppCredentials, GitHubContext, GitHubCredentials, GitHubRepositoryReader,
+    InstallationToken, RepositoryReadError, branch_head_sha, close_pull_request,
     create_installation_access_token_for_pr, create_pull_request, enable_auto_merge,
     get_pull_request, merge_pull_request, resolve_authenticated_url, sign_app_jwt,
 };
 use fabro_test::{GitHubAppOptions, GitHubAppState, TwinGitHub};
+use fabro_types::GitHubRepositorySlug;
 use fabro_types::settings::run::MergeStrategy;
 
 const TEST_RSA_KEY: &str = include_str!("../src/testdata/rsa_private.pem");
+const HEAD_SHA: &str = "1111111111111111111111111111111111111111";
+const TAG_SHA: &str = "2222222222222222222222222222222222222222";
+const UPPER_SHA: &str = "ABCDEFABCDEFABCDEFABCDEFABCDEFABCDEFABCD";
 
 fn github_credentials() -> GitHubCredentials {
     GitHubCredentials::App(GitHubAppCredentials {
@@ -33,7 +40,46 @@ fn standard_app_state() -> GitHubAppState {
         vec!["main".into(), "feature".into()],
         false,
     );
+    state.set_repository_ref("acme", "widgets", "heads/main", HEAD_SHA);
+    state.set_repository_ref("acme", "widgets", "heads/release", HEAD_SHA);
+    state.set_repository_ref("acme", "widgets", "tags/release", TAG_SHA);
+    state.set_repository_ref("acme", "widgets", "heads/fabro/run/123", HEAD_SHA);
+    state.set_repository_ref("acme", "widgets", "heads/uppercase", UPPER_SHA);
+    state.add_repository_file(
+        "acme",
+        "widgets",
+        HEAD_SHA,
+        ".fabro/workflows/build/workflow.toml",
+        b"name = \"build\"\n".to_vec(),
+    );
+    state.add_repository_file(
+        "acme",
+        "widgets",
+        HEAD_SHA,
+        "dir/hello world#.txt",
+        b"hello\n".to_vec(),
+    );
+    state.add_repository_file("acme", "widgets", HEAD_SHA, "invalid.txt", vec![0xff, 0xfe]);
+    state.add_repository_file("acme", "widgets", HEAD_SHA, "empty.txt", Vec::new());
+    state.add_repository_file(
+        "acme",
+        "widgets",
+        HEAD_SHA,
+        "five-bytes.txt",
+        b"12345".to_vec(),
+    );
+    state.add_repository_file(
+        "acme",
+        "widgets",
+        HEAD_SHA,
+        "nested/a b/%/é.toml",
+        "unicode: 🦀\n".as_bytes().to_vec(),
+    );
     state
+}
+
+fn repository() -> GitHubRepositorySlug {
+    GitHubRepositorySlug::try_new("acme/widgets").expect("test repository slug should be valid")
 }
 
 #[fabro_macros::e2e_test(twin)]
@@ -223,6 +269,313 @@ async fn resolve_authenticated_url_errors_on_non_github_url() {
     .unwrap_err();
 
     assert!(error.to_string().contains("Not a GitHub HTTPS URL"));
+
+    twin.shutdown().await;
+}
+
+#[fabro_macros::e2e_test(twin)]
+async fn repository_reader_reuses_one_app_token_for_ref_and_file_reads() {
+    let twin = TwinGitHub::start(standard_app_state()).await;
+    assert_eq!(twin.active_token_count().await, 0);
+    let creds = github_credentials();
+    let base_url = format!("{}/", twin.base_url);
+    let reader = GitHubRepositoryReader::open(
+        &GitHubContext::with_http_client(&creds, &base_url, fabro_test::test_http_client()),
+        &repository(),
+    )
+    .await
+    .unwrap();
+    assert_eq!(twin.active_token_count().await, 1);
+
+    assert_eq!(reader.resolve_commit("heads/main").await.unwrap(), HEAD_SHA);
+    assert_eq!(
+        reader
+            .read_utf8_file_at(HEAD_SHA, ".fabro/workflows/build/workflow.toml", 1024)
+            .await
+            .unwrap(),
+        "name = \"build\"\n"
+    );
+    assert_eq!(
+        reader
+            .read_utf8_file_at(HEAD_SHA, "dir/hello world#.txt", 1024)
+            .await
+            .unwrap(),
+        "hello\n"
+    );
+    let unicode_contents = "unicode: 🦀\n";
+    assert_eq!(
+        reader
+            .read_utf8_file_at(HEAD_SHA, "nested/a b/%/é.toml", unicode_contents.len(),)
+            .await
+            .unwrap(),
+        unicode_contents
+    );
+    assert!(matches!(
+        reader
+            .read_utf8_file_at(HEAD_SHA, "nested/a b/%/é.toml", unicode_contents.len() - 1,)
+            .await,
+        Err(RepositoryReadError::BodyTooLarge { .. })
+    ));
+    assert_eq!(twin.active_token_count().await, 1);
+
+    twin.shutdown().await;
+}
+
+#[fabro_macros::e2e_test(twin)]
+async fn repository_reader_preserves_exact_ref_namespaces() {
+    let twin = TwinGitHub::start(standard_app_state()).await;
+    let creds = github_credentials();
+    let reader = GitHubRepositoryReader::open(
+        &GitHubContext::with_http_client(&creds, &twin.base_url, fabro_test::test_http_client()),
+        &repository(),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(
+        reader.resolve_commit("heads/release").await.unwrap(),
+        HEAD_SHA
+    );
+    assert_eq!(
+        reader.resolve_commit("tags/release").await.unwrap(),
+        TAG_SHA
+    );
+    assert_eq!(
+        reader.resolve_commit("heads/fabro/run/123").await.unwrap(),
+        HEAD_SHA
+    );
+    assert_eq!(reader.resolve_commit(HEAD_SHA).await.unwrap(), HEAD_SHA);
+    assert_eq!(
+        reader.resolve_commit("heads/uppercase").await.unwrap(),
+        UPPER_SHA.to_ascii_lowercase()
+    );
+    assert!(matches!(
+        reader.resolve_commit("heads/missing").await,
+        Err(RepositoryReadError::RevisionNotFound)
+    ));
+
+    twin.shutdown().await;
+}
+
+#[fabro_macros::e2e_test(twin)]
+async fn repository_reader_classifies_file_failures_without_retaining_bytes() {
+    let twin = TwinGitHub::start(standard_app_state()).await;
+    let creds = github_credentials();
+    let reader = GitHubRepositoryReader::open(
+        &GitHubContext::with_http_client(&creds, &twin.base_url, fabro_test::test_http_client()),
+        &repository(),
+    )
+    .await
+    .unwrap();
+
+    assert!(matches!(
+        reader
+            .read_utf8_file_at(HEAD_SHA, ".fabro/workflows/build/workflow.toml", 4)
+            .await,
+        Err(RepositoryReadError::BodyTooLarge { max_bytes: 4 })
+    ));
+    let error = reader
+        .read_utf8_file_at(HEAD_SHA, "invalid.txt", 16)
+        .await
+        .unwrap_err();
+    assert!(matches!(error, RepositoryReadError::InvalidUtf8 { .. }));
+    assert!(
+        error
+            .source()
+            .and_then(|source| source.downcast_ref::<std::str::Utf8Error>())
+            .is_some()
+    );
+    assert!(!format!("{error:?}").contains("255"));
+    let directory_error = reader
+        .read_utf8_file_at(HEAD_SHA, "dir", 1024)
+        .await
+        .unwrap_err();
+    assert!(matches!(
+        directory_error,
+        RepositoryReadError::ContentNotFile
+    ));
+    assert!(!format!("{directory_error:?}").contains("[]"));
+    assert!(matches!(
+        reader
+            .read_utf8_file_at(HEAD_SHA, "missing.txt", 1024)
+            .await,
+        Err(RepositoryReadError::ContentNotFound)
+    ));
+    assert_eq!(
+        reader
+            .read_utf8_file_at(HEAD_SHA, "five-bytes.txt", 5)
+            .await
+            .unwrap(),
+        "12345"
+    );
+    assert!(matches!(
+        reader
+            .read_utf8_file_at(HEAD_SHA, "five-bytes.txt", 4)
+            .await,
+        Err(RepositoryReadError::BodyTooLarge { max_bytes: 4 })
+    ));
+    assert_eq!(
+        reader
+            .read_utf8_file_at(HEAD_SHA, "empty.txt", 0)
+            .await
+            .unwrap(),
+        ""
+    );
+
+    twin.shutdown().await;
+}
+
+#[fabro_macros::e2e_test(twin)]
+async fn static_repository_credentials_do_not_mint_tokens() {
+    let mut state = standard_app_state();
+    let static_token = state.generate_access_token(
+        "42",
+        1,
+        vec!["widgets".to_string()],
+        serde_json::json!({ "contents": "read" }),
+    );
+    let twin = TwinGitHub::start(state).await;
+    let initial_tokens = twin.active_token_count().await;
+
+    for credentials in [
+        GitHubCredentials::Pat(static_token.clone()),
+        GitHubCredentials::Installation(InstallationToken {
+            token:      static_token.clone(),
+            expires_at: chrono::Utc::now() + chrono::Duration::hours(1),
+        }),
+    ] {
+        let reader = GitHubRepositoryReader::open(
+            &GitHubContext::with_http_client(
+                &credentials,
+                &twin.base_url,
+                fabro_test::test_http_client(),
+            ),
+            &repository(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(reader.resolve_commit("heads/main").await.unwrap(), HEAD_SHA);
+        assert_eq!(
+            reader
+                .read_utf8_file_at(HEAD_SHA, "five-bytes.txt", 5)
+                .await
+                .unwrap(),
+            "12345"
+        );
+    }
+
+    assert_eq!(twin.active_token_count().await, initial_tokens);
+    twin.shutdown().await;
+}
+
+#[fabro_macros::e2e_test(twin)]
+async fn expired_installation_token_keeps_credential_error_source() {
+    let twin = TwinGitHub::start(standard_app_state()).await;
+    let credentials = GitHubCredentials::Installation(InstallationToken {
+        token:      "ghs_expired".to_string(),
+        expires_at: chrono::Utc::now() - chrono::Duration::minutes(1),
+    });
+
+    let error = GitHubRepositoryReader::open(
+        &GitHubContext::with_http_client(
+            &credentials,
+            &twin.base_url,
+            fabro_test::test_http_client(),
+        ),
+        &repository(),
+    )
+    .await
+    .err()
+    .expect("expired installation token should fail");
+    let RepositoryReadError::CredentialResolution { source } = error else {
+        panic!("expected credential resolution error");
+    };
+    assert!(source.to_string().contains("expired"));
+
+    twin.shutdown().await;
+}
+
+#[fabro_macros::e2e_test(twin)]
+async fn branch_head_compatibility_wrapper_uses_repository_reader() {
+    let twin = TwinGitHub::start(standard_app_state()).await;
+    let credentials = github_credentials();
+    let context = GitHubContext::with_http_client(
+        &credentials,
+        &twin.base_url,
+        fabro_test::test_http_client(),
+    );
+
+    assert_eq!(
+        branch_head_sha(&context, "acme", "widgets", "release")
+            .await
+            .unwrap(),
+        Some(HEAD_SHA.to_string())
+    );
+    assert_eq!(
+        branch_head_sha(&context, "acme", "widgets", "missing")
+            .await
+            .unwrap(),
+        None
+    );
+
+    twin.shutdown().await;
+}
+
+#[fabro_macros::e2e_test(twin)]
+async fn repository_reader_keeps_auth_and_malformed_sha_failures_distinct() {
+    let mut state = standard_app_state();
+    state.set_repository_ref("acme", "widgets", "heads/malformed", "short-sha");
+    let denied_token =
+        state.generate_access_token("42", 1, vec!["widgets".to_string()], serde_json::json!({}));
+    let twin = TwinGitHub::start(state).await;
+
+    let invalid_credentials = GitHubCredentials::Pat("invalid-token".to_string());
+    let invalid_reader = GitHubRepositoryReader::open(
+        &GitHubContext::with_http_client(
+            &invalid_credentials,
+            &twin.base_url,
+            fabro_test::test_http_client(),
+        ),
+        &repository(),
+    )
+    .await
+    .unwrap();
+    assert!(matches!(
+        invalid_reader.resolve_commit("heads/main").await,
+        Err(RepositoryReadError::AuthenticationRejected)
+    ));
+
+    let denied_credentials = GitHubCredentials::Pat(denied_token);
+    let denied_reader = GitHubRepositoryReader::open(
+        &GitHubContext::with_http_client(
+            &denied_credentials,
+            &twin.base_url,
+            fabro_test::test_http_client(),
+        ),
+        &repository(),
+    )
+    .await
+    .unwrap();
+    assert!(matches!(
+        denied_reader.resolve_commit("heads/main").await,
+        Err(RepositoryReadError::PermissionDenied)
+    ));
+
+    let app_credentials = github_credentials();
+    let app_reader = GitHubRepositoryReader::open(
+        &GitHubContext::with_http_client(
+            &app_credentials,
+            &twin.base_url,
+            fabro_test::test_http_client(),
+        ),
+        &repository(),
+    )
+    .await
+    .unwrap();
+    assert!(matches!(
+        app_reader.resolve_commit("heads/malformed").await,
+        Err(RepositoryReadError::MalformedCommitSha)
+    ));
 
     twin.shutdown().await;
 }

--- a/lib/components/fabro-github/tests/integration.rs
+++ b/lib/components/fabro-github/tests/integration.rs
@@ -2,7 +2,7 @@ use std::error::Error as _;
 
 use fabro_github::{
     GitHubAppCredentials, GitHubContext, GitHubCredentials, GitHubRepositoryReader,
-    InstallationToken, RepositoryReadError, branch_head_sha, close_pull_request,
+    InstallationToken, RepositoryReadError, close_pull_request,
     create_installation_access_token_for_pr, create_pull_request, enable_auto_merge,
     get_pull_request, merge_pull_request, resolve_authenticated_url, sign_app_jwt,
 };
@@ -464,27 +464,23 @@ async fn expired_installation_token_keeps_credential_error_source() {
 }
 
 #[fabro_macros::e2e_test(twin)]
-async fn branch_head_compatibility_wrapper_uses_repository_reader() {
+async fn branch_head_resolution_distinguishes_missing_from_present() {
     let twin = TwinGitHub::start(standard_app_state()).await;
     let credentials = github_credentials();
-    let context = GitHubContext::with_http_client(
-        &credentials,
-        &twin.base_url,
-        fabro_test::test_http_client(),
-    );
+    let reader = open_reader(&twin.base_url, &credentials).await.unwrap();
 
     assert_eq!(
-        branch_head_sha(&context, "acme", "widgets", "release")
-            .await
-            .unwrap(),
-        Some(HEAD_SHA.to_string())
+        reader.resolve_commit("heads/release").await.unwrap(),
+        HEAD_SHA
     );
-    assert_eq!(
-        branch_head_sha(&context, "acme", "widgets", "missing")
-            .await
-            .unwrap(),
-        None
-    );
+    // GitHub answers an absent branch with 404, which the reader reports as
+    // "not observable" rather than proving the branch does not exist.
+    assert!(matches!(
+        reader.resolve_commit("heads/missing").await,
+        Err(RepositoryReadError::NotFound {
+            operation: fabro_github::Operation::Revision,
+        })
+    ));
 
     twin.shutdown().await;
 }

--- a/lib/components/fabro-github/tests/integration.rs
+++ b/lib/components/fabro-github/tests/integration.rs
@@ -45,41 +45,36 @@ fn standard_app_state() -> GitHubAppState {
     state.set_repository_ref("acme", "widgets", "tags/release", TAG_SHA);
     state.set_repository_ref("acme", "widgets", "heads/fabro/run/123", HEAD_SHA);
     state.set_repository_ref("acme", "widgets", "heads/uppercase", UPPER_SHA);
-    state.add_repository_file(
-        "acme",
-        "widgets",
-        HEAD_SHA,
-        ".fabro/workflows/build/workflow.toml",
-        b"name = \"build\"\n".to_vec(),
-    );
-    state.add_repository_file(
-        "acme",
-        "widgets",
-        HEAD_SHA,
-        "dir/hello world#.txt",
-        b"hello\n".to_vec(),
-    );
-    state.add_repository_file("acme", "widgets", HEAD_SHA, "invalid.txt", vec![0xff, 0xfe]);
-    state.add_repository_file("acme", "widgets", HEAD_SHA, "empty.txt", Vec::new());
-    state.add_repository_file(
-        "acme",
-        "widgets",
-        HEAD_SHA,
-        "five-bytes.txt",
-        b"12345".to_vec(),
-    );
-    state.add_repository_file(
-        "acme",
-        "widgets",
-        HEAD_SHA,
-        "nested/a b/%/é.toml",
-        "unicode: 🦀\n".as_bytes().to_vec(),
-    );
+    for (path, contents) in [
+        (
+            ".fabro/workflows/build/workflow.toml",
+            b"name = \"build\"\n".to_vec(),
+        ),
+        ("dir/hello world#.txt", b"hello\n".to_vec()),
+        ("invalid.txt", vec![0xff, 0xfe]),
+        ("empty.txt", Vec::new()),
+        ("five-bytes.txt", b"12345".to_vec()),
+        ("nested/a b/%/é.toml", "unicode: 🦀\n".as_bytes().to_vec()),
+    ] {
+        state.add_repository_file("acme", "widgets", HEAD_SHA, path, contents);
+    }
     state
 }
 
 fn repository() -> GitHubRepositorySlug {
     GitHubRepositorySlug::try_new("acme/widgets").expect("test repository slug should be valid")
+}
+
+/// Open a reader for the standard repository against `base_url`.
+async fn open_reader(
+    base_url: &str,
+    credentials: &GitHubCredentials,
+) -> Result<GitHubRepositoryReader, RepositoryReadError> {
+    GitHubRepositoryReader::open(
+        &GitHubContext::with_http_client(credentials, base_url, fabro_test::test_http_client()),
+        &repository(),
+    )
+    .await
 }
 
 #[fabro_macros::e2e_test(twin)]
@@ -279,12 +274,7 @@ async fn repository_reader_reuses_one_app_token_for_ref_and_file_reads() {
     assert_eq!(twin.active_token_count().await, 0);
     let creds = github_credentials();
     let base_url = format!("{}/", twin.base_url);
-    let reader = GitHubRepositoryReader::open(
-        &GitHubContext::with_http_client(&creds, &base_url, fabro_test::test_http_client()),
-        &repository(),
-    )
-    .await
-    .unwrap();
+    let reader = open_reader(&base_url, &creds).await.unwrap();
     assert_eq!(twin.active_token_count().await, 1);
 
     assert_eq!(reader.resolve_commit("heads/main").await.unwrap(), HEAD_SHA);
@@ -325,12 +315,7 @@ async fn repository_reader_reuses_one_app_token_for_ref_and_file_reads() {
 async fn repository_reader_preserves_exact_ref_namespaces() {
     let twin = TwinGitHub::start(standard_app_state()).await;
     let creds = github_credentials();
-    let reader = GitHubRepositoryReader::open(
-        &GitHubContext::with_http_client(&creds, &twin.base_url, fabro_test::test_http_client()),
-        &repository(),
-    )
-    .await
-    .unwrap();
+    let reader = open_reader(&twin.base_url, &creds).await.unwrap();
 
     assert_eq!(
         reader.resolve_commit("heads/release").await.unwrap(),
@@ -351,7 +336,9 @@ async fn repository_reader_preserves_exact_ref_namespaces() {
     );
     assert!(matches!(
         reader.resolve_commit("heads/missing").await,
-        Err(RepositoryReadError::RevisionNotFound)
+        Err(RepositoryReadError::NotFound {
+            operation: fabro_github::Operation::Revision,
+        })
     ));
 
     twin.shutdown().await;
@@ -361,12 +348,7 @@ async fn repository_reader_preserves_exact_ref_namespaces() {
 async fn repository_reader_classifies_file_failures_without_retaining_bytes() {
     let twin = TwinGitHub::start(standard_app_state()).await;
     let creds = github_credentials();
-    let reader = GitHubRepositoryReader::open(
-        &GitHubContext::with_http_client(&creds, &twin.base_url, fabro_test::test_http_client()),
-        &repository(),
-    )
-    .await
-    .unwrap();
+    let reader = open_reader(&twin.base_url, &creds).await.unwrap();
 
     assert!(matches!(
         reader
@@ -399,7 +381,9 @@ async fn repository_reader_classifies_file_failures_without_retaining_bytes() {
         reader
             .read_utf8_file_at(HEAD_SHA, "missing.txt", 1024)
             .await,
-        Err(RepositoryReadError::ContentNotFound)
+        Err(RepositoryReadError::NotFound {
+            operation: fabro_github::Operation::Content,
+        })
     ));
     assert_eq!(
         reader
@@ -444,16 +428,7 @@ async fn static_repository_credentials_do_not_mint_tokens() {
             expires_at: chrono::Utc::now() + chrono::Duration::hours(1),
         }),
     ] {
-        let reader = GitHubRepositoryReader::open(
-            &GitHubContext::with_http_client(
-                &credentials,
-                &twin.base_url,
-                fabro_test::test_http_client(),
-            ),
-            &repository(),
-        )
-        .await
-        .unwrap();
+        let reader = open_reader(&twin.base_url, &credentials).await.unwrap();
         assert_eq!(reader.resolve_commit("heads/main").await.unwrap(), HEAD_SHA);
         assert_eq!(
             reader
@@ -476,17 +451,10 @@ async fn expired_installation_token_keeps_credential_error_source() {
         expires_at: chrono::Utc::now() - chrono::Duration::minutes(1),
     });
 
-    let error = GitHubRepositoryReader::open(
-        &GitHubContext::with_http_client(
-            &credentials,
-            &twin.base_url,
-            fabro_test::test_http_client(),
-        ),
-        &repository(),
-    )
-    .await
-    .err()
-    .expect("expired installation token should fail");
+    let error = open_reader(&twin.base_url, &credentials)
+        .await
+        .err()
+        .expect("expired installation token should fail");
     let RepositoryReadError::CredentialResolution { source } = error else {
         panic!("expected credential resolution error");
     };
@@ -530,48 +498,25 @@ async fn repository_reader_keeps_auth_and_malformed_sha_failures_distinct() {
     let twin = TwinGitHub::start(state).await;
 
     let invalid_credentials = GitHubCredentials::Pat("invalid-token".to_string());
-    let invalid_reader = GitHubRepositoryReader::open(
-        &GitHubContext::with_http_client(
-            &invalid_credentials,
-            &twin.base_url,
-            fabro_test::test_http_client(),
-        ),
-        &repository(),
-    )
-    .await
-    .unwrap();
+    let invalid_reader = open_reader(&twin.base_url, &invalid_credentials)
+        .await
+        .unwrap();
     assert!(matches!(
         invalid_reader.resolve_commit("heads/main").await,
         Err(RepositoryReadError::AuthenticationRejected)
     ));
 
     let denied_credentials = GitHubCredentials::Pat(denied_token);
-    let denied_reader = GitHubRepositoryReader::open(
-        &GitHubContext::with_http_client(
-            &denied_credentials,
-            &twin.base_url,
-            fabro_test::test_http_client(),
-        ),
-        &repository(),
-    )
-    .await
-    .unwrap();
+    let denied_reader = open_reader(&twin.base_url, &denied_credentials)
+        .await
+        .unwrap();
     assert!(matches!(
         denied_reader.resolve_commit("heads/main").await,
         Err(RepositoryReadError::PermissionDenied)
     ));
 
     let app_credentials = github_credentials();
-    let app_reader = GitHubRepositoryReader::open(
-        &GitHubContext::with_http_client(
-            &app_credentials,
-            &twin.base_url,
-            fabro_test::test_http_client(),
-        ),
-        &repository(),
-    )
-    .await
-    .unwrap();
+    let app_reader = open_reader(&twin.base_url, &app_credentials).await.unwrap();
     assert!(matches!(
         app_reader.resolve_commit("heads/malformed").await,
         Err(RepositoryReadError::MalformedCommitSha)

--- a/lib/components/fabro-workflow/src/pipeline/pull_request.rs
+++ b/lib/components/fabro-workflow/src/pipeline/pull_request.rs
@@ -539,9 +539,9 @@ async fn enable_auto_merge_if_requested(
 
 /// How many times to read the remote branch head before giving up.
 ///
-/// `GET /repos/{owner}/{repo}/branches/{branch}` is replica-served, so shortly
-/// after the push that publish just made it can still report the previous
-/// commit — or 404 for a branch that is new on the remote.
+/// Remote ref visibility can lag shortly after the push that publish just
+/// made, so the exact-ref lookup can still report the previous commit — or
+/// 404 for a branch that is new on the remote.
 const BRANCH_HEAD_ATTEMPTS: u32 = 3;
 const BRANCH_HEAD_RETRY_DELAY: Duration = Duration::from_millis(500);
 
@@ -702,6 +702,9 @@ mod tests {
     use tokio::sync::RwLock as AsyncRwLock;
 
     use super::*;
+
+    const FINAL_SHA: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    const STALE_SHA: &str = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
     use crate::event::{Event, append_event};
     use crate::records::StageSummary;
 
@@ -1488,14 +1491,14 @@ mod tests {
     #[tokio::test]
     async fn stale_remote_branch_is_rejected_before_pull_request_creation() {
         let payload = pr_content_json("Fix bug", "Narrative.");
-        let harness = setup_fallback_test_harness_with_branch_sha(&payload, "stale-sha").await;
+        let harness = setup_fallback_test_harness_with_branch_sha(&payload, STALE_SHA).await;
         let github_base_url = harness.github_server.url("");
         let error = open_pull_request(OpenPullRequestRequest {
             github:            fabro_github::GitHubContext::new(&harness.creds, &github_base_url),
             origin_url:        "https://github.com/owner/repo.git",
             base_branch:       "main",
             head_branch:       "fabro/run/123",
-            expected_head_sha: "final-sha",
+            expected_head_sha: FINAL_SHA,
             goal:              "Fix bug",
             diff:              "diff --git a/src/lib.rs b/src/lib.rs\n+fn x() {}\n",
             model:             "claude-sonnet-4-20250514",
@@ -1510,8 +1513,8 @@ mod tests {
         .await
         .expect_err("stale remote branch must prevent PR creation");
 
-        assert!(error.contains("stale-sha"));
-        assert!(error.contains("final-sha"));
+        assert!(error.contains(STALE_SHA));
+        assert!(error.contains(FINAL_SHA));
         // The branch is re-read to ride out replica lag...
         httpmock::Mock::new(harness.branch_mock_id, &harness.github_server)
             .assert_calls_async(BRANCH_HEAD_ATTEMPTS as usize)
@@ -1709,7 +1712,7 @@ mod tests {
     /// credential source, and a run store seeded with a non-empty
     /// `final_patch`.
     async fn setup_fallback_test_harness(openai_payload_text: &str) -> FallbackHarness {
-        setup_fallback_test_harness_with_branch_sha(openai_payload_text, "final-sha").await
+        setup_fallback_test_harness_with_branch_sha(openai_payload_text, FINAL_SHA).await
     }
 
     async fn setup_fallback_test_harness_with_branch_sha(
@@ -1742,13 +1745,12 @@ mod tests {
         let branch_mock = github_server
             .mock_async(move |when, then| {
                 when.method(GET)
-                    .path("/repos/owner/repo/branches/fabro/run/123")
-                    .header("authorization", "Bearer test-token");
+                    .path("/repos/owner/repo/commits/heads%2Ffabro%2Frun%2F123")
+                    .header("authorization", "Bearer test-token")
+                    .header("accept", "application/vnd.github.sha");
                 then.status(200)
-                    .header("content-type", "application/json")
-                    .json_body(serde_json::json!({
-                        "commit": { "sha": branch_sha }
-                    }));
+                    .header("content-type", "application/vnd.github.sha")
+                    .body(branch_sha);
             })
             .await;
         let github_mock = github_server
@@ -1892,13 +1894,13 @@ mod tests {
         let payload = pr_content_json("Unused", "Unused.");
         let harness = setup_fallback_test_harness_with(
             &payload,
-            "final-sha",
+            FINAL_SHA,
             serde_json::json!([{
                 "html_url": "https://github.com/owner/repo/pull/7",
                 "number": 7,
                 "node_id": "PR_existing",
                 "title": "Reconciled title",
-                "head": {"sha": "final-sha"}
+                "head": {"sha": FINAL_SHA}
             }]),
         )
         .await;
@@ -1911,7 +1913,7 @@ mod tests {
             origin_url: "https://github.com/owner/repo.git",
             base_branch: "main",
             head_branch: "fabro/run/123",
-            expected_head_sha: "final-sha",
+            expected_head_sha: FINAL_SHA,
             goal: "Fix telemetry leak",
             diff: "diff --git a/src/lib.rs b/src/lib.rs\n+fn x() {}\n",
             model: "gpt-5.4",
@@ -1959,7 +1961,7 @@ mod tests {
             origin_url: "https://github.com/owner/repo.git",
             base_branch: "main",
             head_branch: "fabro/run/123",
-            expected_head_sha: "final-sha",
+            expected_head_sha: FINAL_SHA,
             goal: "Fix telemetry leak\n\ndetails...",
             diff: "diff --git a/src/lib.rs b/src/lib.rs\n+fn x() {}\n",
             model: "gpt-5.4",
@@ -1996,7 +1998,7 @@ mod tests {
             origin_url: "https://github.com/owner/repo.git",
             base_branch: "main",
             head_branch: "fabro/run/123",
-            expected_head_sha: "final-sha",
+            expected_head_sha: FINAL_SHA,
             goal: &goal,
             diff: "diff --git a/src/lib.rs b/src/lib.rs\n+fn x() {}\n",
             model: "gpt-5.4",

--- a/lib/components/fabro-workflow/src/pipeline/pull_request.rs
+++ b/lib/components/fabro-workflow/src/pipeline/pull_request.rs
@@ -3,14 +3,16 @@ use std::sync::{Arc, LazyLock};
 use std::time::Duration;
 
 use fabro_auth::CredentialSource;
-use fabro_github::{self as github_app, ssh_url_to_https};
+use fabro_github::{
+    self as github_app, GitHubRepositoryReader, RepositoryReadError, ssh_url_to_https,
+};
 use fabro_graphviz::parser;
 use fabro_llm::client::Client;
 use fabro_llm::generate::{GenerateParams, generate_object};
 use fabro_model::{Catalog, ProviderId};
 use fabro_store::RunProjection;
-use fabro_types::PullRequestLink;
 use fabro_types::settings::run::MergeStrategy;
+use fabro_types::{GitHubRepositorySlug, PullRequestLink};
 use fabro_util::text::strip_goal_decoration;
 use tokio::time::sleep;
 use tracing::{debug, info, warn};
@@ -548,15 +550,29 @@ const BRANCH_HEAD_RETRY_DELAY: Duration = Duration::from_millis(500);
 /// Confirm the remote branch points at the run's final commit.
 ///
 /// Publish failures are terminal, so a replica that has not caught up yet must
-/// not be mistaken for a genuinely stale branch.
+/// not be mistaken for a genuinely stale branch. Credentials are resolved once
+/// and reused across attempts; only the ref lookup is retried.
 async fn verify_remote_head(
     req: &OpenPullRequestRequest<'_>,
     owner: &str,
     repo: &str,
 ) -> Result<(), String> {
+    let repository =
+        GitHubRepositorySlug::try_new(&format!("{owner}/{repo}")).ok_or_else(|| {
+            format!("failed to verify remote branch head: invalid repository {owner}/{repo}")
+        })?;
+    let reader = GitHubRepositoryReader::open(&req.github, &repository)
+        .await
+        .map_err(|err| format!("failed to verify remote branch head: {err:#}"))?;
+    let selector = format!("heads/{}", req.head_branch);
+
     let mut last_seen = Ok(None);
     for attempt in 1..=BRANCH_HEAD_ATTEMPTS {
-        last_seen = github_app::branch_head_sha(&req.github, owner, repo, req.head_branch).await;
+        last_seen = match reader.resolve_commit(&selector).await {
+            Ok(sha) => Ok(Some(sha)),
+            Err(RepositoryReadError::NotFound { .. }) => Ok(None),
+            Err(err) => Err(err),
+        };
         match &last_seen {
             Ok(Some(head)) if head == req.expected_head_sha => return Ok(()),
             Ok(head) => debug!(
@@ -702,11 +718,11 @@ mod tests {
     use tokio::sync::RwLock as AsyncRwLock;
 
     use super::*;
+    use crate::event::{Event, append_event};
+    use crate::records::StageSummary;
 
     const FINAL_SHA: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
     const STALE_SHA: &str = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
-    use crate::event::{Event, append_event};
-    use crate::records::StageSummary;
 
     struct MockProvider {
         name:          String,

--- a/lib/foundation/fabro-test/src/lib.rs
+++ b/lib/foundation/fabro-test/src/lib.rs
@@ -2122,6 +2122,10 @@ impl TwinGitHub {
     pub async fn shutdown(self) {
         self.server.shutdown().await;
     }
+
+    pub async fn active_token_count(&self) -> usize {
+        self.server.active_token_count().await
+    }
 }
 
 impl TwinOpenAi {

--- a/test/twin/github/src/fixtures.rs
+++ b/test/twin/github/src/fixtures.rs
@@ -213,28 +213,16 @@ impl FixtureState {
         state.repositories = self
             .repositories
             .into_iter()
-            .map(|repository| {
-                let refs = repository
-                    .branches
-                    .into_iter()
-                    .map(|branch| {
-                        (
-                            format!("heads/{branch}"),
-                            crate::state::DEFAULT_REPOSITORY_SHA.to_string(),
-                        )
-                    })
-                    .collect();
-                Repository {
-                    owner: repository.owner,
-                    name: repository.name,
-                    refs,
-                    files: HashMap::new(),
-                    default_branch: repository
-                        .default_branch
-                        .unwrap_or_else(|| "main".to_string()),
-                    private: repository.private,
-                    git_dir: None,
-                }
+            .map(|repository| Repository {
+                owner:          repository.owner,
+                name:           repository.name,
+                refs:           crate::state::head_refs(repository.branches),
+                files:          HashMap::new(),
+                default_branch: repository
+                    .default_branch
+                    .unwrap_or_else(|| "main".to_string()),
+                private:        repository.private,
+                git_dir:        None,
             })
             .collect();
 

--- a/test/twin/github/src/fixtures.rs
+++ b/test/twin/github/src/fixtures.rs
@@ -213,15 +213,28 @@ impl FixtureState {
         state.repositories = self
             .repositories
             .into_iter()
-            .map(|repository| Repository {
-                owner:          repository.owner,
-                name:           repository.name,
-                branches:       repository.branches,
-                default_branch: repository
-                    .default_branch
-                    .unwrap_or_else(|| "main".to_string()),
-                private:        repository.private,
-                git_dir:        None,
+            .map(|repository| {
+                let refs = repository
+                    .branches
+                    .into_iter()
+                    .map(|branch| {
+                        (
+                            format!("heads/{branch}"),
+                            crate::state::DEFAULT_REPOSITORY_SHA.to_string(),
+                        )
+                    })
+                    .collect();
+                Repository {
+                    owner: repository.owner,
+                    name: repository.name,
+                    refs,
+                    files: HashMap::new(),
+                    default_branch: repository
+                        .default_branch
+                        .unwrap_or_else(|| "main".to_string()),
+                    private: repository.private,
+                    git_dir: None,
+                }
             })
             .collect();
 

--- a/test/twin/github/src/handlers/branches.rs
+++ b/test/twin/github/src/handlers/branches.rs
@@ -55,16 +55,16 @@ pub async fn get_branch(
         };
     }
 
-    // Find repository and check branch
+    // Find repository and check branch.
     for repo_data in &state.repositories {
         if repo_data.owner == owner && repo_data.name == repo {
-            if repo_data.branches.contains(&branch) {
+            if let Some(sha) = repo_data.refs.get(&format!("heads/{branch}")) {
                 return (
                     StatusCode::OK,
                     Json(serde_json::json!({
                         "name": branch,
                         "commit": {
-                            "sha": "abc123def456",
+                            "sha": sha,
                         },
                         "protected": false,
                     })),
@@ -92,7 +92,7 @@ pub async fn get_branch(
 #[cfg(test)]
 mod tests {
     use crate::server::TestServer;
-    use crate::state::{AppOptions, AppState};
+    use crate::state::{AppOptions, AppState, DEFAULT_REPOSITORY_SHA};
     use crate::test_support::{sign_test_jwt, test_http_client, test_rsa_private_key};
 
     async fn get_installation_token(
@@ -168,6 +168,7 @@ mod tests {
         assert_eq!(resp.status(), 200);
         let body: serde_json::Value = resp.json().await.unwrap();
         assert_eq!(body["name"], "feature");
+        assert_eq!(body["commit"]["sha"], DEFAULT_REPOSITORY_SHA);
 
         server.shutdown().await;
     }
@@ -213,6 +214,7 @@ mod tests {
         assert_eq!(resp.status(), 200);
         let body: serde_json::Value = resp.json().await.unwrap();
         assert_eq!(body["name"], "fabro/run/123");
+        assert_eq!(body["commit"]["sha"], DEFAULT_REPOSITORY_SHA);
 
         server.shutdown().await;
     }

--- a/test/twin/github/src/handlers/branches.rs
+++ b/test/twin/github/src/handlers/branches.rs
@@ -58,7 +58,7 @@ pub async fn get_branch(
     // Find repository and check branch.
     for repo_data in &state.repositories {
         if repo_data.owner == owner && repo_data.name == repo {
-            if let Some(sha) = repo_data.refs.get(&format!("heads/{branch}")) {
+            if let Some(sha) = repo_data.refs.get(&crate::state::heads_selector(&branch)) {
                 return (
                     StatusCode::OK,
                     Json(serde_json::json!({

--- a/test/twin/github/src/handlers/commits.rs
+++ b/test/twin/github/src/handlers/commits.rs
@@ -1,0 +1,233 @@
+use axum::Json;
+use axum::extract::{Path, State};
+use axum::http::header::{ACCEPT, CONTENT_TYPE};
+use axum::http::{HeaderMap, StatusCode};
+use axum::response::{IntoResponse, Response};
+
+use crate::auth::{
+    BearerTokenError, InstallationTokenAccessError, authorize_installation_token,
+    ensure_repo_permission,
+};
+use crate::server::SharedState;
+use crate::state::{AppState, PermissionLevel, TokenPermission};
+
+const SHA_MEDIA_TYPE: &str = "application/vnd.github.sha";
+
+/// GET /repos/{owner}/{repo}/commits/{ref}
+pub async fn get_commit(
+    State(state): State<SharedState>,
+    Path((owner, repo, selector)): Path<(String, String, String)>,
+    headers: HeaderMap,
+) -> Response {
+    let state = state.read().await;
+    if !accepts(&headers, SHA_MEDIA_TYPE) {
+        return message(StatusCode::NOT_ACCEPTABLE, "Not Acceptable");
+    }
+    if let Err(error) = authorize(&headers, &state, &repo) {
+        return authorization_error(error);
+    }
+
+    let Some(repository) = state
+        .repositories
+        .iter()
+        .find(|repository| repository.owner == owner && repository.name == repo)
+    else {
+        return message(StatusCode::NOT_FOUND, "Not Found");
+    };
+
+    let sha = repository.refs.get(&selector).cloned().or_else(|| {
+        is_exact_commit_sha(&selector)
+            .then(|| selector.clone())
+            .filter(|sha| {
+                repository.refs.values().any(|known| known == sha)
+                    || repository.files.keys().any(|(known, _)| known == sha)
+            })
+    });
+    let Some(sha) = sha else {
+        return message(StatusCode::NOT_FOUND, "Not Found");
+    };
+
+    (StatusCode::OK, [(CONTENT_TYPE, SHA_MEDIA_TYPE)], sha).into_response()
+}
+
+#[derive(Clone, Copy)]
+enum AuthorizationError {
+    MissingCredentials,
+    InvalidCredentials,
+    RepoNotAccessible,
+    PermissionDenied,
+}
+
+fn authorize(headers: &HeaderMap, state: &AppState, repo: &str) -> Result<(), AuthorizationError> {
+    let token = authorize_installation_token(headers, state).map_err(|error| match error {
+        BearerTokenError::Missing => AuthorizationError::MissingCredentials,
+        BearerTokenError::Invalid => AuthorizationError::InvalidCredentials,
+    })?;
+    ensure_repo_permission(
+        &token,
+        repo,
+        TokenPermission::Contents,
+        PermissionLevel::Read,
+    )
+    .map_err(|error| match error {
+        InstallationTokenAccessError::RepoNotAccessible => AuthorizationError::RepoNotAccessible,
+        InstallationTokenAccessError::PermissionDenied => AuthorizationError::PermissionDenied,
+    })
+}
+
+fn authorization_error(error: AuthorizationError) -> Response {
+    match error {
+        AuthorizationError::MissingCredentials => message(StatusCode::UNAUTHORIZED, "Unauthorized"),
+        AuthorizationError::InvalidCredentials => {
+            message(StatusCode::UNAUTHORIZED, "Bad credentials")
+        }
+        AuthorizationError::RepoNotAccessible => message(StatusCode::NOT_FOUND, "Not Found"),
+        AuthorizationError::PermissionDenied => message(
+            StatusCode::FORBIDDEN,
+            "Resource not accessible by integration",
+        ),
+    }
+}
+
+fn accepts(headers: &HeaderMap, media_type: &str) -> bool {
+    headers.get_all(ACCEPT).iter().any(|value| {
+        value.to_str().is_ok_and(|value| {
+            value
+                .split(',')
+                .any(|candidate| candidate.trim() == media_type)
+        })
+    })
+}
+
+fn is_exact_commit_sha(value: &str) -> bool {
+    value.len() == 40 && value.bytes().all(|byte| byte.is_ascii_hexdigit())
+}
+
+fn message(status: StatusCode, body: &'static str) -> Response {
+    (status, Json(serde_json::json!({ "message": body }))).into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::server::TestServer;
+    use crate::state::AppState;
+    use crate::test_support::test_http_client;
+
+    const HEAD_SHA: &str = "1111111111111111111111111111111111111111";
+    const TAG_SHA: &str = "2222222222222222222222222222222222222222";
+
+    fn state_with_repository() -> (AppState, String) {
+        let mut state = AppState::new();
+        state.add_repository("owner", "repo", vec!["main".to_string()], true);
+        state.set_repository_ref("owner", "repo", "heads/main", HEAD_SHA);
+        state.set_repository_ref("owner", "repo", "tags/v1.0.0", TAG_SHA);
+        let token = state.generate_access_token(
+            "app",
+            1,
+            vec!["repo".to_string()],
+            serde_json::json!({ "contents": "read" }),
+        );
+        (state, token)
+    }
+
+    #[tokio::test]
+    async fn resolves_branch_tag_and_exact_sha_as_raw_bodies() {
+        let (state, token) = state_with_repository();
+        let server = TestServer::start(state).await;
+        let client = test_http_client();
+
+        for (selector, expected) in [
+            ("heads%2Fmain", HEAD_SHA),
+            ("tags%2Fv1.0.0", TAG_SHA),
+            (HEAD_SHA, HEAD_SHA),
+        ] {
+            let response = client
+                .get(format!(
+                    "{}/repos/owner/repo/commits/{selector}",
+                    server.url()
+                ))
+                .bearer_auth(&token)
+                .header(ACCEPT, SHA_MEDIA_TYPE)
+                .send()
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::OK);
+            assert_eq!(
+                response.headers().get(CONTENT_TYPE).unwrap(),
+                SHA_MEDIA_TYPE
+            );
+            assert_eq!(response.text().await.unwrap(), expected);
+        }
+
+        let response = client
+            .get(format!(
+                "{}/repos/owner/repo/commits/heads%2Fmissing",
+                server.url()
+            ))
+            .bearer_auth(&token)
+            .header(ACCEPT, SHA_MEDIA_TYPE)
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+
+        server.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn enforces_auth_repository_permission_and_media_type() {
+        let (mut state, token) = state_with_repository();
+        let other_repo_token = state.generate_access_token(
+            "app",
+            1,
+            vec!["other".to_string()],
+            serde_json::json!({ "contents": "read" }),
+        );
+        let denied_token =
+            state.generate_access_token("app", 1, vec!["repo".to_string()], serde_json::json!({}));
+        let server = TestServer::start(state).await;
+        let client = test_http_client();
+        let url = format!("{}/repos/owner/repo/commits/heads%2Fmain", server.url());
+
+        let missing = client
+            .get(&url)
+            .header(ACCEPT, SHA_MEDIA_TYPE)
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(missing.status(), StatusCode::UNAUTHORIZED);
+
+        let invalid = client
+            .get(&url)
+            .bearer_auth("invalid")
+            .header(ACCEPT, SHA_MEDIA_TYPE)
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(invalid.status(), StatusCode::UNAUTHORIZED);
+
+        let hidden = client
+            .get(&url)
+            .bearer_auth(other_repo_token)
+            .header(ACCEPT, SHA_MEDIA_TYPE)
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(hidden.status(), StatusCode::NOT_FOUND);
+
+        let denied = client
+            .get(&url)
+            .bearer_auth(denied_token)
+            .header(ACCEPT, SHA_MEDIA_TYPE)
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(denied.status(), StatusCode::FORBIDDEN);
+
+        let unacceptable = client.get(&url).bearer_auth(token).send().await.unwrap();
+        assert_eq!(unacceptable.status(), StatusCode::NOT_ACCEPTABLE);
+
+        server.shutdown().await;
+    }
+}

--- a/test/twin/github/src/handlers/commits.rs
+++ b/test/twin/github/src/handlers/commits.rs
@@ -1,15 +1,11 @@
-use axum::Json;
 use axum::extract::{Path, State};
-use axum::http::header::{ACCEPT, CONTENT_TYPE};
+use axum::http::header::CONTENT_TYPE;
 use axum::http::{HeaderMap, StatusCode};
 use axum::response::{IntoResponse, Response};
 
-use crate::auth::{
-    BearerTokenError, InstallationTokenAccessError, authorize_installation_token,
-    ensure_repo_permission,
-};
+use crate::handlers::support::{accepts, authorize_repo_access, is_exact_commit_sha, message};
 use crate::server::SharedState;
-use crate::state::{AppState, PermissionLevel, TokenPermission};
+use crate::state::{PermissionLevel, TokenPermission};
 
 const SHA_MEDIA_TYPE: &str = "application/vnd.github.sha";
 
@@ -23,25 +19,25 @@ pub async fn get_commit(
     if !accepts(&headers, SHA_MEDIA_TYPE) {
         return message(StatusCode::NOT_ACCEPTABLE, "Not Acceptable");
     }
-    if let Err(error) = authorize(&headers, &state, &repo) {
-        return authorization_error(error);
+    if let Err(response) = authorize_repo_access(
+        &headers,
+        &state,
+        &repo,
+        TokenPermission::Contents,
+        PermissionLevel::Read,
+    ) {
+        return *response;
     }
 
-    let Some(repository) = state
-        .repositories
-        .iter()
-        .find(|repository| repository.owner == owner && repository.name == repo)
-    else {
+    let Some(repository) = state.find_repository(&owner, &repo) else {
         return message(StatusCode::NOT_FOUND, "Not Found");
     };
 
+    // A selector is either a known ref, or an exact SHA this repository can
+    // already serve; an unknown SHA must not resolve to itself.
     let sha = repository.refs.get(&selector).cloned().or_else(|| {
-        is_exact_commit_sha(&selector)
+        (is_exact_commit_sha(&selector) && repository.knows_commit(&selector))
             .then(|| selector.clone())
-            .filter(|sha| {
-                repository.refs.values().any(|known| known == sha)
-                    || repository.files.keys().any(|(known, _)| known == sha)
-            })
     });
     let Some(sha) = sha else {
         return message(StatusCode::NOT_FOUND, "Not Found");
@@ -50,65 +46,10 @@ pub async fn get_commit(
     (StatusCode::OK, [(CONTENT_TYPE, SHA_MEDIA_TYPE)], sha).into_response()
 }
 
-#[derive(Clone, Copy)]
-enum AuthorizationError {
-    MissingCredentials,
-    InvalidCredentials,
-    RepoNotAccessible,
-    PermissionDenied,
-}
-
-fn authorize(headers: &HeaderMap, state: &AppState, repo: &str) -> Result<(), AuthorizationError> {
-    let token = authorize_installation_token(headers, state).map_err(|error| match error {
-        BearerTokenError::Missing => AuthorizationError::MissingCredentials,
-        BearerTokenError::Invalid => AuthorizationError::InvalidCredentials,
-    })?;
-    ensure_repo_permission(
-        &token,
-        repo,
-        TokenPermission::Contents,
-        PermissionLevel::Read,
-    )
-    .map_err(|error| match error {
-        InstallationTokenAccessError::RepoNotAccessible => AuthorizationError::RepoNotAccessible,
-        InstallationTokenAccessError::PermissionDenied => AuthorizationError::PermissionDenied,
-    })
-}
-
-fn authorization_error(error: AuthorizationError) -> Response {
-    match error {
-        AuthorizationError::MissingCredentials => message(StatusCode::UNAUTHORIZED, "Unauthorized"),
-        AuthorizationError::InvalidCredentials => {
-            message(StatusCode::UNAUTHORIZED, "Bad credentials")
-        }
-        AuthorizationError::RepoNotAccessible => message(StatusCode::NOT_FOUND, "Not Found"),
-        AuthorizationError::PermissionDenied => message(
-            StatusCode::FORBIDDEN,
-            "Resource not accessible by integration",
-        ),
-    }
-}
-
-fn accepts(headers: &HeaderMap, media_type: &str) -> bool {
-    headers.get_all(ACCEPT).iter().any(|value| {
-        value.to_str().is_ok_and(|value| {
-            value
-                .split(',')
-                .any(|candidate| candidate.trim() == media_type)
-        })
-    })
-}
-
-fn is_exact_commit_sha(value: &str) -> bool {
-    value.len() == 40 && value.bytes().all(|byte| byte.is_ascii_hexdigit())
-}
-
-fn message(status: StatusCode, body: &'static str) -> Response {
-    (status, Json(serde_json::json!({ "message": body }))).into_response()
-}
-
 #[cfg(test)]
 mod tests {
+    use axum::http::header::ACCEPT;
+
     use super::*;
     use crate::server::TestServer;
     use crate::state::AppState;

--- a/test/twin/github/src/handlers/contents.rs
+++ b/test/twin/github/src/handlers/contents.rs
@@ -1,17 +1,14 @@
 use axum::Json;
 use axum::body::Body;
 use axum::extract::{Path, Query, State};
-use axum::http::header::{ACCEPT, CONTENT_TYPE};
+use axum::http::header::CONTENT_TYPE;
 use axum::http::{HeaderMap, StatusCode};
 use axum::response::{IntoResponse, Response};
 use serde::Deserialize;
 
-use crate::auth::{
-    BearerTokenError, InstallationTokenAccessError, authorize_installation_token,
-    ensure_repo_permission,
-};
+use crate::handlers::support::{accepts, authorize_repo_access, is_exact_commit_sha, message};
 use crate::server::SharedState;
-use crate::state::{AppState, PermissionLevel, TokenPermission};
+use crate::state::{PermissionLevel, TokenPermission};
 
 const RAW_CONTENT_MEDIA_TYPE: &str = "application/vnd.github.raw+json";
 
@@ -32,25 +29,24 @@ pub async fn get_content(
     if !accepts(&headers, RAW_CONTENT_MEDIA_TYPE) {
         return message(StatusCode::NOT_ACCEPTABLE, "Not Acceptable");
     }
-    if let Err(error) = authorize(&headers, &state, &repo) {
-        return authorization_error(error);
+    if let Err(response) = authorize_repo_access(
+        &headers,
+        &state,
+        &repo,
+        TokenPermission::Contents,
+        PermissionLevel::Read,
+    ) {
+        return *response;
     }
     if !is_exact_commit_sha(&query.revision) {
         return message(StatusCode::NOT_FOUND, "Not Found");
     }
 
-    let Some(repository) = state
-        .repositories
-        .iter()
-        .find(|repository| repository.owner == owner && repository.name == repo)
-    else {
+    let Some(repository) = state.find_repository(&owner, &repo) else {
         return message(StatusCode::NOT_FOUND, "Not Found");
     };
 
-    if let Some(contents) = repository
-        .files
-        .get(&(query.revision.clone(), path.clone()))
-    {
+    if let Some(contents) = repository.file_at(&query.revision, &path) {
         return (
             StatusCode::OK,
             [(CONTENT_TYPE, RAW_CONTENT_MEDIA_TYPE)],
@@ -59,75 +55,19 @@ pub async fn get_content(
             .into_response();
     }
 
-    let directory_prefix = format!("{path}/");
-    if repository.files.keys().any(|(sha, stored_path)| {
-        sha == &query.revision && stored_path.starts_with(&directory_prefix)
-    }) {
+    // GitHub answers a directory path with a JSON listing rather than raw
+    // bytes, which is what lets the reader reject non-file targets.
+    if repository.has_directory_at(&query.revision, &format!("{path}/")) {
         return (StatusCode::OK, Json(serde_json::json!([]))).into_response();
     }
 
     message(StatusCode::NOT_FOUND, "Not Found")
 }
 
-#[derive(Clone, Copy)]
-enum AuthorizationError {
-    MissingCredentials,
-    InvalidCredentials,
-    RepoNotAccessible,
-    PermissionDenied,
-}
-
-fn authorize(headers: &HeaderMap, state: &AppState, repo: &str) -> Result<(), AuthorizationError> {
-    let token = authorize_installation_token(headers, state).map_err(|error| match error {
-        BearerTokenError::Missing => AuthorizationError::MissingCredentials,
-        BearerTokenError::Invalid => AuthorizationError::InvalidCredentials,
-    })?;
-    ensure_repo_permission(
-        &token,
-        repo,
-        TokenPermission::Contents,
-        PermissionLevel::Read,
-    )
-    .map_err(|error| match error {
-        InstallationTokenAccessError::RepoNotAccessible => AuthorizationError::RepoNotAccessible,
-        InstallationTokenAccessError::PermissionDenied => AuthorizationError::PermissionDenied,
-    })
-}
-
-fn authorization_error(error: AuthorizationError) -> Response {
-    match error {
-        AuthorizationError::MissingCredentials => message(StatusCode::UNAUTHORIZED, "Unauthorized"),
-        AuthorizationError::InvalidCredentials => {
-            message(StatusCode::UNAUTHORIZED, "Bad credentials")
-        }
-        AuthorizationError::RepoNotAccessible => message(StatusCode::NOT_FOUND, "Not Found"),
-        AuthorizationError::PermissionDenied => message(
-            StatusCode::FORBIDDEN,
-            "Resource not accessible by integration",
-        ),
-    }
-}
-
-fn accepts(headers: &HeaderMap, media_type: &str) -> bool {
-    headers.get_all(ACCEPT).iter().any(|value| {
-        value.to_str().is_ok_and(|value| {
-            value
-                .split(',')
-                .any(|candidate| candidate.trim() == media_type)
-        })
-    })
-}
-
-fn is_exact_commit_sha(value: &str) -> bool {
-    value.len() == 40 && value.bytes().all(|byte| byte.is_ascii_hexdigit())
-}
-
-fn message(status: StatusCode, body: &'static str) -> Response {
-    (status, Json(serde_json::json!({ "message": body }))).into_response()
-}
-
 #[cfg(test)]
 mod tests {
+    use axum::http::header::ACCEPT;
+
     use super::*;
     use crate::server::TestServer;
     use crate::state::AppState;

--- a/test/twin/github/src/handlers/contents.rs
+++ b/test/twin/github/src/handlers/contents.rs
@@ -1,0 +1,282 @@
+use axum::Json;
+use axum::body::Body;
+use axum::extract::{Path, Query, State};
+use axum::http::header::{ACCEPT, CONTENT_TYPE};
+use axum::http::{HeaderMap, StatusCode};
+use axum::response::{IntoResponse, Response};
+use serde::Deserialize;
+
+use crate::auth::{
+    BearerTokenError, InstallationTokenAccessError, authorize_installation_token,
+    ensure_repo_permission,
+};
+use crate::server::SharedState;
+use crate::state::{AppState, PermissionLevel, TokenPermission};
+
+const RAW_CONTENT_MEDIA_TYPE: &str = "application/vnd.github.raw+json";
+
+#[derive(Deserialize)]
+pub struct ContentQuery {
+    #[serde(rename = "ref")]
+    revision: String,
+}
+
+/// GET /repos/{owner}/{repo}/contents/{path}?ref={sha}
+pub async fn get_content(
+    State(state): State<SharedState>,
+    Path((owner, repo, path)): Path<(String, String, String)>,
+    Query(query): Query<ContentQuery>,
+    headers: HeaderMap,
+) -> Response {
+    let state = state.read().await;
+    if !accepts(&headers, RAW_CONTENT_MEDIA_TYPE) {
+        return message(StatusCode::NOT_ACCEPTABLE, "Not Acceptable");
+    }
+    if let Err(error) = authorize(&headers, &state, &repo) {
+        return authorization_error(error);
+    }
+    if !is_exact_commit_sha(&query.revision) {
+        return message(StatusCode::NOT_FOUND, "Not Found");
+    }
+
+    let Some(repository) = state
+        .repositories
+        .iter()
+        .find(|repository| repository.owner == owner && repository.name == repo)
+    else {
+        return message(StatusCode::NOT_FOUND, "Not Found");
+    };
+
+    if let Some(contents) = repository
+        .files
+        .get(&(query.revision.clone(), path.clone()))
+    {
+        return (
+            StatusCode::OK,
+            [(CONTENT_TYPE, RAW_CONTENT_MEDIA_TYPE)],
+            Body::from(contents.clone()),
+        )
+            .into_response();
+    }
+
+    let directory_prefix = format!("{path}/");
+    if repository.files.keys().any(|(sha, stored_path)| {
+        sha == &query.revision && stored_path.starts_with(&directory_prefix)
+    }) {
+        return (StatusCode::OK, Json(serde_json::json!([]))).into_response();
+    }
+
+    message(StatusCode::NOT_FOUND, "Not Found")
+}
+
+#[derive(Clone, Copy)]
+enum AuthorizationError {
+    MissingCredentials,
+    InvalidCredentials,
+    RepoNotAccessible,
+    PermissionDenied,
+}
+
+fn authorize(headers: &HeaderMap, state: &AppState, repo: &str) -> Result<(), AuthorizationError> {
+    let token = authorize_installation_token(headers, state).map_err(|error| match error {
+        BearerTokenError::Missing => AuthorizationError::MissingCredentials,
+        BearerTokenError::Invalid => AuthorizationError::InvalidCredentials,
+    })?;
+    ensure_repo_permission(
+        &token,
+        repo,
+        TokenPermission::Contents,
+        PermissionLevel::Read,
+    )
+    .map_err(|error| match error {
+        InstallationTokenAccessError::RepoNotAccessible => AuthorizationError::RepoNotAccessible,
+        InstallationTokenAccessError::PermissionDenied => AuthorizationError::PermissionDenied,
+    })
+}
+
+fn authorization_error(error: AuthorizationError) -> Response {
+    match error {
+        AuthorizationError::MissingCredentials => message(StatusCode::UNAUTHORIZED, "Unauthorized"),
+        AuthorizationError::InvalidCredentials => {
+            message(StatusCode::UNAUTHORIZED, "Bad credentials")
+        }
+        AuthorizationError::RepoNotAccessible => message(StatusCode::NOT_FOUND, "Not Found"),
+        AuthorizationError::PermissionDenied => message(
+            StatusCode::FORBIDDEN,
+            "Resource not accessible by integration",
+        ),
+    }
+}
+
+fn accepts(headers: &HeaderMap, media_type: &str) -> bool {
+    headers.get_all(ACCEPT).iter().any(|value| {
+        value.to_str().is_ok_and(|value| {
+            value
+                .split(',')
+                .any(|candidate| candidate.trim() == media_type)
+        })
+    })
+}
+
+fn is_exact_commit_sha(value: &str) -> bool {
+    value.len() == 40 && value.bytes().all(|byte| byte.is_ascii_hexdigit())
+}
+
+fn message(status: StatusCode, body: &'static str) -> Response {
+    (status, Json(serde_json::json!({ "message": body }))).into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::server::TestServer;
+    use crate::state::AppState;
+    use crate::test_support::test_http_client;
+
+    const SHA: &str = "1111111111111111111111111111111111111111";
+
+    fn state_with_file() -> (AppState, String) {
+        let mut state = AppState::new();
+        state.add_repository("owner", "repo", vec!["main".to_string()], true);
+        state.set_repository_ref("owner", "repo", "heads/main", SHA);
+        state.add_repository_file("owner", "repo", SHA, "dir/file.bin", vec![0, 0xff, 1]);
+        let token = state.generate_access_token(
+            "app",
+            1,
+            vec!["repo".to_string()],
+            serde_json::json!({ "contents": "read" }),
+        );
+        (state, token)
+    }
+
+    #[tokio::test]
+    async fn serves_only_exact_sha_files_and_marks_directories_as_json() {
+        let (state, token) = state_with_file();
+        let server = TestServer::start(state).await;
+        let client = test_http_client();
+
+        let response = client
+            .get(format!(
+                "{}/repos/owner/repo/contents/dir/file.bin?ref={SHA}",
+                server.url()
+            ))
+            .bearer_auth(&token)
+            .header(ACCEPT, RAW_CONTENT_MEDIA_TYPE)
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            response.headers().get(CONTENT_TYPE).unwrap(),
+            RAW_CONTENT_MEDIA_TYPE
+        );
+        assert_eq!(response.bytes().await.unwrap().as_ref(), &[0, 0xff, 1]);
+
+        let directory = client
+            .get(format!(
+                "{}/repos/owner/repo/contents/dir?ref={SHA}",
+                server.url()
+            ))
+            .bearer_auth(&token)
+            .header(ACCEPT, RAW_CONTENT_MEDIA_TYPE)
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(directory.status(), StatusCode::OK);
+        assert_eq!(
+            directory.headers().get(CONTENT_TYPE).unwrap(),
+            "application/json"
+        );
+
+        for suffix in [
+            "dir/file.bin?ref=heads%2Fmain",
+            "dir/file.bin?ref=2222222222222222222222222222222222222222",
+            &format!("missing.bin?ref={SHA}"),
+        ] {
+            let response = client
+                .get(format!(
+                    "{}/repos/owner/repo/contents/{suffix}",
+                    server.url()
+                ))
+                .bearer_auth(&token)
+                .header(ACCEPT, RAW_CONTENT_MEDIA_TYPE)
+                .send()
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::NOT_FOUND);
+        }
+
+        let missing_ref = client
+            .get(format!(
+                "{}/repos/owner/repo/contents/dir/file.bin",
+                server.url()
+            ))
+            .bearer_auth(&token)
+            .header(ACCEPT, RAW_CONTENT_MEDIA_TYPE)
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(missing_ref.status(), StatusCode::BAD_REQUEST);
+
+        server.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn enforces_auth_repository_permission_and_media_type() {
+        let (mut state, token) = state_with_file();
+        let other_repo_token = state.generate_access_token(
+            "app",
+            1,
+            vec!["other".to_string()],
+            serde_json::json!({ "contents": "read" }),
+        );
+        let denied_token =
+            state.generate_access_token("app", 1, vec!["repo".to_string()], serde_json::json!({}));
+        let server = TestServer::start(state).await;
+        let client = test_http_client();
+        let url = format!(
+            "{}/repos/owner/repo/contents/dir/file.bin?ref={SHA}",
+            server.url()
+        );
+
+        let missing = client
+            .get(&url)
+            .header(ACCEPT, RAW_CONTENT_MEDIA_TYPE)
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(missing.status(), StatusCode::UNAUTHORIZED);
+
+        let invalid = client
+            .get(&url)
+            .bearer_auth("invalid")
+            .header(ACCEPT, RAW_CONTENT_MEDIA_TYPE)
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(invalid.status(), StatusCode::UNAUTHORIZED);
+
+        let hidden = client
+            .get(&url)
+            .bearer_auth(other_repo_token)
+            .header(ACCEPT, RAW_CONTENT_MEDIA_TYPE)
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(hidden.status(), StatusCode::NOT_FOUND);
+
+        let denied = client
+            .get(&url)
+            .bearer_auth(denied_token)
+            .header(ACCEPT, RAW_CONTENT_MEDIA_TYPE)
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(denied.status(), StatusCode::FORBIDDEN);
+
+        let unacceptable = client.get(&url).bearer_auth(token).send().await.unwrap();
+        assert_eq!(unacceptable.status(), StatusCode::NOT_ACCEPTABLE);
+
+        server.shutdown().await;
+    }
+}

--- a/test/twin/github/src/handlers/mod.rs
+++ b/test/twin/github/src/handlers/mod.rs
@@ -1,5 +1,7 @@
 pub mod app;
 pub mod branches;
+pub mod commits;
+pub mod contents;
 pub mod git;
 pub mod graphql;
 pub mod installations;
@@ -35,6 +37,16 @@ pub fn build_router(state: SharedState) -> Router {
         .route(
             "/repos/{owner}/{repo}/branches/{*branch}",
             get(branches::get_branch),
+        )
+        // Repository-reader endpoints. Refs and paths may both contain `/`,
+        // so each is captured as the remainder of its route.
+        .route(
+            "/repos/{owner}/{repo}/commits/{*selector}",
+            get(commits::get_commit),
+        )
+        .route(
+            "/repos/{owner}/{repo}/contents/{*path}",
+            get(contents::get_content),
         )
         // Pull request endpoints
         .route(

--- a/test/twin/github/src/handlers/mod.rs
+++ b/test/twin/github/src/handlers/mod.rs
@@ -9,6 +9,7 @@ pub mod manifests;
 pub mod oauth;
 pub mod pulls;
 pub mod releases;
+pub mod support;
 pub mod users;
 
 use axum::Router;

--- a/test/twin/github/src/handlers/pulls.rs
+++ b/test/twin/github/src/handlers/pulls.rs
@@ -3,42 +3,10 @@ use axum::extract::{Path, State};
 use axum::http::{HeaderMap, StatusCode};
 use axum::response::IntoResponse;
 
-use crate::auth::{
-    BearerTokenError, InstallationTokenAccessError, authorize_installation_token,
-    ensure_repo_permission,
-};
+use crate::auth::{authorize_installation_token, ensure_repo_permission};
+use crate::handlers::support::{bearer_token_error_response, repo_permission_error_response};
 use crate::server::SharedState;
 use crate::state::{PermissionLevel, PullRequest, TokenPermission};
-
-fn bearer_token_error_response(error: BearerTokenError) -> axum::response::Response {
-    match error {
-        BearerTokenError::Missing => (
-            StatusCode::UNAUTHORIZED,
-            Json(serde_json::json!({"message": "Unauthorized"})),
-        )
-            .into_response(),
-        BearerTokenError::Invalid => (
-            StatusCode::UNAUTHORIZED,
-            Json(serde_json::json!({"message": "Bad credentials"})),
-        )
-            .into_response(),
-    }
-}
-
-fn repo_permission_error_response(error: InstallationTokenAccessError) -> axum::response::Response {
-    match error {
-        InstallationTokenAccessError::RepoNotAccessible => (
-            StatusCode::NOT_FOUND,
-            Json(serde_json::json!({"message": "Not Found"})),
-        )
-            .into_response(),
-        InstallationTokenAccessError::PermissionDenied => (
-            StatusCode::FORBIDDEN,
-            Json(serde_json::json!({"message": "Resource not accessible by integration"})),
-        )
-            .into_response(),
-    }
-}
 
 /// POST /repos/{owner}/{repo}/pulls
 pub async fn create_pull_request(

--- a/test/twin/github/src/handlers/support.rs
+++ b/test/twin/github/src/handlers/support.rs
@@ -1,0 +1,75 @@
+//! Response and authorization helpers shared by the twin's handlers.
+//!
+//! GitHub answers every rejection with the same `{"message": ...}` envelope, so
+//! the mapping from an auth failure to a status lives here once rather than in
+//! each endpoint.
+
+use axum::Json;
+use axum::http::header::ACCEPT;
+use axum::http::{HeaderMap, StatusCode};
+use axum::response::{IntoResponse, Response};
+
+use crate::auth::{
+    BearerTokenError, InstallationTokenAccessError, authorize_installation_token,
+    ensure_repo_permission,
+};
+use crate::state::{AppState, PermissionLevel, TokenInfo, TokenPermission};
+
+/// Render GitHub's `{"message": ...}` error envelope.
+pub fn message(status: StatusCode, body: &'static str) -> Response {
+    (status, Json(serde_json::json!({ "message": body }))).into_response()
+}
+
+pub fn bearer_token_error_response(error: BearerTokenError) -> Response {
+    match error {
+        BearerTokenError::Missing => message(StatusCode::UNAUTHORIZED, "Unauthorized"),
+        BearerTokenError::Invalid => message(StatusCode::UNAUTHORIZED, "Bad credentials"),
+    }
+}
+
+pub fn repo_permission_error_response(error: InstallationTokenAccessError) -> Response {
+    match error {
+        InstallationTokenAccessError::RepoNotAccessible => {
+            message(StatusCode::NOT_FOUND, "Not Found")
+        }
+        InstallationTokenAccessError::PermissionDenied => message(
+            StatusCode::FORBIDDEN,
+            "Resource not accessible by integration",
+        ),
+    }
+}
+
+/// Authorize an installation token against one repository permission,
+/// rendering GitHub's response shape for every rejection.
+///
+/// The rejection is boxed because an `axum` `Response` is far larger than the
+/// token it displaces in the `Ok` path.
+pub fn authorize_repo_access(
+    headers: &HeaderMap,
+    state: &AppState,
+    repo: &str,
+    permission: TokenPermission,
+    level: PermissionLevel,
+) -> Result<TokenInfo, Box<Response>> {
+    let token = authorize_installation_token(headers, state)
+        .map_err(|error| Box::new(bearer_token_error_response(error)))?;
+    ensure_repo_permission(&token, repo, permission, level)
+        .map_err(|error| Box::new(repo_permission_error_response(error)))?;
+    Ok(token)
+}
+
+/// Whether the client explicitly listed `media_type` in its `Accept` header.
+pub fn accepts(headers: &HeaderMap, media_type: &str) -> bool {
+    headers.get_all(ACCEPT).iter().any(|value| {
+        value.to_str().is_ok_and(|value| {
+            value
+                .split(',')
+                .any(|candidate| candidate.trim() == media_type)
+        })
+    })
+}
+
+/// Whether `value` is an exact 40-character hex commit SHA.
+pub fn is_exact_commit_sha(value: &str) -> bool {
+    value.len() == 40 && value.bytes().all(|byte| byte.is_ascii_hexdigit())
+}

--- a/test/twin/github/src/server.rs
+++ b/test/twin/github/src/server.rs
@@ -13,6 +13,7 @@ pub type SharedState = Arc<RwLock<AppState>>;
 /// A running test server instance.
 pub struct TestServer {
     url:         String,
+    state:       SharedState,
     shutdown_tx: Option<tokio::sync::oneshot::Sender<()>>,
     handle:      Option<tokio::task::JoinHandle<()>>,
     _git_root:   TempDir, // Kept alive for the server's lifetime; cleaned up on drop
@@ -25,7 +26,7 @@ impl TestServer {
         init_git_repos(&mut state, git_root.path()).expect("failed to initialize git repos");
 
         let shared_state: SharedState = Arc::new(RwLock::new(state));
-        let router = build_router(shared_state);
+        let router = build_router(shared_state.clone());
 
         let listener = TcpListener::bind("127.0.0.1:0")
             .await
@@ -49,6 +50,7 @@ impl TestServer {
 
         Self {
             url,
+            state: shared_state,
             shutdown_tx: Some(shutdown_tx),
             handle: Some(handle),
             _git_root: git_root,
@@ -57,6 +59,10 @@ impl TestServer {
 
     pub fn url(&self) -> &str {
         &self.url
+    }
+
+    pub async fn active_token_count(&self) -> usize {
+        self.state.read().await.active_tokens.len()
     }
 
     pub async fn shutdown(mut self) {

--- a/test/twin/github/src/state.rs
+++ b/test/twin/github/src/state.rs
@@ -40,14 +40,50 @@ pub struct Installation {
 pub struct Repository {
     pub owner:          String,
     pub name:           String,
+    /// Ref selector (`heads/main`, `tags/v1.0.0`) to the commit SHA it names.
     pub refs:           HashMap<String, String>,
-    pub files:          HashMap<(String, String), Vec<u8>>,
+    /// Commit SHA to the repository paths readable at that commit.
+    pub files:          HashMap<String, HashMap<String, Vec<u8>>>,
     pub default_branch: String,
     pub private:        bool,
     pub git_dir:        Option<std::path::PathBuf>,
 }
 
+impl Repository {
+    /// Contents of `path` at `sha`, if the fixture seeded one.
+    pub fn file_at(&self, sha: &str, path: &str) -> Option<&Vec<u8>> {
+        self.files.get(sha).and_then(|paths| paths.get(path))
+    }
+
+    /// Whether any path at `sha` sits under `prefix`, i.e. `prefix` names a
+    /// directory rather than a file.
+    pub fn has_directory_at(&self, sha: &str, prefix: &str) -> bool {
+        self.files
+            .get(sha)
+            .is_some_and(|paths| paths.keys().any(|stored| stored.starts_with(prefix)))
+    }
+
+    /// Whether `sha` is a commit this repository can serve content for.
+    pub fn knows_commit(&self, sha: &str) -> bool {
+        self.files.contains_key(sha) || self.refs.values().any(|known| known == sha)
+    }
+}
+
 pub const DEFAULT_REPOSITORY_SHA: &str = "0123456789abcdef0123456789abcdef01234567";
+
+/// The ref selector GitHub uses for a branch.
+pub fn heads_selector(branch: &str) -> String {
+    format!("heads/{branch}")
+}
+
+/// Seed each branch at [`DEFAULT_REPOSITORY_SHA`], the shape every repository
+/// fixture starts in.
+pub fn head_refs(branches: Vec<String>) -> HashMap<String, String> {
+    branches
+        .into_iter()
+        .map(|branch| (heads_selector(&branch), DEFAULT_REPOSITORY_SHA.to_string()))
+        .collect()
+}
 
 /// A pull request.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -393,19 +429,10 @@ impl AppState {
         branches: Vec<String>,
         private: bool,
     ) {
-        let refs = branches
-            .into_iter()
-            .map(|branch| {
-                (
-                    format!("heads/{branch}"),
-                    DEFAULT_REPOSITORY_SHA.to_string(),
-                )
-            })
-            .collect();
         self.repositories.push(Repository {
             owner: owner.to_string(),
             name: name.to_string(),
-            refs,
+            refs: head_refs(branches),
             files: HashMap::new(),
             default_branch: "main".to_string(),
             private,
@@ -413,13 +440,21 @@ impl AppState {
         });
     }
 
-    pub fn set_repository_ref(&mut self, owner: &str, name: &str, selector: &str, sha: &str) {
-        let repository = self
-            .repositories
+    pub fn find_repository(&self, owner: &str, name: &str) -> Option<&Repository> {
+        self.repositories
+            .iter()
+            .find(|repository| repository.owner == owner && repository.name == name)
+    }
+
+    fn repository_mut(&mut self, owner: &str, name: &str) -> &mut Repository {
+        self.repositories
             .iter_mut()
             .find(|repository| repository.owner == owner && repository.name == name)
-            .expect("repository fixture should exist before adding a ref");
-        repository
+            .expect("repository fixture should exist before seeding refs or files")
+    }
+
+    pub fn set_repository_ref(&mut self, owner: &str, name: &str, selector: &str, sha: &str) {
+        self.repository_mut(owner, name)
             .refs
             .insert(selector.to_string(), sha.to_string());
     }
@@ -432,14 +467,11 @@ impl AppState {
         path: &str,
         contents: impl Into<Vec<u8>>,
     ) {
-        let repository = self
-            .repositories
-            .iter_mut()
-            .find(|repository| repository.owner == owner && repository.name == name)
-            .expect("repository fixture should exist before adding a file");
-        repository
+        self.repository_mut(owner, name)
             .files
-            .insert((sha.to_string(), path.to_string()), contents.into());
+            .entry(sha.to_string())
+            .or_default()
+            .insert(path.to_string(), contents.into());
     }
 
     pub fn find_installation(&self, owner: &str, repo: &str) -> Option<&Installation> {

--- a/test/twin/github/src/state.rs
+++ b/test/twin/github/src/state.rs
@@ -40,11 +40,14 @@ pub struct Installation {
 pub struct Repository {
     pub owner:          String,
     pub name:           String,
-    pub branches:       Vec<String>,
+    pub refs:           HashMap<String, String>,
+    pub files:          HashMap<(String, String), Vec<u8>>,
     pub default_branch: String,
     pub private:        bool,
     pub git_dir:        Option<std::path::PathBuf>,
 }
+
+pub const DEFAULT_REPOSITORY_SHA: &str = "0123456789abcdef0123456789abcdef01234567";
 
 /// A pull request.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -390,14 +393,53 @@ impl AppState {
         branches: Vec<String>,
         private: bool,
     ) {
+        let refs = branches
+            .into_iter()
+            .map(|branch| {
+                (
+                    format!("heads/{branch}"),
+                    DEFAULT_REPOSITORY_SHA.to_string(),
+                )
+            })
+            .collect();
         self.repositories.push(Repository {
             owner: owner.to_string(),
             name: name.to_string(),
-            branches,
+            refs,
+            files: HashMap::new(),
             default_branch: "main".to_string(),
             private,
             git_dir: None,
         });
+    }
+
+    pub fn set_repository_ref(&mut self, owner: &str, name: &str, selector: &str, sha: &str) {
+        let repository = self
+            .repositories
+            .iter_mut()
+            .find(|repository| repository.owner == owner && repository.name == name)
+            .expect("repository fixture should exist before adding a ref");
+        repository
+            .refs
+            .insert(selector.to_string(), sha.to_string());
+    }
+
+    pub fn add_repository_file(
+        &mut self,
+        owner: &str,
+        name: &str,
+        sha: &str,
+        path: &str,
+        contents: impl Into<Vec<u8>>,
+    ) {
+        let repository = self
+            .repositories
+            .iter_mut()
+            .find(|repository| repository.owner == owner && repository.name == name)
+            .expect("repository fixture should exist before adding a file");
+        repository
+            .files
+            .insert((sha.to_string(), path.to_string()), contents.into());
     }
 
     pub fn find_installation(&self, owner: &str, repo: &str) -> Option<&Installation> {


### PR DESCRIPTION
## Summary

- Add a repository-scoped `GitHubRepositoryReader` that resolves refs to canonical 40-hex commit SHAs and streams caller-capped UTF-8 files at an explicitly supplied exact SHA.
- Resolve App authentication once per reader while preserving direct PAT and installation-token behavior.
- Require GitHub raw-file media for successful content reads, rejecting directory and object metadata before consuming the body.
- Migrate the live branch-head lookup to the raw commits endpoint while preserving its public signature, retry behavior, and 404-to-`None` compatibility.
- Extend Twin GitHub with exact ref/file state, commit and content endpoints, stored branch SHAs, and inspectable token counts.

## Safety and provider semantics

- Repository paths, ref selectors, API bases, and exact SHAs are validated before their corresponding requests.
- Successful SHA and file bodies are bounded on the wire; invalid UTF-8 errors retain only `std::str::Utf8Error`, not repository bytes.
- New errors omit bearer tokens, raw request URLs, upstream response bodies, ref/path inputs, and file contents while preserving safe source chains.
- GitHub can use 404 to hide inaccessible private resources, so not-found means not observable with the current credentials.
- Rate-limit detection is intentionally header-based. A body-only secondary-limit 403 remains permission-denied because error bodies are never consumed.

## Scope

This establishes the network boundary for later repository-backed `RunIntent` admission. Admission orchestration, materialization policy, aggregate budgets, overall deadlines, retries and caching, clone/tree APIs, persistence, OpenAPI, and generated clients remain out of scope.

## Verification

- `cargo +nightly-2026-04-14 fmt --check --all`
- `cargo +nightly-2026-04-14 clippy -p fabro-github -p twin-github -p fabro-test -p fabro-workflow --all-targets -- -D warnings`
- `cargo nextest run -p twin-github`
- `cargo nextest run -p fabro-github`
- `FABRO_TEST_MODE=twin cargo nextest run -p fabro-github --test integration --run-ignored only`
- `cargo nextest run -p fabro-workflow -- stale_remote_branch_is_rejected_before_pull_request_creation`