### PR TITLE
Default Daytona auto-stop to 120 minutes

### DIFF
--- a/docs/public/execution/run-configuration.mdx
+++ b/docs/public/execution/run-configuration.mdx
@@ -321,7 +321,7 @@ memory = "8GB"
 | `network.allow` | CIDRs for `cidr_allow_list`; entries are validated as CIDRs. |
 | `lifecycle.preserve` | Keep the created sandbox after the run finishes. |
 | `lifecycle.stop_on_terminal` | Stop the sandbox when the run reaches a terminal state. |
-| `lifecycle.auto_stop` | Daytona auto-stop duration, such as `"30m"`. |
+| `lifecycle.auto_stop` | Daytona auto-stop duration, such as `"30m"`. Defaults to `"120m"`; `"0s"` disables auto-stop. |
 | `labels` | Provider labels. Merge by key across layers. |
 | `env` | Environment variables passed to command and agent execution. Merge by key across layers. |
 

--- a/docs/public/integrations/daytona.mdx
+++ b/docs/public/integrations/daytona.mdx
@@ -198,6 +198,10 @@ The `lifecycle.auto_stop` setting tells Daytona to stop the sandbox after a peri
 auto_stop = "30m"
 ```
 
+When `auto_stop` is unset, Fabro applies a default of 120 minutes so a sandbox leaked by an interrupted run is still reclaimed. Set `auto_stop = "0s"` to disable auto-stop and let the sandbox run indefinitely.
+
+Daytona counts inactivity from the last sandbox interaction (a command, file operation, or other API call). Time an agent spends on LLM inference does not touch the sandbox, so intervals shorter than your longest inference call risk stopping the sandbox mid-run.
+
 ## Server defaults
 
 When running via `fabro server start`, the server config at `~/.fabro/settings.toml` can set default Daytona settings for all runs. Run config TOML values override server defaults. Labels are **merged** — run config labels win on key collisions. The `network` setting uses simple override (run config replaces the server default entirely).

--- a/lib/components/fabro-sandbox/src/daytona/mod.rs
+++ b/lib/components/fabro-sandbox/src/daytona/mod.rs
@@ -68,6 +68,12 @@ const DAYTONA_START_TIMEOUT: Duration = Duration::from_mins(1);
 /// deletion, temporary stdin files) so a stalled REST call cannot block
 /// cancellation/timeout paths indefinitely.
 const DAYTONA_CLEANUP_TIMEOUT: Duration = Duration::from_secs(10);
+/// Auto-stop applied when `lifecycle.auto_stop` is unset. Omitting the field
+/// would inherit Daytona's server-side default of 15 idle minutes, which is
+/// shorter than a single long inference call and stops the sandbox mid-run;
+/// 120 minutes clears any realistic call while still reclaiming sandboxes
+/// leaked by a dead worker. An explicit `0` disables auto-stop entirely.
+const DEFAULT_AUTO_STOP_INTERVAL_MINUTES: i32 = 120;
 
 /// Permissions a Daytona API key needs for Fabro's snapshot and sandbox flow.
 pub const REQUIRED_DAYTONA_PERMISSIONS: &[Permissions] = &[
@@ -727,7 +733,10 @@ impl DaytonaSandbox {
         daytona_sdk::SandboxBaseParams {
             name: Some(name),
             env_vars: Some(clean_bash_env(None)),
-            auto_stop_interval: self.config.auto_stop_interval,
+            auto_stop_interval: self
+                .config
+                .auto_stop_interval
+                .or(Some(DEFAULT_AUTO_STOP_INTERVAL_MINUTES)),
             labels: Some(managed_labels::merge_for_run(
                 self.config.labels.as_ref(),
                 self.run_id.as_ref(),
@@ -2951,6 +2960,10 @@ mod tests {
         assert_eq!(params.ephemeral, Some(false));
         assert_eq!(params.auto_delete_interval, Some(-1));
         assert_eq!(
+            params.auto_stop_interval,
+            Some(DEFAULT_AUTO_STOP_INTERVAL_MINUTES)
+        );
+        assert_eq!(
             params.env_vars,
             Some(HashMap::from([(BASH_ENV_VAR.to_string(), String::new())]))
         );
@@ -2961,6 +2974,27 @@ mod tests {
                 "true".to_string(),
             )]))
         );
+    }
+
+    #[tokio::test]
+    async fn base_params_passes_explicit_auto_stop_through() {
+        for interval in [0, 45] {
+            let sandbox = DaytonaSandbox::new(
+                DaytonaConfig {
+                    auto_stop_interval: Some(interval),
+                    ..DaytonaConfig::default()
+                },
+                None,
+                None,
+                None,
+                None,
+                Some("dtn_test".to_string()),
+            )
+            .await
+            .expect("sandbox config should be valid");
+
+            assert_eq!(sandbox.base_params().auto_stop_interval, Some(interval));
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Why

Fabro omits `autoStopInterval` from the Daytona create-sandbox request when `lifecycle.auto_stop` is unset, which inherits Daytona's server-side default of **15 idle minutes**. Daytona counts inactivity from the last sandbox interaction (command, file op, API call) — and LLM inference never touches the sandbox — so one long inference call is enough for the sandbox to auto-stop mid-run.

A run failed exactly this way: the agent's last sandbox command finished at 20:20:47, the agent then thought for ~15 minutes, and Daytona began stopping the sandbox at the 15:00 mark — 11 seconds before the stage finished and the pipeline tried to reactivate it.

## What

- Send an explicit 120-minute default when `lifecycle.auto_stop` is unset, applied in `base_params()` so every create path is covered. 120 minutes clears any realistic inference call while still reclaiming sandboxes leaked by a dead worker.
- An explicit `auto_stop = "0s"` still passes through as `0` and disables auto-stop entirely.
- Docs: state the default and the inference-doesn't-count-as-activity caveat in the Daytona integration page and run-configuration reference.

## Tests

- `base_params_create_run_owned_non_ephemeral_sandbox` now asserts the 120-minute default.
- New `base_params_passes_explicit_auto_stop_through` covers explicit `0` (disabled) and explicit non-zero values.
- Full `fabro-sandbox` suite passes with `daytona,docker` features; clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)