### PR TITLE
Harden template dependency discovery

### DIFF
--- a/lib/foundation/fabro-template/src/dependency.rs
+++ b/lib/foundation/fabro-template/src/dependency.rs
@@ -32,10 +32,18 @@ pub struct ExtractedTemplateDependencies {
 
 #[derive(Debug, Error)]
 pub enum TemplateDiscoveryError {
-    #[error(transparent)]
-    Parse(#[from] TemplateError),
-    #[error(transparent)]
-    Load(#[from] TemplateLoadError),
+    #[error("invalid template `{parent}`")]
+    Parse {
+        parent: ManifestPath,
+        #[source]
+        source: Box<TemplateError>,
+    },
+    #[error("failed to load a template dependency of `{parent}`")]
+    Load {
+        parent: ManifestPath,
+        #[source]
+        source: TemplateLoadError,
+    },
     #[error("missing template dependency `{reference}` from `{parent}`")]
     Missing {
         parent:    ManifestPath,
@@ -43,6 +51,19 @@ pub enum TemplateDiscoveryError {
     },
     #[error("dynamic template dependency in `{parent}` must be declared explicitly")]
     Dynamic { parent: ManifestPath },
+}
+
+impl TemplateDiscoveryError {
+    /// Path of the template source this error is attributed to.
+    #[must_use]
+    pub fn source_path(&self) -> &ManifestPath {
+        match self {
+            Self::Parse { parent, .. }
+            | Self::Load { parent, .. }
+            | Self::Missing { parent, .. }
+            | Self::Dynamic { parent } => parent,
+        }
+    }
 }
 
 #[derive(Clone, Debug, Default)]
@@ -107,20 +128,27 @@ pub fn discover_static_dependency_closure(
     }
 
     while let Some(source) = queue.pop_front() {
-        let dependencies =
-            extract_template_dependencies(&source.path.to_string(), &source.content)?;
+        let dependencies = extract_template_dependencies(&source.path.to_string(), &source.content)
+            .map_err(|error| TemplateDiscoveryError::Parse {
+                parent: source.path.clone(),
+                source: Box::new(error),
+            })?;
         if !dependencies.dynamic_references.is_empty() {
             return Err(TemplateDiscoveryError::Dynamic {
                 parent: source.path,
             });
         }
         for dependency in dependencies.static_references {
-            let loaded = store.load(&source, &dependency.reference)?.ok_or_else(|| {
-                TemplateDiscoveryError::Missing {
+            let loaded = store
+                .load(&source, &dependency.reference)
+                .map_err(|error| TemplateDiscoveryError::Load {
+                    parent: source.path.clone(),
+                    source: error,
+                })?
+                .ok_or_else(|| TemplateDiscoveryError::Missing {
                     parent:    source.path.clone(),
                     reference: dependency.reference.clone(),
-                }
-            })?;
+                })?;
             enqueue(loaded, &mut sources, &mut queue);
         }
     }

--- a/lib/foundation/fabro-template/src/dependency.rs
+++ b/lib/foundation/fabro-template/src/dependency.rs
@@ -80,15 +80,30 @@ pub fn discover_static_dependency_closure(
     store: &dyn TemplateStore,
 ) -> Result<TemplateDependencyClosure, TemplateDiscoveryError> {
     let mut sources = HashMap::new();
+    // A root and a loaded file can collide on `path` while carrying different
+    // content (an inline prompt is anchored at its graph file's path), so
+    // traversal dedup keys on the full occurrence rather than the path: a
+    // path-keyed check would leave the collided occurrence unparsed. The
+    // result map stays path-keyed, with the last distinct occurrence winning.
+    let mut parsed = HashSet::new();
     let mut queue = VecDeque::new();
 
-    for source in roots {
-        if sources
-            .insert(source.path.clone(), source.clone())
-            .is_none()
-        {
+    let mut enqueue = |source: TemplateSource,
+                       sources: &mut HashMap<ManifestPath, TemplateSource>,
+                       queue: &mut VecDeque<TemplateSource>| {
+        let occurrence = (
+            source.path.clone(),
+            source.root.clone(),
+            source.content.clone(),
+        );
+        if parsed.insert(occurrence) {
+            sources.insert(source.path.clone(), source.clone());
             queue.push_back(source);
         }
+    };
+
+    for source in roots {
+        enqueue(source, &mut sources, &mut queue);
     }
 
     while let Some(source) = queue.pop_front() {
@@ -106,12 +121,7 @@ pub fn discover_static_dependency_closure(
                     reference: dependency.reference.clone(),
                 }
             })?;
-            if sources
-                .insert(loaded.path.clone(), loaded.clone())
-                .is_none()
-            {
-                queue.push_back(loaded);
-            }
+            enqueue(loaded, &mut sources, &mut queue);
         }
     }
 

--- a/lib/foundation/fabro-template/src/lib.rs
+++ b/lib/foundation/fabro-template/src/lib.rs
@@ -1389,6 +1389,123 @@ mod tests {
     }
 
     #[test]
+    fn static_dependency_closure_visits_colliding_root_occurrences() {
+        let roots = [
+            TemplateSource::new(manifest_path("workflow.fabro"), manifest_path("."), "valid"),
+            TemplateSource::new(
+                manifest_path("workflow.fabro"),
+                manifest_path("."),
+                r"{% include inputs.partial %}",
+            ),
+        ];
+
+        let error =
+            discover_static_dependency_closure(roots, bundle_store(&[]).as_ref()).unwrap_err();
+
+        assert!(matches!(
+            error,
+            TemplateDiscoveryError::Dynamic { parent }
+                if parent == manifest_path("workflow.fabro")
+        ));
+    }
+
+    #[test]
+    fn static_dependency_closure_parses_dependencies_shadowed_by_root_paths() {
+        // An inline root anchored at its graph file's path must not shadow the
+        // file itself when another template includes it: the loaded file
+        // content still gets parsed.
+        let roots = [
+            TemplateSource::new(manifest_path("workflow.fabro"), manifest_path("."), "valid"),
+            TemplateSource::new(
+                manifest_path("goal.md"),
+                manifest_path("."),
+                r#"{% include "workflow.fabro" %}"#,
+            ),
+        ];
+
+        let error = discover_static_dependency_closure(
+            roots,
+            bundle_store(&[("workflow.fabro", r#"{% include "missing.md" %}"#)]).as_ref(),
+        )
+        .unwrap_err();
+
+        assert!(matches!(
+            error,
+            TemplateDiscoveryError::Missing { parent, reference }
+                if parent == manifest_path("workflow.fabro") && reference == "missing.md"
+        ));
+    }
+
+    #[test]
+    fn static_dependency_closure_parses_identical_root_occurrences_once() {
+        struct CountingStore {
+            inner: Arc<dyn TemplateStore>,
+            loads: std::sync::atomic::AtomicUsize,
+        }
+
+        impl TemplateStore for CountingStore {
+            fn load(
+                &self,
+                parent: &TemplateSource,
+                reference: &str,
+            ) -> Result<Option<TemplateSource>, TemplateLoadError> {
+                self.loads
+                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                self.inner.load(parent, reference)
+            }
+        }
+
+        let root = TemplateSource::new(
+            manifest_path("main.md"),
+            manifest_path("."),
+            r#"{% include "shared.md" %}"#,
+        );
+        let store = CountingStore {
+            inner: bundle_store(&[("shared.md", "shared")]),
+            loads: std::sync::atomic::AtomicUsize::new(0),
+        };
+
+        let closure = discover_static_dependency_closure([root.clone(), root], &store).unwrap();
+
+        assert!(closure.sources.contains_key(&manifest_path("shared.md")));
+        assert_eq!(store.loads.load(std::sync::atomic::Ordering::Relaxed), 1);
+    }
+
+    #[test]
+    fn static_dependency_closure_deduplicates_loaded_dependencies_across_roots() {
+        let roots = [
+            TemplateSource::new(
+                manifest_path("first.md"),
+                manifest_path("."),
+                r#"{% include "shared.md" %}"#,
+            ),
+            TemplateSource::new(
+                manifest_path("second.md"),
+                manifest_path("."),
+                r#"{% include "shared.md" %}"#,
+            ),
+        ];
+
+        let closure = discover_static_dependency_closure(
+            roots,
+            bundle_store(&[
+                ("shared.md", r#"{% include "nested.md" %}"#),
+                ("nested.md", "nested"),
+            ])
+            .as_ref(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            closure.paths(),
+            ["first.md", "second.md", "shared.md", "nested.md"]
+                .into_iter()
+                .map(manifest_path)
+                .collect()
+        );
+    }
+
+    #[test]
     fn render_lenient_named_preserves_source_name_for_syntax_errors() {
         let ctx = TemplateContext::new();
         let err = render_lenient_named("workflow.fabro", "{{ unterminated", &ctx).unwrap_err();


### PR DESCRIPTION
## Summary

- Template dependency discovery pre-seeded roots into the path-keyed result map and reused that map as its traversal-dedup set, so a loaded include target whose path matched a root was recorded but never parsed (an include chain that reaches the file anchoring a root silently skips validating its content), and a second root occurrence at an already-seeded path was dropped without parsing. Traversal now dedups on the full (path, root, content) occurrence: every distinct authored occurrence is parsed exactly once, and identical duplicates parse once.
- `TemplateDiscoveryError` now carries the failing source's path on every variant with a total `source_path()` accessor, replacing per-variant Display-string attribution (parent for some load failures, the child path for dynamic dependencies, nothing for I/O). Parse and load failures render a parent-naming message above the preserved source chain instead of forwarding transparently.

Extracted ahead of #748, which batches multiple discovery roots per call and consumes `source_path()` for error attribution.

## Verification

- cargo nextest run -p fabro-template -p fabro-workflow-version -p fabro-manifest
- cargo build --workspace
- cargo +nightly-2026-04-14 clippy -p fabro-template -p fabro-workflow-version -p fabro-manifest --all-targets -- -D warnings
- cargo +nightly-2026-04-14 fmt --check --all
- New regression tests verified to fail against the previous discovery implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)