### PR TITLE
Classify sandbox state-change rejections as transient infra

### DIFF
--- a/lib/components/fabro-workflow/src/error.rs
+++ b/lib/components/fabro-workflow/src/error.rs
@@ -84,6 +84,8 @@ const TRANSIENT_INFRA_HINTS: &[&str] = &[
     "cross-device link",
     "invalid cross-device link",
     "os error 18",
+    "state change in progress",
+    "sandbox stop still in progress",
 ];
 
 const BUDGET_EXHAUSTED_HINTS: &[&str] = &[
@@ -808,6 +810,18 @@ mod tests {
     }
 
     #[test]
+    fn engine_error_with_sandbox_state_change_cause_classifies_transient() {
+        let source = TestOuterError {
+            message: "Failed to start Daytona sandbox",
+            source:  TestCause("Sandbox state change in progress"),
+        };
+        let err = Error::engine_with_source("Pipeline lifecycle operation failed", source);
+
+        assert_eq!(err.failure_category(), FailureCategory::TransientInfra);
+        assert!(err.is_retryable());
+    }
+
+    #[test]
     fn handler_error_display() {
         let err = Error::handler("LLM call failed");
         assert_eq!(err.to_string(), "Handler error: LLM call failed");
@@ -1281,7 +1295,7 @@ mod tests {
 
     #[test]
     fn transient_infra_hints_count() {
-        assert_eq!(TRANSIENT_INFRA_HINTS.len(), 38);
+        assert_eq!(TRANSIENT_INFRA_HINTS.len(), 40);
     }
 
     #[test]
@@ -1446,6 +1460,25 @@ mod tests {
     fn classify_reason_connection_reset() {
         assert_eq!(
             classify_failure_reason("connection reset by peer"),
+            FailureCategory::TransientInfra
+        );
+    }
+
+    #[test]
+    fn classify_reason_sandbox_state_change_in_progress() {
+        assert_eq!(
+            classify_failure_reason(
+                "Pipeline lifecycle operation failed: failed to activate sandbox after node \
+                 attempt survey: Failed to start Daytona sandbox: Sandbox state change in progress"
+            ),
+            FailureCategory::TransientInfra
+        );
+    }
+
+    #[test]
+    fn classify_reason_sandbox_stop_still_in_progress() {
+        assert_eq!(
+            classify_failure_reason("Daytona sandbox stop still in progress after 120s"),
             FailureCategory::TransientInfra
         );
     }


### PR DESCRIPTION
## Why

When a Daytona "Sandbox state change in progress" rejection surfaces through the pipeline lifecycle path, the run fails with `message: "Pipeline lifecycle operation failed"` and `category: deterministic` — the rendered error chain matches no `TRANSIENT_INFRA_HINTS` entry, and `classify_failure_reason` falls through to `Deterministic`.

A real run hit this: an inactivity auto-stop raced the post-stage sandbox activation, and the resulting failure event reported the transient provider condition as deterministic. The condition is a provider lifecycle transition that finishes on its own within seconds — the definition of transient infrastructure — and the deterministic label misinforms retry machinery and anyone reading the failure.

## What

Two new `TRANSIENT_INFRA_HINTS` entries:

- `"state change in progress"` — the Daytona API rejection while a lifecycle transition is in flight.
- `"sandbox stop still in progress"` — the bounded-wait timeout an activation reports when a stop transition outlives its budget.

## Tests

- `classify_reason_sandbox_state_change_in_progress` uses the exact rendered chain from the incident.
- `classify_reason_sandbox_stop_still_in_progress` covers the bounded-wait message.
- `engine_error_with_sandbox_state_change_cause_classifies_transient` proves the incident's error path (`engine_with_source` over a nested cause chain) now classifies transient and retryable.
- `transient_infra_hints_count` bumped 38 → 40; full `fabro-workflow` lib suite passes (1143 tests); clippy clean.

Related: #766 makes the underlying race rare, #767 makes it harmless. This PR makes any remaining escape honest about its nature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)