### PR TITLE
Label sandbox git execs with git_op tracing spans

### DIFF
--- a/lib/components/fabro-sandbox/src/daytona/mod.rs
+++ b/lib/components/fabro-sandbox/src/daytona/mod.rs
@@ -1542,6 +1542,7 @@ impl Sandbox for DaytonaSandbox {
         Ok(Some((preview.url, headers)))
     }
 
+    #[tracing::instrument(name = "git_op", skip_all, fields(op = "refresh-credentials"))]
     async fn refresh_push_credentials(&self) -> crate::Result<RefreshOutcome> {
         if !self.repo_cloned() {
             return Ok(RefreshOutcome::Skipped);

--- a/lib/components/fabro-sandbox/src/docker.rs
+++ b/lib/components/fabro-sandbox/src/docker.rs
@@ -2180,6 +2180,7 @@ impl Sandbox for DockerSandbox {
         self.origin_url.get().map(String::as_str)
     }
 
+    #[tracing::instrument(name = "git_op", skip_all, fields(op = "refresh-credentials"))]
     async fn refresh_push_credentials(&self) -> crate::Result<RefreshOutcome> {
         if !self.repo_cloned() {
             return Ok(RefreshOutcome::Skipped);

--- a/lib/components/fabro-sandbox/src/sandbox.rs
+++ b/lib/components/fabro-sandbox/src/sandbox.rs
@@ -1465,6 +1465,7 @@ pub async fn setup_git_via_exec(
     })
 }
 
+#[tracing::instrument(name = "git_op", skip_all, fields(op = "fetch"))]
 pub(crate) async fn fetch_source_run_ref(
     sandbox: &dyn Sandbox,
     source_run_id: &str,
@@ -1513,6 +1514,7 @@ pub(crate) async fn fetch_source_run_ref(
 
 /// Helper for sandbox implementations that manage git internally.
 /// Pushes a refspec to origin via exec_command inside the sandbox.
+#[tracing::instrument(name = "git_op", skip_all, fields(op = "push"))]
 pub async fn git_push_via_exec(sandbox: &dyn Sandbox, refspec: &str) -> crate::Result<()> {
     if let Err(e) = sandbox.refresh_push_credentials().await {
         tracing::warn!(

--- a/lib/components/fabro-workflow/src/run_metadata.rs
+++ b/lib/components/fabro-workflow/src/run_metadata.rs
@@ -184,6 +184,7 @@ impl RunMetadataWriterHandle {
         .unwrap()
     }
 
+    #[tracing::instrument(name = "git_op", skip_all, fields(op = "metadata-push"))]
     pub(crate) async fn write_snapshot(
         &self,
         dump: &RunDump,

--- a/lib/components/fabro-workflow/src/sandbox_git.rs
+++ b/lib/components/fabro-workflow/src/sandbox_git.rs
@@ -158,6 +158,7 @@ pub async fn git_checkpoint(
     clippy::too_many_arguments,
     reason = "Checkpointing needs explicit run metadata, checkpoint settings, and author inputs."
 )]
+#[tracing::instrument(name = "git_op", skip_all, fields(op = "checkpoint-commit"))]
 pub(crate) async fn checked_git_checkpoint(
     runtime: &SandboxGitRuntime,
     sandbox: &dyn Sandbox,


### PR DESCRIPTION
## Summary

Label sandbox Git operations with a structured `git_op` tracing span. This lets exec logs identify push, credential refresh, checkpoint commit, fetch, and metadata push operations.

This PR is based directly on `main` and contains one commit.

## Testing

- `cargo +nightly-2026-04-14 fmt --check --all`
- `cargo nextest run -p fabro-sandbox -p fabro-workflow` — 1,568 passed
- `cargo +nightly-2026-04-14 clippy -p fabro-sandbox -p fabro-workflow --all-targets -- -D warnings`