### PR TITLE
Classify provider 412s as failover-eligible account lockouts

### DIFF
--- a/lib/components/fabro-llm/src/error.rs
+++ b/lib/components/fabro-llm/src/error.rs
@@ -355,7 +355,12 @@ pub fn error_from_status_code(
     // error types
     let kind = match status_code {
         401 => ProviderErrorKind::Authentication,
-        403 => ProviderErrorKind::AccessDenied,
+        // A 412 is never about the request: no LLM request carries
+        // conditional-request preconditions. Fireworks uses it for
+        // account-level lockouts (suspension over a spending cap or unpaid
+        // invoices), the same family as `account_deactivated`: deterministic
+        // here, but another provider has independent billing.
+        403 | 412 => ProviderErrorKind::AccessDenied,
         404 => ProviderErrorKind::NotFound,
         408 => {
             return Error::RequestTimeout {
@@ -726,6 +731,53 @@ mod tests {
             None,
         );
         assert_eq!(err.provider_kind(), Some(ProviderErrorKind::QuotaExceeded));
+    }
+
+    /// Fireworks reports an account suspension (spending cap reached or
+    /// unpaid invoices) as HTTP 412 with `code: "PRECONDITION_FAILED"` in
+    /// the body. A chat completion carries no conditional-request
+    /// preconditions, so a 412 is always an account-level lockout, never a
+    /// defect in the request: it must not classify as `InvalidRequest`, and
+    /// a fallback provider with independent billing must stay eligible.
+    #[test]
+    fn account_suspension_412_is_failover_eligible() {
+        let err = error_from_status_code(
+            412,
+            "Account lithoscomputer is suspended, possibly due to reaching \
+             the monthly spending limit or failure to pay past invoices."
+                .into(),
+            "fireworks".into(),
+            // The openai_compatible dialect reads `error.type` as the code,
+            // so the discriminating `PRECONDITION_FAILED` only reaches this
+            // mapping through the status code.
+            Some("error".into()),
+            Some(serde_json::json!({
+                "error": {
+                    "message": "Account lithoscomputer is suspended, possibly due to reaching the monthly spending limit or failure to pay past invoices. Please go to https://fireworks.ai/account/billing for more information.",
+                    "param": null,
+                    "code": "PRECONDITION_FAILED",
+                    "type": "error"
+                },
+                "request_id": "chatcmpl-d9652b89a6604931ac27dddd5ef5bdc0"
+            })),
+            None,
+        );
+
+        assert_eq!(err.provider_kind(), Some(ProviderErrorKind::AccessDenied));
+        assert!(!err.retryable());
+        assert!(err.failover_eligible());
+
+        // A bare 412 with no parseable body classifies the same way.
+        let err = error_from_status_code(
+            412,
+            "Precondition Failed".into(),
+            "fireworks".into(),
+            None,
+            None,
+            None,
+        );
+        assert_eq!(err.provider_kind(), Some(ProviderErrorKind::AccessDenied));
+        assert!(err.failover_eligible());
     }
 
     #[test]

--- a/lib/components/fabro-llm/src/error.rs
+++ b/lib/components/fabro-llm/src/error.rs
@@ -356,10 +356,12 @@ pub fn error_from_status_code(
     let kind = match status_code {
         401 => ProviderErrorKind::Authentication,
         // A 412 is never about the request: no LLM request carries
-        // conditional-request preconditions. Fireworks uses it for
-        // account-level lockouts (suspension over a spending cap or unpaid
-        // invoices), the same family as `account_deactivated`: deterministic
-        // here, but another provider has independent billing.
+        // conditional-request preconditions. Fireworks documents it as
+        // "Account is suspended or there's an issue with account status",
+        // also emitted for a LoRA model that failed to load
+        // (https://docs.fireworks.ai/guides/inference-error-codes). The same
+        // family as `account_deactivated`: deterministic here, but another
+        // provider has independent billing and model inventory.
         403 | 412 => ProviderErrorKind::AccessDenied,
         404 => ProviderErrorKind::NotFound,
         408 => {


### PR DESCRIPTION
## Problem

Fireworks reports an account suspension (spending cap reached or unpaid invoices) as **HTTP 412** with `code: PRECONDITION_FAILED`:

```json
{"error": {"message": "Account ... is suspended, possibly due to reaching the monthly spending limit or failure to pay past invoices.", "param": null, "code": "PRECONDITION_FAILED", "type": "error"}}
```

`error_from_status_code` had no explicit 412 mapping, and the openai_compatible dialect extracts `error.type` (`"error"`) as the error code, so the discriminating `PRECONDITION_FAILED` never reached the classifier. The suspension fell through to `InvalidRequest` — a deterministic request defect — which suppressed both same-provider retry and the configured model fallback chain. A live `implement-work-order` run (`01M0AQSB0PKTKPTPGTM301ZJMQ`) died mid-plan-stage this way with five healthy fallback candidates configured, surfacing only as `goal gate unsatisfied for node finalization`.

## Fix

No LLM request carries conditional-request preconditions (`If-Match` etc.), so a 412 from a provider is never about the request — it's account-level policy. Map 412 to `AccessDenied`, the same family as the existing `account_deactivated` error-code mapping: non-retryable on the same provider, but `failover_eligible()`, so the workflow engine's fallback path (`handler/llm/api.rs`) can continue on a provider with independent billing.

Written test-first: the new test reproduces the production event verbatim (real status, extracted code, and body) and failed with `InvalidRequest` before the one-arm fix.

## Verification

- `cargo nextest run -p fabro-llm` — 692/692 pass
- `cargo +nightly-2026-04-14 fmt --check -p fabro-llm` — clean
- `cargo +nightly-2026-04-14 clippy -p fabro-llm --all-targets -- -D warnings` — clean (the 403/412 arms are merged per `match_same_arms`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)