### PR TITLE
Stop run sandboxes that read-only inspection resurrects

### DIFF
--- a/lib/apps/fabro-server/src/run_files.rs
+++ b/lib/apps/fabro-server/src/run_files.rs
@@ -36,9 +36,9 @@ use fabro_api::types::{
     RunFilesMetaToSha,
 };
 use fabro_sandbox::reconnect::reconnect_for_run;
-use fabro_sandbox::shell_quote;
+use fabro_sandbox::{SandboxActivation, shell_quote};
 use fabro_static::EnvVars;
-use fabro_types::RunId;
+use fabro_types::{RunId, RunStatus};
 use fabro_workflow::sandbox_git::{
     DiffError, DiffNumstat, RawDiffEntry, SubmoduleChange, SymlinkChange, list_changed_files_raw,
     list_diff_numstat, stream_blob_metadata, stream_blobs,
@@ -306,20 +306,25 @@ async fn materialize_sandbox_range_path(
 ) -> ListRunFilesResult {
     let start = Instant::now();
     let projection = load_projection(state, run_id).await?;
-    let sandbox = reconnect_run_sandbox(state, run_id, &projection).await?;
-    let (resolved_to_sha, to_sha_committed_at) =
-        resolve_ref_sha_and_time(sandbox.as_ref(), to_sha).await?;
-    materialize_committed_range_sandbox_path(
-        sandbox.as_ref(),
-        None,
-        from_sha,
-        &resolved_to_sha,
-        to_sha_committed_at,
-        RunFilesMetaScope::Range,
-        run_id,
-        start,
-    )
-    .await
+    let inspection = reconnect_run_sandbox(state, run_id, &projection).await?;
+    let outcome = async {
+        let (resolved_to_sha, to_sha_committed_at) =
+            resolve_ref_sha_and_time(inspection.sandbox(), to_sha).await?;
+        materialize_committed_range_sandbox_path(
+            inspection.sandbox(),
+            None,
+            from_sha,
+            &resolved_to_sha,
+            to_sha_committed_at,
+            RunFilesMetaScope::Range,
+            run_id,
+            start,
+        )
+        .await
+    }
+    .await;
+    inspection.finish().await;
+    outcome
 }
 
 async fn materialize_run_commits(
@@ -333,25 +338,30 @@ async fn materialize_run_commits(
         .as_ref()
         .and_then(|s| s.base_sha.clone())
         .ok_or_else(|| ApiError::new(StatusCode::CONFLICT, "Run has no base SHA."))?;
-    let sandbox = reconnect_run_sandbox(state, run_id, &projection).await?;
-    let (head_sha, _) = resolve_ref_sha_and_time(sandbox.as_ref(), "HEAD").await?;
-    let output = git_log_commits(sandbox.as_ref(), &base_sha, &head_sha, limit + 1).await?;
-    let mut commits = parse_git_log_commits(&output)?;
-    let truncated = commits.len() > usize::try_from(limit).unwrap_or(usize::MAX);
-    commits.truncate(usize::try_from(limit).unwrap_or(usize::MAX));
-    let total_returned = u64::try_from(commits.len()).unwrap_or(u64::MAX);
+    let inspection = reconnect_run_sandbox(state, run_id, &projection).await?;
+    let outcome = async {
+        let (head_sha, _) = resolve_ref_sha_and_time(inspection.sandbox(), "HEAD").await?;
+        let output = git_log_commits(inspection.sandbox(), &base_sha, &head_sha, limit + 1).await?;
+        let mut commits = parse_git_log_commits(&output)?;
+        let truncated = commits.len() > usize::try_from(limit).unwrap_or(usize::MAX);
+        commits.truncate(usize::try_from(limit).unwrap_or(usize::MAX));
+        let total_returned = u64::try_from(commits.len()).unwrap_or(u64::MAX);
 
-    Ok(PaginatedRunCommitList {
-        data: commits,
-        meta: RunCommitsMeta {
-            source: RunCommitsMetaSource::Sandbox,
-            base_sha: sha_newtype::<RunCommitsMetaBaseSha>(&base_sha)?,
-            head_sha: sha_newtype::<RunCommitsMetaHeadSha>(&head_sha)?,
-            limit: NonZeroU64::new(limit).expect("commit limit is non-zero"),
-            total_returned,
-            truncated,
-        },
-    })
+        Ok(PaginatedRunCommitList {
+            data: commits,
+            meta: RunCommitsMeta {
+                source: RunCommitsMetaSource::Sandbox,
+                base_sha: sha_newtype::<RunCommitsMetaBaseSha>(&base_sha)?,
+                head_sha: sha_newtype::<RunCommitsMetaHeadSha>(&head_sha)?,
+                limit: NonZeroU64::new(limit).expect("commit limit is non-zero"),
+                total_returned,
+                truncated,
+            },
+        })
+    }
+    .await;
+    inspection.finish().await;
+    outcome
 }
 
 async fn git_log_commits(
@@ -524,8 +534,8 @@ async fn materialize_sandbox_path(
         ));
     };
 
-    let sandbox = match reconnect_run_sandbox(state, run_id, &projection).await {
-        Ok(sandbox) => sandbox,
+    let inspection = match reconnect_run_sandbox(state, run_id, &projection).await {
+        Ok(inspection) => inspection,
         Err(err) if sandbox_read_error_should_fallback(&err) => {
             return Ok(build_fallback_response(
                 &projection,
@@ -540,7 +550,7 @@ async fn materialize_sandbox_path(
     let materialized = match scope {
         ListRunFilesScope::Committed => {
             materialize_committed_sandbox_path(
-                sandbox.as_ref(),
+                inspection.sandbox(),
                 &projection,
                 &base_sha,
                 run_id,
@@ -550,7 +560,7 @@ async fn materialize_sandbox_path(
         }
         ListRunFilesScope::Uncommitted => {
             materialize_working_tree_sandbox_path(
-                sandbox.as_ref(),
+                inspection.sandbox(),
                 "HEAD",
                 RunFilesMetaScope::Uncommitted,
                 run_id,
@@ -560,7 +570,7 @@ async fn materialize_sandbox_path(
         }
         ListRunFilesScope::All => {
             materialize_working_tree_sandbox_path(
-                sandbox.as_ref(),
+                inspection.sandbox(),
                 &base_sha,
                 RunFilesMetaScope::All,
                 run_id,
@@ -570,7 +580,7 @@ async fn materialize_sandbox_path(
         }
     };
 
-    match materialized {
+    let outcome = match materialized {
         Ok(body) => Ok(body),
         Err(err) if sandbox_read_error_should_fallback(&err) => Ok(build_fallback_response(
             &projection,
@@ -579,7 +589,9 @@ async fn materialize_sandbox_path(
             start,
         )),
         Err(err) => Err(err),
-    }
+    };
+    inspection.finish().await;
+    outcome
 }
 
 fn sandbox_read_error_should_fallback(err: &ApiError) -> bool {
@@ -1198,11 +1210,71 @@ async fn load_projection(
     Ok(state.cached_run(run_id).await?.projection)
 }
 
+/// A run sandbox borrowed by a read-only inspection.
+///
+/// Inspection endpoints reconnect to the run's sandbox and activate it. When
+/// the run already reached a terminal state, activation may start a sandbox
+/// the run lifecycle previously stopped — and nothing else would ever stop it
+/// again, leaking a running sandbox forever. The guard records whether this
+/// inspection is responsible for restoring the stopped state; call
+/// [`InspectionSandbox::finish`] on every exit path.
+pub(crate) struct InspectionSandbox {
+    sandbox:    Box<dyn Sandbox>,
+    run_id:     RunId,
+    stop_after: bool,
+}
+
+impl InspectionSandbox {
+    /// Wrap an activated sandbox for a read-only inspection of a run in
+    /// `status`. The guard stops the sandbox again in [`Self::finish`] only
+    /// when the activation started it and the run already terminated.
+    pub(crate) fn new(
+        sandbox: Box<dyn Sandbox>,
+        run_id: RunId,
+        activation: SandboxActivation,
+        status: RunStatus,
+    ) -> Self {
+        Self {
+            sandbox,
+            run_id,
+            stop_after: inspection_should_stop(activation, status),
+        }
+    }
+
+    pub(crate) fn sandbox(&self) -> &dyn Sandbox {
+        self.sandbox.as_ref()
+    }
+
+    /// Restore the lifecycle state the inspection found: stop the sandbox
+    /// again when this inspection started it. Best-effort — cleanup failures
+    /// are logged, never surfaced over the inspection result.
+    pub(crate) async fn finish(self) {
+        if !self.stop_after {
+            return;
+        }
+        if let Err(err) = self.sandbox.stop().await {
+            tracing::warn!(
+                run_id = %self.run_id,
+                error = %err,
+                "Failed to stop run sandbox after read-only inspection"
+            );
+        }
+    }
+}
+
+/// Whether a read-only inspection that observed `activation` for a run in
+/// `status` must stop the sandbox again when it is finished. Only a terminal
+/// run's sandbox is safe to stop: any other status may belong to an active
+/// run whose lifecycle owns the sandbox.
+fn inspection_should_stop(activation: SandboxActivation, status: RunStatus) -> bool {
+    activation == SandboxActivation::Started && status.is_terminal()
+}
+
 async fn reconnect_run_sandbox(
     state: &Arc<AppState>,
     run_id: &RunId,
     projection: &fabro_store::RunProjection,
-) -> std::result::Result<Box<dyn Sandbox>, ApiError> {
+) -> std::result::Result<InspectionSandbox, ApiError> {
     let record = projection
         .sandbox
         .as_ref()
@@ -1216,11 +1288,16 @@ async fn reconnect_run_sandbox(
     let sandbox = reconnect_for_run(&record, daytona_api_key, Some(*run_id))
         .await
         .map_err(|err| ApiError::new(StatusCode::CONFLICT, err.to_string()))?;
-    sandbox
+    let activation = sandbox
         .activate()
         .await
         .map_err(|err| ApiError::new(StatusCode::CONFLICT, err.display_with_causes()))?;
-    Ok(sandbox)
+    Ok(InspectionSandbox::new(
+        sandbox,
+        *run_id,
+        activation,
+        projection.status,
+    ))
 }
 
 /// Resolve HEAD's SHA and its commit time in a single sandbox round-trip.
@@ -3135,5 +3212,160 @@ rename to .env.production
             .await
             .expect("small SHA lists skip phase 1 entirely; phase-2 success is the full story");
         assert_eq!(table.get(&sha), Some(&Some("hello".to_string())));
+    }
+
+    struct StopCountingSandbox {
+        stop_calls: std::sync::Arc<AtomicUsize>,
+    }
+
+    #[async_trait::async_trait]
+    impl fabro_agent::Sandbox for StopCountingSandbox {
+        async fn exec_command(
+            &self,
+            _command: &str,
+            _timeout_ms: u64,
+            _working_dir: Option<&str>,
+            _env_vars: Option<&std::collections::HashMap<String, String>>,
+            _cancel_token: Option<tokio_util::sync::CancellationToken>,
+        ) -> fabro_sandbox::Result<fabro_sandbox::ExecResult> {
+            unimplemented!("inspection guard tests never execute commands")
+        }
+        async fn read_file_bytes(&self, _path: &str) -> fabro_sandbox::Result<Vec<u8>> {
+            unimplemented!()
+        }
+        async fn write_file(&self, _: &str, _: &str) -> fabro_sandbox::Result<()> {
+            unimplemented!()
+        }
+        async fn delete_file(&self, _: &str) -> fabro_sandbox::Result<()> {
+            unimplemented!()
+        }
+        async fn file_exists(&self, _: &str) -> fabro_sandbox::Result<bool> {
+            unimplemented!()
+        }
+        async fn list_directory(
+            &self,
+            _path: &str,
+            _depth: Option<usize>,
+        ) -> fabro_sandbox::Result<Vec<fabro_sandbox::DirEntry>> {
+            unimplemented!()
+        }
+        async fn grep(
+            &self,
+            _pattern: &str,
+            _path: &str,
+            _options: &fabro_sandbox::GrepOptions,
+        ) -> fabro_sandbox::Result<Vec<String>> {
+            unimplemented!()
+        }
+        async fn glob(
+            &self,
+            _pattern: &str,
+            _path: Option<&str>,
+        ) -> fabro_sandbox::Result<Vec<String>> {
+            unimplemented!()
+        }
+        async fn download_file_to_local(
+            &self,
+            _remote: &str,
+            _local: &std::path::Path,
+        ) -> fabro_sandbox::Result<()> {
+            unimplemented!()
+        }
+        async fn upload_file_from_local(
+            &self,
+            _local: &std::path::Path,
+            _remote: &str,
+        ) -> fabro_sandbox::Result<()> {
+            unimplemented!()
+        }
+        async fn initialize(&self) -> fabro_sandbox::Result<()> {
+            Ok(())
+        }
+        async fn stop(&self) -> fabro_sandbox::Result<()> {
+            self.stop_calls.fetch_add(1, Ordering::Relaxed);
+            Ok(())
+        }
+        async fn cleanup(&self) -> fabro_sandbox::Result<()> {
+            Ok(())
+        }
+        fn working_directory(&self) -> &'static str {
+            "/workspace"
+        }
+        fn platform(&self) -> &'static str {
+            "linux"
+        }
+        fn os_version(&self) -> String {
+            "test".to_string()
+        }
+    }
+
+    fn succeeded_status() -> RunStatus {
+        RunStatus::Succeeded {
+            reason: fabro_types::SuccessReason::Completed,
+        }
+    }
+
+    #[test]
+    fn inspection_stop_decision_requires_started_activation_and_terminal_run() {
+        // Only the combination "activation started the sandbox" + "run is
+        // terminal" may stop it: an active run's lifecycle owns its sandbox,
+        // and an already-active sandbox was not resurrected by the caller.
+        assert!(inspection_should_stop(
+            SandboxActivation::Started,
+            succeeded_status()
+        ));
+        assert!(!inspection_should_stop(
+            SandboxActivation::Started,
+            RunStatus::Running
+        ));
+        assert!(!inspection_should_stop(
+            SandboxActivation::AlreadyActive,
+            succeeded_status()
+        ));
+    }
+
+    #[tokio::test]
+    async fn inspection_guard_stops_resurrected_terminal_run_sandbox() {
+        let stop_calls = std::sync::Arc::new(AtomicUsize::new(0));
+        let guard = InspectionSandbox::new(
+            Box::new(StopCountingSandbox {
+                stop_calls: std::sync::Arc::clone(&stop_calls),
+            }),
+            RunId::new(),
+            SandboxActivation::Started,
+            succeeded_status(),
+        );
+        guard.finish().await;
+        assert_eq!(stop_calls.load(Ordering::Relaxed), 1);
+    }
+
+    #[tokio::test]
+    async fn inspection_guard_leaves_active_run_sandbox_running() {
+        let stop_calls = std::sync::Arc::new(AtomicUsize::new(0));
+        let guard = InspectionSandbox::new(
+            Box::new(StopCountingSandbox {
+                stop_calls: std::sync::Arc::clone(&stop_calls),
+            }),
+            RunId::new(),
+            SandboxActivation::Started,
+            RunStatus::Running,
+        );
+        guard.finish().await;
+        assert_eq!(stop_calls.load(Ordering::Relaxed), 0);
+    }
+
+    #[tokio::test]
+    async fn inspection_guard_leaves_already_active_sandbox_running() {
+        let stop_calls = std::sync::Arc::new(AtomicUsize::new(0));
+        let guard = InspectionSandbox::new(
+            Box::new(StopCountingSandbox {
+                stop_calls: std::sync::Arc::clone(&stop_calls),
+            }),
+            RunId::new(),
+            SandboxActivation::AlreadyActive,
+            succeeded_status(),
+        );
+        guard.finish().await;
+        assert_eq!(stop_calls.load(Ordering::Relaxed), 0);
     }
 }

--- a/lib/apps/fabro-server/src/server/handler/sandbox.rs
+++ b/lib/apps/fabro-server/src/server/handler/sandbox.rs
@@ -4,7 +4,7 @@ use std::num::NonZeroU64;
 use std::sync::Arc;
 
 use axum::extract::ws::{Message as WsMessage, WebSocket, WebSocketUpgrade};
-use fabro_sandbox::{TerminalSize, open_terminal_for_run};
+use fabro_sandbox::{SandboxActivation, TerminalSize, open_terminal_for_run};
 use fabro_types::{
     RunSandboxInstance, SandboxProviderKind, SandboxServiceDiscoverySource, SandboxServiceListMeta,
 };
@@ -20,6 +20,7 @@ use super::super::{
     parse_run_id_path, post, reconnect_for_run, reject_if_archived, render_with_causes,
     sandbox_details,
 };
+use crate::run_files::InspectionSandbox;
 
 const MAX_TERMINAL_CONTROL_BYTES: usize = 4096;
 const DEFAULT_VNC_NO_VNC_PORT: u16 = 6080;
@@ -433,10 +434,11 @@ async fn create_ssh_access(
             }
         }
         SandboxProviderKind::Docker => {
-            let sandbox = match reconnect_run_sandbox_instance(&state, &id, &record).await {
-                Ok(sandbox) => sandbox,
-                Err(response) => return response,
-            };
+            let (sandbox, _activation) =
+                match reconnect_run_sandbox_instance(&state, &id, &record).await {
+                    Ok(pair) => pair,
+                    Err(response) => return response,
+                };
             match sandbox.ssh_access_command().await {
                 Ok(Some(command)) => {
                     (StatusCode::CREATED, Json(SshAccessResponse { command })).into_response()
@@ -543,11 +545,16 @@ async fn list_sandbox_files(
         Ok(id) => id,
         Err(response) => return response,
     };
-    let sandbox = match reconnect_run_sandbox(&state, &id).await {
-        Ok(sandbox) => sandbox,
+    let inspection = match reconnect_run_sandbox_for_inspection(&state, &id).await {
+        Ok(inspection) => inspection,
         Err(response) => return response,
     };
-    match sandbox.list_directory(&params.path, params.depth).await {
+    let listing = inspection
+        .sandbox()
+        .list_directory(&params.path, params.depth)
+        .await;
+    inspection.finish().await;
+    match listing {
         Ok(entries) => Json(SandboxFileListResponse {
             data: entries
                 .into_iter()
@@ -577,11 +584,12 @@ async fn list_sandbox_services(
         Err(response) => return response,
     };
     let provider = record.provider;
-    let sandbox = match reconnect_run_sandbox_instance(&state, &id, &record).await {
-        Ok(sandbox) => sandbox,
+    let inspection = match reconnect_run_sandbox_for_inspection(&state, &id).await {
+        Ok(inspection) => inspection,
         Err(response) => return response,
     };
-    let result = match sandbox
+    let exec = inspection
+        .sandbox()
         .exec_command(
             LIST_SANDBOX_SERVICES_COMMAND,
             LIST_SANDBOX_SERVICES_TIMEOUT_MS,
@@ -589,8 +597,9 @@ async fn list_sandbox_services(
             None,
             None,
         )
-        .await
-    {
+        .await;
+    inspection.finish().await;
+    let result = match exec {
         Ok(result) => result,
         Err(err) => {
             return ApiError::new(StatusCode::CONFLICT, err.display_with_causes()).into_response();
@@ -798,8 +807,8 @@ async fn get_sandbox_file(
         Ok(id) => id,
         Err(response) => return response,
     };
-    let sandbox = match reconnect_run_sandbox(&state, &id).await {
-        Ok(sandbox) => sandbox,
+    let inspection = match reconnect_run_sandbox_for_inspection(&state, &id).await {
+        Ok(inspection) => inspection,
         Err(response) => return response,
     };
     let temp = match NamedTempFile::new() {
@@ -809,10 +818,12 @@ async fn get_sandbox_file(
                 .into_response();
         }
     };
-    if let Err(err) = sandbox
+    let download = inspection
+        .sandbox()
         .download_file_to_local(&params.path, temp.path())
-        .await
-    {
+        .await;
+    inspection.finish().await;
+    if let Err(err) = download {
         return ApiError::new(StatusCode::NOT_FOUND, err.display_with_causes()).into_response();
     }
     match fs::read(temp.path()).await {
@@ -837,8 +848,8 @@ async fn put_sandbox_file(
     if let Some(response) = reject_if_archived(state.as_ref(), &id).await {
         return response;
     }
-    let sandbox = match reconnect_run_sandbox(&state, &id).await {
-        Ok(sandbox) => sandbox,
+    let (sandbox, _activation) = match reconnect_run_sandbox(&state, &id).await {
+        Ok(pair) => pair,
         Err(response) => return response,
     };
     let temp = match NamedTempFile::new() {
@@ -864,7 +875,7 @@ async fn put_sandbox_file(
 async fn reconnect_run_sandbox(
     state: &Arc<AppState>,
     run_id: &RunId,
-) -> Result<Box<dyn Sandbox>, Response> {
+) -> Result<(Box<dyn Sandbox>, SandboxActivation), Response> {
     let record = load_run_sandbox_instance(state, run_id).await?;
     reconnect_run_sandbox_instance(state, run_id, &record).await
 }
@@ -873,7 +884,7 @@ async fn reconnect_run_sandbox_instance(
     state: &Arc<AppState>,
     run_id: &RunId,
     record: &RunSandboxInstance,
-) -> Result<Box<dyn Sandbox>, Response> {
+) -> Result<(Box<dyn Sandbox>, SandboxActivation), Response> {
     let daytona_api_key = load_daytona_api_key(state).await?;
     let sandbox = reconnect_for_run(record, daytona_api_key, Some(*run_id))
         .await
@@ -881,10 +892,28 @@ async fn reconnect_run_sandbox_instance(
             let detail = render_with_causes(&err.to_string(), &collect_causes(err.as_ref()));
             ApiError::new(StatusCode::CONFLICT, detail).into_response()
         })?;
-    sandbox.activate().await.map_err(|err| {
+    let activation = sandbox.activate().await.map_err(|err| {
         ApiError::new(StatusCode::CONFLICT, err.display_with_causes()).into_response()
     })?;
-    Ok(sandbox)
+    Ok((sandbox, activation))
+}
+
+/// Reconnect a run sandbox for a read-only inspection and wrap it in an
+/// [`InspectionSandbox`] guard that restores the stopped state when the
+/// inspection itself started a sandbox of an already-terminated run.
+async fn reconnect_run_sandbox_for_inspection(
+    state: &Arc<AppState>,
+    run_id: &RunId,
+) -> Result<InspectionSandbox, Response> {
+    let status = state
+        .cached_run(run_id)
+        .await
+        .map_err(IntoResponse::into_response)?
+        .projection
+        .status;
+    let record = load_run_sandbox_instance(state, run_id).await?;
+    let (sandbox, activation) = reconnect_run_sandbox_instance(state, run_id, &record).await?;
+    Ok(InspectionSandbox::new(sandbox, *run_id, activation, status))
 }
 
 async fn reconnect_daytona_sandbox(

--- a/lib/components/fabro-sandbox/src/daytona/mod.rs
+++ b/lib/components/fabro-sandbox/src/daytona/mod.rs
@@ -37,8 +37,8 @@ use crate::sandbox::{
 };
 use crate::{
     CommandOutputCallback, DirEntry, ExecResult, ExecStreamingRequest, ExecStreamingResult,
-    GrepOptions, Sandbox, SandboxEvent, SandboxEventCallback, SandboxFile, StdioProcess,
-    WalkOptions, managed_labels, shell_quote,
+    GrepOptions, Sandbox, SandboxActivation, SandboxEvent, SandboxEventCallback, SandboxFile,
+    StdioProcess, WalkOptions, managed_labels, shell_quote,
 };
 
 /// Remediation shown when a Daytona sandbox has no usable Bash.
@@ -1609,7 +1609,7 @@ impl Sandbox for DaytonaSandbox {
             .await
     }
 
-    async fn activate(&self) -> crate::Result<()> {
+    async fn activate(&self) -> crate::Result<SandboxActivation> {
         let sandbox = self.sandbox()?;
         let deadline = time::Instant::now() + DAYTONA_STATE_CHANGE_TIMEOUT;
         let current = time::timeout_at(deadline, self.client.get(&sandbox.name))
@@ -1621,6 +1621,10 @@ impl Sandbox for DaytonaSandbox {
                 crate::Error::context("Failed to inspect Daytona sandbox before activation", e)
             })?;
         let state = if is_transitional_state(current.state) {
+            // Someone else is driving the lifecycle through a transitional
+            // state; wait for it to settle instead of racing them. Settling
+            // into Started means this call did not start the sandbox, so the
+            // caller must not own stopping it.
             time::timeout_at(deadline, self.wait_for_stable_state(&sandbox.name))
                 .await
                 .map_err(|_| {
@@ -1638,9 +1642,11 @@ impl Sandbox for DaytonaSandbox {
             current.state
         };
         if state == Some(SandboxState::Started) {
-            return Ok(());
+            return Ok(SandboxActivation::AlreadyActive);
         }
-        self.start_with_deadline(deadline).await
+        self.start_with_deadline(deadline)
+            .await
+            .map(|()| SandboxActivation::Started)
     }
 
     async fn stop(&self) -> crate::Result<()> {
@@ -3234,11 +3240,12 @@ mod tests {
             .expect("test sandbox should initialize once");
 
         let get_calls_before = get_sandbox.calls_async().await;
-        sandbox
+        let activation = sandbox
             .activate()
             .await
             .expect("an active sandbox should require no restart");
 
+        assert_eq!(activation, SandboxActivation::AlreadyActive);
         assert_eq!(get_sandbox.calls_async().await, get_calls_before + 1);
         start_sandbox.assert_calls_async(0).await;
     }
@@ -3291,11 +3298,13 @@ mod tests {
             .expect("test sandbox should initialize once");
 
         let get_calls_before = get_sandbox.calls_async().await;
-        sandbox
+        let activation = sandbox
             .activate()
             .await
             .expect("an in-progress start should be awaited");
 
+        // Someone else initiated the start; this call must not own stopping.
+        assert_eq!(activation, SandboxActivation::AlreadyActive);
         assert_eq!(get_sandbox.calls_async().await, get_calls_before + 2);
         start_sandbox.assert_calls_async(0).await;
     }

--- a/lib/components/fabro-sandbox/src/docker.rs
+++ b/lib/components/fabro-sandbox/src/docker.rs
@@ -38,9 +38,9 @@ use crate::sandbox::{
 };
 use crate::{
     CommandOutputCallback, DEFAULT_EXEC_OUTPUT_TAIL_BYTES, DirEntry, ExecResult,
-    ExecStreamingRequest, ExecStreamingResult, GrepOptions, Sandbox, SandboxEvent,
-    SandboxEventCallback, SandboxFile, StderrCollector, StdioProcess, StdioProcessHandle,
-    StdioProcessTermination, WalkOptions, format_lines_numbered, shell_quote,
+    ExecStreamingRequest, ExecStreamingResult, GrepOptions, Sandbox, SandboxActivation,
+    SandboxEvent, SandboxEventCallback, SandboxFile, StderrCollector, StdioProcess,
+    StdioProcessHandle, StdioProcessTermination, WalkOptions, format_lines_numbered, shell_quote,
 };
 
 const DOCKER_BASH_REQUIREMENT: &str = "Docker sandboxes require /bin/bash for every command, with no `sh` fallback; use an \
@@ -1676,23 +1676,27 @@ impl Sandbox for DockerSandbox {
             .await
     }
 
-    async fn activate(&self) -> crate::Result<()> {
+    async fn activate(&self) -> crate::Result<SandboxActivation> {
         let container_id = self.container_id()?.to_string();
         let inspect = self.inspect_container(&container_id).await?;
         let labels = container_labels(&inspect);
         verify_managed_labels(&container_id, &labels, self.run_id.as_ref())?;
         let Some(action) = activation_action(&inspect) else {
-            return Ok(());
+            return Ok(SandboxActivation::AlreadyActive);
         };
         match action {
+            // Unpausing leaves an already-running container running; the
+            // caller did not borrow a stopped lifecycle and must not stop it.
             ContainerStartAction::Unpause => {
                 self.set_container_running(&container_id, &labels, action)
-                    .await
+                    .await?;
+                Ok(SandboxActivation::AlreadyActive)
             }
             ContainerStartAction::Start => {
                 let started = self.begin_start();
                 self.complete_start(started, &container_id, &labels, action)
-                    .await
+                    .await?;
+                Ok(SandboxActivation::Started)
             }
         }
     }
@@ -2387,13 +2391,63 @@ mod tests {
             .expect("mock Docker client should connect");
         let sandbox = test_docker_sandbox(docker, "test-container");
 
-        sandbox
+        let activation = sandbox
             .activate()
             .await
             .expect("a paused running container should be unpaused");
 
+        assert_eq!(activation, SandboxActivation::AlreadyActive);
         inspect.assert_calls_async(1).await;
         unpause.assert_calls_async(1).await;
+        start.assert_calls_async(0).await;
+    }
+
+    #[tokio::test]
+    async fn activate_reports_already_active_for_running_container() {
+        let server = MockServer::start_async().await;
+        let inspect = server
+            .mock_async(|when, then| {
+                when.method(GET)
+                    .path_suffix("/containers/test-container/json");
+                then.status(200)
+                    .header("content-type", "application/json")
+                    .json_body(serde_json::json!({
+                        "Config": {
+                            "Labels": managed_labels::for_run(None)
+                        },
+                        "State": {
+                            "Running": true,
+                            "Paused": false
+                        }
+                    }));
+            })
+            .await;
+        let unpause = server
+            .mock_async(|when, then| {
+                when.method(POST)
+                    .path_suffix("/containers/test-container/unpause");
+                then.status(204);
+            })
+            .await;
+        let start = server
+            .mock_async(|when, then| {
+                when.method(POST)
+                    .path_suffix("/containers/test-container/start");
+                then.status(204);
+            })
+            .await;
+        let docker = Docker::connect_with_http(&server.base_url(), 5, API_DEFAULT_VERSION)
+            .expect("mock Docker client should connect");
+        let sandbox = test_docker_sandbox(docker, "test-container");
+
+        let activation = sandbox
+            .activate()
+            .await
+            .expect("a running container needs no lifecycle change");
+
+        assert_eq!(activation, SandboxActivation::AlreadyActive);
+        inspect.assert_calls_async(1).await;
+        unpause.assert_calls_async(0).await;
         start.assert_calls_async(0).await;
     }
 

--- a/lib/components/fabro-sandbox/src/lib.rs
+++ b/lib/components/fabro-sandbox/src/lib.rs
@@ -59,8 +59,8 @@ pub use sandbox::{
     CommandOutputCallback, DEFAULT_EXEC_OUTPUT_TAIL_BYTES, DirEntry, ExecResult,
     ExecStreamingRequest, ExecStreamingResult, GitRunInfo, GitSetupIntent, GrepOptions,
     PushAttempt, PushError, PushReport, RefreshOutcome, RemoteCredentialAction, Sandbox,
-    SandboxEvent, SandboxEventCallback, SandboxFile, StderrCollector, StdioProcess,
-    StdioProcessHandle, StdioProcessTermination, WalkOptions, format_lines_numbered,
+    SandboxActivation, SandboxEvent, SandboxEventCallback, SandboxFile, StderrCollector,
+    StdioProcess, StdioProcessHandle, StdioProcessTermination, WalkOptions, format_lines_numbered,
     redacted_output_tail, setup_git_via_exec, shell_quote,
 };
 pub use sandbox_spec::SandboxSpec;

--- a/lib/components/fabro-sandbox/src/local.rs
+++ b/lib/components/fabro-sandbox/src/local.rs
@@ -18,9 +18,9 @@ use crate::sandbox::{
 };
 use crate::{
     CommandOutputCallback, DEFAULT_EXEC_OUTPUT_TAIL_BYTES, DirEntry, ExecResult,
-    ExecStreamingRequest, ExecStreamingResult, GrepOptions, Sandbox, SandboxEvent,
-    SandboxEventCallback, SandboxFile, StderrCollector, StdioProcess, StdioProcessHandle,
-    StdioProcessTermination, WalkOptions,
+    ExecStreamingRequest, ExecStreamingResult, GrepOptions, Sandbox, SandboxActivation,
+    SandboxEvent, SandboxEventCallback, SandboxFile, StderrCollector, StdioProcess,
+    StdioProcessHandle, StdioProcessTermination, WalkOptions,
 };
 
 /// Remediation shown when the worker has no usable Bash.
@@ -871,11 +871,11 @@ impl Sandbox for LocalSandbox {
         result
     }
 
-    async fn activate(&self) -> crate::Result<()> {
+    async fn activate(&self) -> crate::Result<SandboxActivation> {
         // Local sandboxes have no provider resource that can stop or pause.
         // Resume paths still call `start()` to recreate the directory and
         // verify Bash.
-        Ok(())
+        Ok(SandboxActivation::AlreadyActive)
     }
 
     async fn git_push_ref(

--- a/lib/components/fabro-sandbox/src/sandbox.rs
+++ b/lib/components/fabro-sandbox/src/sandbox.rs
@@ -241,7 +241,7 @@ macro_rules! delegate_sandbox {
                 self.$field.initialize().await
             }
 
-            async fn activate(&self) -> $crate::Result<()> {
+            async fn activate(&self) -> $crate::Result<$crate::SandboxActivation> {
                 self.$field.activate().await
             }
 
@@ -1076,6 +1076,19 @@ impl RefreshOutcome {
     }
 }
 
+/// Outcome of [`Sandbox::activate`], telling callers whether the call
+/// changed the sandbox lifecycle.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SandboxActivation {
+    /// The sandbox was already running (or only needed unpausing); the caller
+    /// is not responsible for stopping it afterwards.
+    AlreadyActive,
+    /// The sandbox transitioned from stopped to running because of this call.
+    /// Read-only inspections that borrow the sandbox transiently should stop
+    /// it again when they are finished, or it stays running forever.
+    Started,
+}
+
 #[async_trait]
 pub trait Sandbox: Send + Sync {
     async fn read_file_bytes(&self, path: &str) -> crate::Result<Vec<u8>>;
@@ -1262,9 +1275,11 @@ pub trait Sandbox: Send + Sync {
     /// This access-time operation must be idempotent. Providers that can stop
     /// independently should avoid restarting an already-active sandbox. This
     /// lightweight check does not require the full health verification done by
-    /// [`Sandbox::start`], and it does not keep a sandbox active between calls.
-    async fn activate(&self) -> crate::Result<()> {
-        self.start().await
+    /// [`Sandbox::start`], and it does not keep a sandbox active between calls:
+    /// when the call reports [`SandboxActivation::Started`], transient
+    /// read-only callers must stop the sandbox again when they are done.
+    async fn activate(&self) -> crate::Result<SandboxActivation> {
+        self.start().await.map(|()| SandboxActivation::Started)
     }
     async fn start(&self) -> crate::Result<()> {
         Ok(())

--- a/lib/components/fabro-sandbox/src/test_support.rs
+++ b/lib/components/fabro-sandbox/src/test_support.rs
@@ -13,8 +13,8 @@ use tokio_util::sync::CancellationToken;
 use crate::sandbox::{self, StdioProcessControl};
 use crate::{
     DEFAULT_EXEC_OUTPUT_TAIL_BYTES, DirEntry, ExecResult, ExecStreamingRequest, GrepOptions,
-    Sandbox, SandboxEvent, SandboxEventCallback, SandboxFile, StderrCollector, StdioProcess,
-    StdioProcessHandle, StdioProcessTermination, WalkOptions,
+    Sandbox, SandboxActivation, SandboxEvent, SandboxEventCallback, SandboxFile, StderrCollector,
+    StdioProcess, StdioProcessHandle, StdioProcessTermination, WalkOptions,
 };
 
 // --- MockSandbox ---
@@ -505,7 +505,7 @@ impl Sandbox for MockSandbox {
         Ok(())
     }
 
-    async fn activate(&self) -> crate::Result<()> {
+    async fn activate(&self) -> crate::Result<SandboxActivation> {
         *self
             .activate_calls
             .lock()
@@ -516,7 +516,7 @@ impl Sandbox for MockSandbox {
                 std::io::Error::other(error.clone()),
             ));
         }
-        self.start().await
+        self.start().await.map(|()| SandboxActivation::Started)
     }
 
     async fn start(&self) -> crate::Result<()> {


### PR DESCRIPTION
## Problem

Follow-up to #670, which added `Sandbox::activate()` on the terminal, sandbox API, and run-files access paths. Activation on those paths is correct for interactive use, but read-only inspection has a lifecycle gap:

Browsing a finished run in the web UI (Files tab, `GET /api/v1/runs/{id}/files`) reconnects and activates the run sandbox. For a terminal run, that starts a Docker container the run lifecycle already stopped — and nothing ever stops it again. Every read-only inspection of a terminal run leaves a running container behind until manual cleanup (`docker rm` / `system prune`).

Observed on a nightly self-host (2026-08-21): runs `01M0GG56PQYP` and `01M0GJVW659C` completed and stopped their sandboxes (`Sandbox stop completed` ~1.4s after `Workflow run completed`). Hours later, web UI inspection logged `Sandbox start completed` (one per Files-tab visit) and both containers stayed `Up` for 35+ minutes until they were removed manually.

## Change

- `Sandbox::activate()` now returns `SandboxActivation::{AlreadyActive, Started}` so callers can tell whether they borrowed a stopped lifecycle
  - Docker: `AlreadyActive` for running/unpaused-only containers, `Started` when activation started the container
  - Daytona: `Started` only when this call issued the start; waiting on transitional states started by someone else reports `AlreadyActive` (adapted to the deadline-based activation from #767)
  - Local: always `AlreadyActive` (no provider resource)
- New `InspectionSandbox` guard in `fabro-server::run_files` wraps read-only inspection sandboxes. On every exit path (including degraded fallbacks and errors) it stops the sandbox again exactly when the inspection started it **and** the run already reached a terminal state. An active run's sandbox is never stopped by an inspection.
- Read-only endpoints use the guard: `GET /runs/{id}/files`, `GET /runs/{id}/commits`, `GET /runs/{id}/sandbox/files`, `GET /runs/{id}/sandbox/file`, `GET /runs/{id}/sandbox/services`
- Interactive endpoints (terminal, SSH, file upload) intentionally keep resurrect-on-use from #670

## Testing

- `cargo test -p fabro-sandbox --lib` — 129 passed (includes new activation-outcome assertions for running/paused Docker containers and Daytona already-active/starting states)
- `cargo test -p fabro-server --lib` — includes new guard tests: stop-after-finish only when `Started` + terminal run; never for active runs or already-active sandboxes
- End-to-end on a self-hosted instance: Files inspection of the failed terminal run `01M0J3733RGTVD9GKRR8F8WF9G` now logs `Sandbox start completed` → `Sandbox stop completed` (no leaked container)
- `cargo +nightly-2026-04-14 fmt --check --all`
- `cargo +nightly-2026-04-14 clippy -p fabro-sandbox -p fabro-server --all-targets -- -D warnings`
