### PR TITLE
Request Packages read permission in the GitHub App manifest

### DIFF
--- a/docs/public/integrations/github.mdx
+++ b/docs/public/integrations/github.mdx
@@ -62,6 +62,7 @@ When you choose the GitHub App strategy, the CLI opens GitHub with a pre-filled 
    | Emails | Read | Read verified email for OAuth login |
    | Dependabot alerts | Write | Read and manage repository vulnerability alerts |
    | Organization projects | Write | Read and update organization Projects V2 |
+   | Packages | Read | Download private GitHub Packages (e.g. npm registry) with the sandbox `GITHUB_TOKEN` |
 
 These permissions are included when Fabro registers a new app. For an existing GitHub App, add the missing permissions in the app's settings, then approve the permission update on each installation before workflows can use them.
 

--- a/lib/apps/fabro-cli/src/commands/install.rs
+++ b/lib/apps/fabro-cli/src/commands/install.rs
@@ -950,7 +950,8 @@ fn build_github_app_manifest(app_name: &str, port: u16, web_url: &str) -> serde_
             "issues": "write",
             "emails": "read",
             "vulnerability_alerts": "write",
-            "organization_projects": "write"
+            "organization_projects": "write",
+            "packages": "read"
         },
         "default_events": []
     })
@@ -2681,6 +2682,10 @@ client_id = "client-id"
         assert_eq!(
             manifest["default_permissions"]["organization_projects"],
             serde_json::json!("write"),
+        );
+        assert_eq!(
+            manifest["default_permissions"]["packages"],
+            serde_json::json!("read"),
         );
     }
 

--- a/lib/apps/fabro-server/src/install.rs
+++ b/lib/apps/fabro-server/src/install.rs
@@ -2059,7 +2059,8 @@ fn build_github_app_manifest(
             "issues": "write",
             "emails": "read",
             "vulnerability_alerts": "write",
-            "organization_projects": "write"
+            "organization_projects": "write",
+            "packages": "read"
         },
         "default_events": []
     })
@@ -2372,6 +2373,21 @@ mod tests {
         assert!(
             manifest["default_permissions"].get("workflows").is_none(),
             "GitHub App must not be able to write workflow files"
+        );
+    }
+
+    #[test]
+    fn github_app_manifest_includes_packages_read_permission() {
+        let manifest = build_github_app_manifest(
+            "Fabro Test",
+            "https://fabro.example/setup",
+            "https://fabro.example/auth/callback/github",
+            "https://fabro.example/setup",
+        );
+
+        assert_eq!(
+            manifest["default_permissions"]["packages"],
+            serde_json::json!("read"),
         );
     }
 


### PR DESCRIPTION
## Why

Fabro supports minting a scoped sandbox `GITHUB_TOKEN` through `[run.integrations.github.permissions]`, and the permission map passes any GitHub App permission name through to the installation token API — including `packages = "read"`. But the App Manifest used by the registration flow never requests the Packages permission, so apps registered through `fabro install` cannot actually grant it: the installation token's upper bound is the app's granted permission set.

Concrete case: a workflow whose `yarn install` needs to read private npm packages from GitHub Packages (`npm.pkg.github.com`). In GitHub Actions this works with the built-in `GITHUB_TOKEN`; on Fabro the equivalent is a sandbox `GITHUB_TOKEN` minted with `packages = "read"`, which requires the app to hold the permission.

## What

- Add `"packages": "read"` to `default_permissions` in both App Manifest builders (CLI `fabro install` flow and server install flow).
- Extend the CLI manifest test and add a server manifest test asserting the permission.
- Add the Packages row to the manifest permission table in `docs/public/integrations/github.mdx`.

Existing apps are unaffected; as the docs already describe, they need the permission added manually in the app's settings plus an installation approval.

## Testing

- `cargo nextest run -p fabro-cli -p fabro-server -E 'test(manifest)'` — 69 passed
- `cargo +nightly-2026-04-14 fmt --check --all` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)