### PR TITLE
Additional GitHub repository access

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2663,6 +2663,7 @@ dependencies = [
  "fabro-static",
  "fabro-test",
  "fabro-types",
+ "futures",
  "jsonwebtoken",
  "serde",
  "serde_json",

--- a/docs/public/api-reference/fabro-api.yaml
+++ b/docs/public/api-reference/fabro-api.yaml
@@ -14447,6 +14447,17 @@ components:
           type: object
           additionalProperties:
             type: string
+        additional_repositories:
+          type: array
+          description: |
+            Additional GitHub repositories, beyond the implicit run origin,
+            that the minted GITHUB_TOKEN must cover. Each entry is a full
+            `owner/repository` slug; every repository must share one owner
+            with the run origin. Omitted when empty; settings persisted
+            before this field existed deserialize to an empty set.
+          items:
+            type: string
+          uniqueItems: true
 
     RunGoal:
       oneOf:

--- a/docs/public/changelog/2026-08-21.mdx
+++ b/docs/public/changelog/2026-08-21.mdx
@@ -1,0 +1,20 @@
+---
+title: "Additional GitHub repositories"
+date: "2026-08-21"
+---
+
+## One token for the whole repository set
+
+A run can now declare additional GitHub repositories that its stages may access through the managed `GITHUB_TOKEN`:
+
+```toml
+[run.integrations.github]
+additional_repositories = ["fabro-sh/keystone"]
+permissions = { contents = "read" }
+```
+
+The run origin stays implicit, and Fabro mints one installation token scoped to the origin plus every declared repository with the shared permission map. Inside stages, `gh` commands, raw GitHub API calls, plain Git over HTTPS, and the common SSH URL spellings (`git@github.com:owner/repo` and `ssh://git@github.com/owner/repo`) all work against the declared set — the SSH forms are transparently rewritten to authenticated HTTPS with no secret placed in Git configuration.
+
+Every repository must share one owner and be reachable by the origin's GitHub App installation. Preflight resolves each repository's installation, mints the scoped token once, and probes every repository with `git ls-remote`, naming the exact repository when something is not accessible; run initialization enforces the same checks. A declared-but-inaccessible repository fails the run before its first stage.
+
+Declaring additional repositories requires `contents = "read"` or `contents = "write"`. With `contents = "write"`, any stage can push to any declared repository — declare the smallest set and weakest permissions that work. See [Additional repositories](/integrations/github#additional-repositories) for details, including layering rules and `GH_TOKEN` precedence.

--- a/docs/public/docs.json
+++ b/docs/public/docs.json
@@ -295,6 +295,13 @@
         "icon": "clock-rotate-left",
         "groups": [
           {
+            "group": "August 2026",
+            "icon": "clock-rotate-left",
+            "pages": [
+              "changelog/2026-08-21"
+            ]
+          },
+          {
             "group": "July 2026",
             "icon": "clock-rotate-left",
             "pages": [

--- a/docs/public/execution/run-configuration.mdx
+++ b/docs/public/execution/run-configuration.mdx
@@ -363,6 +363,24 @@ Only requested permissions are included. The upper bound is the permission set g
 
 This table follows the normal settings precedence order. A higher-precedence layer can set `permissions = {}` to clear inherited permissions and run without a GitHub token.
 
+### `[run.integrations.github].additional_repositories`
+
+Declare extra GitHub repositories, beyond the implicit run origin, that the minted `GITHUB_TOKEN` must cover. The one `permissions` map applies to the origin and every declared repository.
+
+```toml title="run.toml"
+[run.integrations.github]
+additional_repositories = ["fabro-sh/keystone"]
+permissions = { contents = "read" }
+```
+
+Each entry is a full `owner/repository` slug. Every repository in the effective set must share one owner and be reachable by the origin repository's GitHub App installation. A non-empty list requires `contents = "read"` or `contents = "write"`. Malformed slugs, case-insensitive duplicates, cross-owner sets, and sets larger than 499 entries fail configuration validation with indexed error paths such as `run.integrations.github.additional_repositories[1]`.
+
+Unlike permissions-only configuration, declared additional repositories are a hard requirement: missing credentials, a missing origin, or an inaccessible declared repository fails preflight and run initialization with the repository named.
+
+The higher-precedence list replaces the lower one wholesale — no union and no `...` splice — and `additional_repositories = []` explicitly clears an inherited list. `additional_repositories` and `permissions` resolve independently; if layering leaves repositories declared while permissions were cleared, resolution reports the invalid combination instead of dropping either field.
+
+See [Additional repositories](/integrations/github#additional-repositories) for what works inside stages (`gh`, GitHub API, plain Git over HTTPS and the common SSH spellings) and for the security boundary.
+
 ### `[run.notifications]`
 
 Define named notification routes for run events. Slack lifecycle notifications are configured here, not in server config.

--- a/docs/public/integrations/github.mdx
+++ b/docs/public/integrations/github.mdx
@@ -228,7 +228,7 @@ For public repositories, the clone works without credentials. The token is still
 
 ### GITHUB_TOKEN injection
 
-When any settings layer declares `[run.integrations.github.permissions]`, Fabro prepares a scoped GitHub App token source and exposes it as the `GITHUB_TOKEN` environment variable in sandbox command and agent execution. Agents running inside the sandbox can use this token for GitHub API calls, cloning additional private repos, or pushing to branches. The GitHub CLI (`gh`) reads `GITHUB_TOKEN` automatically, so command stages can run `gh pr list`, `gh issue create`, and similar commands without an explicit `gh auth login`.
+When any settings layer declares `[run.integrations.github.permissions]`, Fabro prepares a scoped GitHub App token source and exposes it as the `GITHUB_TOKEN` environment variable in sandbox command and agent execution. Agents running inside the sandbox can use this token for GitHub API calls and pushes within the granted permissions. The GitHub CLI (`gh`) reads `GITHUB_TOKEN` automatically, so command stages can run `gh pr list`, `gh issue create`, and similar commands without an explicit `gh auth login`.
 
 ```toml title="workflow.toml"
 [run.integrations.github.permissions]
@@ -237,6 +237,46 @@ pull_requests = "write"
 ```
 
 Only the listed permissions are requested — the token is scoped to the minimum access needed. If the GitHub App isn't configured or the repository lacks an installation, the run logs a warning and continues without the token.
+
+In App mode, the token covers only the run's origin repository unless the run declares [additional repositories](#additional-repositories). Injecting `GITHUB_TOKEN` alone does not make other private repositories reachable.
+
+### Additional repositories
+
+A run can declare extra GitHub repositories that its stages may access through the same `GITHUB_TOKEN`:
+
+```toml title="workflow.toml"
+[run.integrations.github]
+additional_repositories = ["fabro-sh/keystone"]
+permissions = { contents = "read" }
+```
+
+The run origin stays implicit — never list it. Each entry is a full `owner/repository` slug (no scheme, host, ref, or extra path component). Fabro mints **one** installation token scoped to the origin plus every declared repository, with the one shared `permissions` map applying to all of them.
+
+What works against every declared repository, within the granted permissions:
+
+- **`gh` CLI and raw GitHub API calls** through `GITHUB_TOKEN`.
+- **Plain Git over HTTPS** (`git clone https://github.com/owner/repo`), through a secret-free credential helper that reads `$GITHUB_TOKEN` at invocation time.
+- **The common SSH spellings** `git@github.com:owner/repo[.git]` and `ssh://git@github.com/owner/repo[.git]`, through per-repository SSH-to-HTTPS rewrites injected into the stage environment.
+
+Fabro does not clone additional repositories for you; a workflow that needs one on disk adds its own clone step (`git clone https://github.com/owner/repo` or `gh repo clone owner/repo`).
+
+Requirements and validation:
+
+- Every repository in the effective set must share **one owner** and be reachable by the origin repository's GitHub App installation, because one App installation covers one account. Cross-owner declarations fail configuration validation; a same-owner repository outside the installation fails preflight and run initialization with the repository named.
+- A non-empty `additional_repositories` requires `contents = "read"` or `contents = "write"` in the permission map.
+- Malformed slugs, duplicates (repository identity is case-insensitive), and sets larger than 499 entries fail configuration validation with indexed error paths.
+- Unlike permissions-only configuration, declared additional repositories are a hard requirement: missing GitHub credentials, a missing origin, or an inaccessible declared repository fails preflight and run initialization instead of continuing without the token.
+- Layering: the higher-precedence `additional_repositories` list replaces the lower one wholesale (no union, no `...` splice), and `additional_repositories = []` explicitly clears an inherited list. `permissions` keeps its existing whole-map replacement behavior. If layering leaves repositories declared with permissions cleared, configuration resolution reports the invalid combination.
+
+Behavior notes:
+
+- **Token strategy (PAT):** the configured PAT is used as-is. The repository list drives validation and preflight probes, but it cannot narrow the PAT's inherent GitHub scope — App mode remains the least-authority option.
+- **`GH_TOKEN` precedence:** `gh` checks `GH_TOKEN` before `GITHUB_TOKEN`. If the resolved run environment defines `GH_TOKEN`, `gh` uses it instead of the managed token; Fabro never sets or removes `GH_TOKEN`, and preflight warns when additional repositories are declared alongside one.
+- **SSH rewrites match by prefix.** With `owner/repo` declared, the SSH spelling of `owner/repo-other` is also rewritten to HTTPS. The scoped token is invalid for undeclared repositories at GitHub, so authority is unchanged — but a private undeclared repository fails with a GitHub authorization error instead of a missing-credential or SSH error.
+
+#### Security boundary
+
+Workflow authors may name any repository reachable by the server's GitHub App installation; Fabro applies no second server-side repository intersection. The token is scoped server-side to exactly the declared set — a request to an undeclared repository fails at GitHub, and Fabro never mints an unscoped installation-wide token. With `contents = "write"`, **any stage can push to any declared repository**. Declare the smallest repository set and the weakest permissions that work.
 
 Installation Access Tokens are short-lived. Fabro refreshes its own credentials before checkpoint pushes. For ACP/CLI agent turns launched with GitHub App push credentials, Fabro also re-mints the token and rewrites the sandbox's `origin` URL before the ACP process starts, then every 45 minutes for the lifetime of that turn. Refresh failures are logged and do not fail the stage.
 

--- a/docs/public/reference/user-configuration.mdx
+++ b/docs/public/reference/user-configuration.mdx
@@ -34,7 +34,7 @@ Files that omit `_version` are treated as version `1`. The legacy top-level `ver
 | Scope | Examples |
 |---|---|
 | CLI-only | `[cli.target]`, `[cli.auth]`, `[cli.exec]`, `[cli.output]`, `[cli.updates]`, `[cli.logging]` |
-| Shared run defaults | `[run.model]`, `[run.environment]`, `[environments.<slug>]`, `[run.checkpoint]`, `[run.inputs]`, `[run.prepare]`, `[run.pull_request]`, `[run.integrations.github.permissions]`, `[run.hooks]`, `[run.agent.mcps]` |
+| Shared run defaults | `[run.model]`, `[run.environment]`, `[environments.<slug>]`, `[run.checkpoint]`, `[run.inputs]`, `[run.prepare]`, `[run.pull_request]`, `[run.integrations.github]`, `[run.hooks]`, `[run.agent.mcps]` |
 | Shared LLM catalog | `[llm.providers.<id>]`, provider-scoped `[llm.providers.<id>.models.<slug>]` offerings, limits, features, controls, and costs |
 | Server-only | `[server.listen]`, `[server.api]`, `[server.web]`, `[server.auth]`, `[server.storage]`, `[server.artifacts]`, `[server.slatedb]`, `[server.scheduler]`, `[server.logging]`, `[server.integrations]` |
 

--- a/lib/apps/fabro-cli/src/commands/run/runner.rs
+++ b/lib/apps/fabro-cli/src/commands/run/runner.rs
@@ -161,13 +161,13 @@ pub(crate) async fn execute(
         artifact_sink,
         run_control: Some(run_control),
         github_app,
-        github_permissions: run_spec
+        github_integration: run_spec
             .settings
             .run
             .integrations
             .github
-            .resolve_permissions()
-            .context("failed to resolve github permissions")?,
+            .resolve_integration()
+            .context("failed to resolve github integration")?,
         vault,
         catalog,
         on_node: None,

--- a/lib/apps/fabro-cli/src/commands/run/runner.rs
+++ b/lib/apps/fabro-cli/src/commands/run/runner.rs
@@ -1762,7 +1762,10 @@ mod tests {
                 .parse::<EnvironmentProvider>()
                 .expect("test provider should parse");
             run.integrations = RunIntegrationsSettings {
-                github: RunIntegrationsGithubSettings { permissions },
+                github: RunIntegrationsGithubSettings {
+                    permissions,
+                    ..RunIntegrationsGithubSettings::default()
+                },
             };
             run
         }

--- a/lib/apps/fabro-server/src/automation_materializer.rs
+++ b/lib/apps/fabro-server/src/automation_materializer.rs
@@ -12,8 +12,7 @@ use fabro_util::error::collect_chain;
 use tokio::{fs, task};
 
 use crate::git_checkout::{
-    GitCheckoutError, GitRepoCache, WorktreePrepareInput, github_metadata_url,
-    resolve_git_auth_config,
+    GitCheckoutError, GitRepoCache, WorktreePrepareInput, resolve_git_auth_config,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -199,7 +198,7 @@ fn build_manifest_from_checkout(
 
     let mut manifest = built.manifest;
     manifest.git = Some(GitContext {
-        origin_url: github_metadata_url(&git_context.repo),
+        origin_url: git_context.repo.https_url(),
         branch:     git_context.ref_selector,
         sha:        Some(git_context.checked_out_sha),
         dirty:      DirtyStatus::Clean,

--- a/lib/apps/fabro-server/src/git_checkout.rs
+++ b/lib/apps/fabro-server/src/git_checkout.rs
@@ -165,11 +165,9 @@ async fn bare_clone_may_be_corrupt(bare_dir: &Path) -> bool {
 }
 
 fn github_clone_url(repo: &GitHubRepositorySlug) -> String {
-    format!("https://github.com/{}/{}.git", repo.owner(), repo.repo())
-}
-
-pub(crate) fn github_metadata_url(repo: &GitHubRepositorySlug) -> String {
-    format!("https://github.com/{}/{}", repo.owner(), repo.repo())
+    let mut url = repo.https_url();
+    url.push_str(".git");
+    url
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -478,10 +476,7 @@ mod tests {
             github_clone_url(&repo),
             "https://github.com/fabro-sh/fabro.git"
         );
-        assert_eq!(
-            github_metadata_url(&repo),
-            "https://github.com/fabro-sh/fabro"
-        );
+        assert_eq!(repo.https_url(), "https://github.com/fabro-sh/fabro");
         assert!(!github_clone_url(&repo).contains('@'));
     }
 
@@ -491,10 +486,7 @@ mod tests {
 
         assert_eq!(repo.owner(), "owner");
         assert_eq!(repo.repo(), ".github");
-        assert_eq!(
-            github_metadata_url(&repo),
-            "https://github.com/owner/.github"
-        );
+        assert_eq!(repo.https_url(), "https://github.com/owner/.github");
     }
 
     #[test]

--- a/lib/apps/fabro-server/src/run_manifest.rs
+++ b/lib/apps/fabro-server/src/run_manifest.rs
@@ -12,6 +12,7 @@ use fabro_config::{
     CliLayer, CliOutputLayer, EnvironmentLayer, MergeMap, RunLayer, SettingsLayer,
     WorkflowSettingsBuilder, parse_input_overrides, parse_labels, project,
 };
+use fabro_github::token_source::{InstallationTokenSource, ResolvedToken, TokenSnapshot};
 use fabro_graphviz::graph::{Graph, is_llm_handler_type};
 use fabro_graphviz::render::apply_direction;
 use fabro_llm::model_test::{ModelTestStatus, run_basic_model_probe};
@@ -1200,14 +1201,40 @@ async fn run_github_token_check(
     resolved_run: &RunNamespace,
     github_app: Option<fabro_github::GitHubCredentials>,
 ) -> bool {
-    if !resolved_run.integrations.github.is_token_requested() {
+    run_github_token_check_with(
+        checks,
+        prepared,
+        resolved_run,
+        github_app,
+        mint_scoped_github_token,
+        probe_github_repository,
+    )
+    .await
+}
+
+async fn run_github_token_check_with<M, MFut, P, PFut>(
+    checks: &mut Vec<CheckResult>,
+    prepared: &PreparedManifest,
+    resolved_run: &RunNamespace,
+    github_app: Option<fabro_github::GitHubCredentials>,
+    mint_scoped_token: M,
+    probe_repository: P,
+) -> bool
+where
+    M: FnOnce(fabro_github::GitHubRepositoryAccess, fabro_github::GitHubCredentials) -> MFut,
+    MFut: Future<Output = std::result::Result<ResolvedToken, String>>,
+    P: Fn(fabro_types::GitHubRepositorySlug, ResolvedToken) -> PFut,
+    PFut: Future<Output = std::result::Result<(), String>>,
+{
+    let github = &resolved_run.integrations.github;
+    if !github.is_token_requested() {
         return true;
     }
 
     // Resolve InterpString permission values eagerly for token minting and
     // for display in the preflight report.
-    let github_permissions = match resolved_run.integrations.github.resolve_permissions() {
-        Ok(permissions) => permissions,
+    let integration = match github.resolve_integration() {
+        Ok(integration) => integration,
         Err(err) => {
             checks.push(CheckResult {
                 name:        "GitHub Token".into(),
@@ -1219,13 +1246,191 @@ async fn run_github_token_check(
             return false;
         }
     };
-
-    let perm_details = github_permissions
+    let perm_details = integration
+        .permissions
         .iter()
         .map(|(key, value)| CheckDetail::new(format!("{key}: {value}")))
         .collect::<Vec<_>>();
+
+    if !integration.has_additional_repositories() {
+        // Primary-only behavior is unchanged: a mint check when credentials
+        // and an origin exist, a warning otherwise, and no Git-content probe
+        // (permissions-only workflows may request non-contents permissions).
+        return check_primary_only_github_token(
+            checks,
+            prepared,
+            github_app,
+            &integration.permissions,
+            perm_details,
+        )
+        .await;
+    }
+
+    // `gh` checks GH_TOKEN before GITHUB_TOKEN, so a user-defined GH_TOKEN
+    // bypasses the managed scoped token for gh commands. Warn without
+    // failing; the value is the workflow author's responsibility.
+    if resolved_run.environment.env.contains_key("GH_TOKEN") {
+        checks.push(CheckResult {
+            name:        "GH_TOKEN Override".into(),
+            status:      CheckStatus::Warning,
+            summary:     "gh will not use the managed token".into(),
+            details:     vec![],
+            remediation: Some(
+                "The resolved run environment defines GH_TOKEN, which the gh CLI prefers over \
+                 the managed GITHUB_TOKEN; gh commands will not use the token scoped to the \
+                 declared repositories."
+                    .to_string(),
+            ),
+        });
+    }
+
+    let Some(git) = prepared.git.as_ref() else {
+        checks.push(CheckResult {
+            name:        "GitHub Token".into(),
+            status:      CheckStatus::Error,
+            summary:     "missing origin".into(),
+            details:     perm_details,
+            remediation: Some(
+                "run.integrations.github.additional_repositories requires a GitHub run origin, \
+                 but this run has no repository origin URL"
+                    .to_string(),
+            ),
+        });
+        return false;
+    };
+    let Some(creds) = github_app else {
+        checks.push(CheckResult {
+            name:        "GitHub Token".into(),
+            status:      CheckStatus::Error,
+            summary:     "missing credentials".into(),
+            details:     perm_details,
+            remediation: Some(
+                "run.integrations.github.additional_repositories requires GitHub credentials, \
+                 but none are configured on the server"
+                    .to_string(),
+            ),
+        });
+        return false;
+    };
+    // The same validated access value runtime initialization constructs, so
+    // preflight and runtime cannot disagree about the effective set.
+    let access = match fabro_github::GitHubRepositoryAccess::new(
+        Some(&git.origin_url),
+        &integration.additional_repositories,
+        integration.permissions.clone(),
+    ) {
+        Ok(Some(access)) => access,
+        Ok(None) => {
+            checks.push(CheckResult {
+                name:        "GitHub Token".into(),
+                status:      CheckStatus::Error,
+                summary:     "missing origin".into(),
+                details:     perm_details,
+                remediation: Some(
+                    "run.integrations.github.additional_repositories requires a GitHub run \
+                     origin, but the origin URL is empty"
+                        .to_string(),
+                ),
+            });
+            return false;
+        }
+        Err(err) => {
+            checks.push(CheckResult {
+                name:        "GitHub Token".into(),
+                status:      CheckStatus::Error,
+                summary:     "invalid repository set".into(),
+                details:     perm_details,
+                remediation: Some(format!("{err:#}")),
+            });
+            return false;
+        }
+    };
+
+    // One mint scoped to the whole effective set. In App mode the minter
+    // first resolves every repository's installation so a failure names the
+    // repository the App cannot see.
+    let token = match mint_scoped_token(access.clone(), creds).await {
+        Ok(token) => token,
+        Err(err) => {
+            checks.push(CheckResult {
+                name:        "GitHub Token".into(),
+                status:      CheckStatus::Error,
+                summary:     "failed".into(),
+                details:     perm_details,
+                remediation: Some(err),
+            });
+            return false;
+        }
+    };
+    checks.push(CheckResult {
+        name:        "GitHub Token".into(),
+        status:      CheckStatus::Pass,
+        summary:     "minted".into(),
+        details:     perm_details.clone(),
+        remediation: None,
+    });
+
+    // Probe every effective repository with bounded concurrency, then report
+    // in deterministic primary-first order. Possession of a scoped token is
+    // not proof of access; the probe also verifies PAT/static credentials.
+    let targets: Vec<fabro_types::GitHubRepositorySlug> =
+        access.targets().into_iter().cloned().collect();
+    let probe_repository = &probe_repository;
+    let mut results: Vec<(usize, CheckResult)> =
+        stream::iter(targets.into_iter().enumerate().map(|(index, slug)| {
+            let token = token.clone();
+            let perm_details = perm_details.clone();
+            async move {
+                let check = match probe_repository(slug.clone(), token).await {
+                    Ok(()) => CheckResult {
+                        name:        format!("GitHub Repository ({slug})"),
+                        status:      CheckStatus::Pass,
+                        summary:     "reachable".into(),
+                        details:     perm_details,
+                        remediation: None,
+                    },
+                    Err(err) => CheckResult {
+                        name:        format!("GitHub Repository ({slug})"),
+                        status:      CheckStatus::Error,
+                        summary:     "failed".into(),
+                        details:     perm_details,
+                        remediation: Some(format!("Failed to verify repository access: {err}")),
+                    },
+                };
+                (index, check)
+            }
+        }))
+        .buffer_unordered(REPOSITORY_PROBE_CONCURRENCY)
+        .collect()
+        .await;
+    results.sort_by_key(|(index, _)| *index);
+
+    let mut ok = true;
+    for (_, check) in results {
+        if check.status != CheckStatus::Pass {
+            ok = false;
+        }
+        checks.push(check);
+    }
+    ok
+}
+
+/// Bounded concurrency for per-repository `git ls-remote` probes.
+const REPOSITORY_PROBE_CONCURRENCY: usize = 4;
+
+/// Total probe attempts per repository when failures classify as retryable
+/// (token replication lag or transient infrastructure).
+const REPOSITORY_PROBE_ATTEMPTS: u64 = 3;
+
+async fn check_primary_only_github_token(
+    checks: &mut Vec<CheckResult>,
+    prepared: &PreparedManifest,
+    github_app: Option<fabro_github::GitHubCredentials>,
+    permissions: &HashMap<String, String>,
+    perm_details: Vec<CheckDetail>,
+) -> bool {
     if let (Some(creds), Some(git)) = (&github_app, prepared.git.as_ref()) {
-        match mint_github_token(creds, &git.origin_url, &github_permissions).await {
+        match mint_github_token(creds, &git.origin_url, permissions).await {
             Ok(_) => {
                 checks.push(CheckResult {
                     name:        "GitHub Token".into(),
@@ -1256,6 +1461,106 @@ async fn run_github_token_check(
             remediation: Some("No GitHub credentials or origin URL available".to_string()),
         });
         true
+    }
+}
+
+/// Production minter for the multi-repository path: resolve every
+/// repository's installation in App mode (naming any repository the App
+/// cannot see, or one on a different installation), then mint the single
+/// scoped token. A mint rejection after a clean resolution check surfaces
+/// the raw error.
+async fn mint_scoped_github_token(
+    access: fabro_github::GitHubRepositoryAccess,
+    creds: fabro_github::GitHubCredentials,
+) -> std::result::Result<ResolvedToken, String> {
+    if let fabro_github::GitHubCredentials::App(app) = &creds {
+        access
+            .resolve_shared_installation_via_api(app)
+            .await
+            .map_err(|err| format!("{err:#}"))?;
+    }
+    let source =
+        InstallationTokenSource::for_access(&creds, &access).map_err(|err| format!("{err:#}"))?;
+    source
+        .resolve()
+        .await
+        .map_err(|err| format!("Failed to mint GitHub token: {err:#}"))
+}
+
+/// Production per-repository probe: a non-interactive
+/// `git ls-remote <https-url> HEAD` authenticated through a credential
+/// helper that reads `GITHUB_TOKEN` from the child process environment, so
+/// the token never appears in the URL, argv, or rendered errors. Mirrors the
+/// runtime `git_bridge` credential helper in `fabro-workflow`.
+async fn probe_github_repository(
+    slug: fabro_types::GitHubRepositorySlug,
+    token: ResolvedToken,
+) -> std::result::Result<(), String> {
+    let url = format!("https://github.com/{}/{}", slug.owner(), slug.repo());
+    probe_with_replication_retry(token.snapshot, || run_probe_ls_remote(&url, &token)).await
+}
+
+/// Retry auth-shaped failures with the SAME token: replication of a given
+/// token only makes progress, while re-minting would restart the replication
+/// clock. Classification matches the sandbox git retry policy
+/// (`fabro_sandbox::classify_failure`).
+async fn probe_with_replication_retry<F, Fut>(
+    snapshot: TokenSnapshot,
+    run: F,
+) -> std::result::Result<(), String>
+where
+    F: Fn() -> Fut,
+    Fut: Future<Output = std::result::Result<(), String>>,
+{
+    let credential_context = fabro_sandbox::CredentialContext::from_snapshot(Some(&snapshot));
+    let mut attempt = 0u64;
+    loop {
+        attempt += 1;
+        let Err(message) = run().await else {
+            return Ok(());
+        };
+        if attempt >= REPOSITORY_PROBE_ATTEMPTS
+            || fabro_sandbox::classify_failure(&message, credential_context).is_none()
+        {
+            return Err(message);
+        }
+        time::sleep(Duration::from_secs(attempt)).await;
+    }
+}
+
+async fn run_probe_ls_remote(url: &str, token: &ResolvedToken) -> std::result::Result<(), String> {
+    let mut command = Command::new("git");
+    command
+        .env("GIT_TERMINAL_PROMPT", "0")
+        .env("GIT_CONFIG_NOSYSTEM", "1")
+        .env("GIT_CONFIG_GLOBAL", "/dev/null")
+        .env("GITHUB_TOKEN", token.token.expose())
+        .env("GIT_CONFIG_COUNT", "1")
+        .env("GIT_CONFIG_KEY_0", "credential.https://github.com.helper")
+        .env(
+            "GIT_CONFIG_VALUE_0",
+            r#"!f() { if [ "$1" = get ]; then echo username=x-access-token; echo "password=$GITHUB_TOKEN"; fi; }; f"#,
+        )
+        .args(["ls-remote", url, "HEAD"]);
+
+    let output = time::timeout(Duration::from_secs(10), command.output())
+        .await
+        .map_err(|_| "git ls-remote timed out after 10s".to_string())?
+        .map_err(|err| format!("Failed to run git ls-remote: {err}"))?;
+    if output.status.success() {
+        return Ok(());
+    }
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if !stderr.is_empty() {
+        Err(stderr)
+    } else if !stdout.is_empty() {
+        Err(stdout)
+    } else {
+        Err(format!(
+            "git ls-remote exited with status {}",
+            output.status
+        ))
     }
 }
 
@@ -2971,6 +3276,328 @@ dockerfile = { path = "Dockerfile" }
                 *dockerfile,
                 EnvironmentDockerfileLayer::Inline("FROM ubuntu:24.04\n".to_string()),
                 "catalog dockerfile path should be inlined, got: {dockerfile:?}"
+            );
+        }
+    }
+
+    mod github_additional_repository_checks {
+        //! Seam-injected tests for the declared-additional-repositories
+        //! preflight path: one scoped mint, per-repository probes with
+        //! deterministic primary-first reporting, GH_TOKEN warning, and the
+        //! replication-lag retry policy.
+
+        use std::sync::Mutex as StdMutex;
+        use std::sync::atomic::{AtomicU64, Ordering};
+
+        use fabro_github::token_source::{
+            ResolvedToken, SecretString, TokenProvenance, TokenSnapshot,
+        };
+        use fabro_types::settings::run::RunIntegrationsGithubSettings;
+
+        use super::*;
+
+        fn static_token(secret: &str) -> ResolvedToken {
+            ResolvedToken {
+                token:          SecretString::new(secret.to_string()),
+                snapshot:       TokenSnapshot {
+                    generation: 0,
+                    provenance: TokenProvenance::Static,
+                },
+                refresh_failed: false,
+            }
+        }
+
+        fn fresh_minted_snapshot() -> TokenSnapshot {
+            let now = chrono::Utc::now();
+            TokenSnapshot {
+                generation: 1,
+                provenance: TokenProvenance::Minted {
+                    minted_at:  now,
+                    expires_at: now + chrono::Duration::minutes(60),
+                },
+            }
+        }
+
+        fn declared(origin: &str, additional: &[&str]) -> (PreparedManifest, RunNamespace) {
+            let (prepared, mut resolved) = prepared_and_resolved_for_sandbox(
+                SandboxProviderKind::Local,
+                true,
+                Some(git_context(origin, "main")),
+            );
+            resolved.integrations.github = RunIntegrationsGithubSettings {
+                permissions:             HashMap::from([(
+                    "contents".to_string(),
+                    InterpString::parse("read"),
+                )]),
+                additional_repositories: additional
+                    .iter()
+                    .map(|value| value.parse().expect("test slug should parse"))
+                    .collect(),
+            };
+            (prepared, resolved)
+        }
+
+        fn pat_creds() -> fabro_github::GitHubCredentials {
+            fabro_github::GitHubCredentials::Pat("ghp_test".to_string())
+        }
+
+        #[tokio::test(start_paused = true)]
+        async fn reports_each_repository_primary_first_despite_probe_completion_order() {
+            let (prepared, resolved) = declared("https://github.com/acme/widgets", &[
+                "acme/zeta",
+                "acme/alpha",
+            ]);
+            let minted = Arc::new(StdMutex::new(Vec::new()));
+            let minted_for_seam = Arc::clone(&minted);
+            let mut checks = Vec::new();
+
+            let ok = run_github_token_check_with(
+                &mut checks,
+                &prepared,
+                &resolved,
+                Some(pat_creds()),
+                move |access, _creds| {
+                    minted_for_seam.lock().unwrap().push(access);
+                    async { Ok(static_token("scoped-token")) }
+                },
+                |slug, _token| async move {
+                    // Invert completion order: the primary finishes last.
+                    let delay = match slug.repo() {
+                        "widgets" => 30,
+                        "alpha" => 20,
+                        _ => 10,
+                    };
+                    time::sleep(Duration::from_millis(delay)).await;
+                    Ok(())
+                },
+            )
+            .await;
+
+            assert!(ok);
+            // One mint listing every repository with the shared permissions.
+            let minted = minted.lock().unwrap();
+            assert_eq!(minted.len(), 1);
+            assert_eq!(minted[0].repository_names(), vec![
+                "widgets", "alpha", "zeta"
+            ]);
+            assert_eq!(
+                minted[0].permissions().get("contents").map(String::as_str),
+                Some("read")
+            );
+
+            let names: Vec<&str> = checks.iter().map(|check| check.name.as_str()).collect();
+            assert_eq!(names, vec![
+                "GitHub Token",
+                "GitHub Repository (acme/widgets)",
+                "GitHub Repository (acme/alpha)",
+                "GitHub Repository (acme/zeta)",
+            ]);
+            assert!(checks.iter().all(|check| check.status == CheckStatus::Pass));
+            // The token never reaches check output.
+            for check in &checks {
+                let rendered = format!("{check:?}");
+                assert!(!rendered.contains("scoped-token"), "{rendered}");
+            }
+        }
+
+        #[tokio::test]
+        async fn installation_resolution_failure_names_only_the_inaccessible_repository() {
+            let (prepared, resolved) =
+                declared("https://github.com/acme/widgets", &["acme/keystone"]);
+            let probes = Arc::new(AtomicU64::new(0));
+            let probes_for_seam = Arc::clone(&probes);
+            let mut checks = Vec::new();
+
+            let ok = run_github_token_check_with(
+                &mut checks,
+                &prepared,
+                &resolved,
+                Some(pat_creds()),
+                |_access, _creds| async {
+                    Err(
+                        "the GitHub App installation cannot see repository acme/keystone; add \
+                         it to the installation's repository access"
+                            .to_string(),
+                    )
+                },
+                move |_slug, _token| {
+                    probes_for_seam.fetch_add(1, Ordering::SeqCst);
+                    async { Ok(()) }
+                },
+            )
+            .await;
+
+            assert!(!ok);
+            assert_eq!(
+                probes.load(Ordering::SeqCst),
+                0,
+                "no probes after a failed mint"
+            );
+            assert_eq!(checks.last().unwrap().name, "GitHub Token");
+            assert_eq!(checks.last().unwrap().status, CheckStatus::Error);
+            let remediation = checks.last().unwrap().remediation.as_deref().unwrap();
+            assert!(remediation.contains("acme/keystone"), "{remediation}");
+            assert!(!remediation.contains("acme/widgets"), "{remediation}");
+        }
+
+        #[tokio::test]
+        async fn successful_mint_with_failed_probe_still_fails() {
+            let (prepared, resolved) =
+                declared("https://github.com/acme/widgets", &["acme/keystone"]);
+            let mut checks = Vec::new();
+
+            let ok = run_github_token_check_with(
+                &mut checks,
+                &prepared,
+                &resolved,
+                Some(pat_creds()),
+                |_access, _creds| async { Ok(static_token("scoped-token")) },
+                |slug, _token| async move {
+                    if slug.repo() == "keystone" {
+                        Err("remote: Repository not found.".to_string())
+                    } else {
+                        Ok(())
+                    }
+                },
+            )
+            .await;
+
+            assert!(!ok);
+            let keystone = checks
+                .iter()
+                .find(|check| check.name == "GitHub Repository (acme/keystone)")
+                .expect("keystone probe result should be reported");
+            assert_eq!(keystone.status, CheckStatus::Error);
+            assert!(
+                !keystone
+                    .remediation
+                    .as_deref()
+                    .unwrap_or_default()
+                    .contains("scoped-token")
+            );
+            let widgets = checks
+                .iter()
+                .find(|check| check.name == "GitHub Repository (acme/widgets)")
+                .expect("primary probe result should be reported");
+            assert_eq!(widgets.status, CheckStatus::Pass);
+        }
+
+        #[tokio::test]
+        async fn resolved_gh_token_warns_without_failing() {
+            let (prepared, mut resolved) =
+                declared("https://github.com/acme/widgets", &["acme/keystone"]);
+            resolved
+                .environment
+                .env
+                .insert("GH_TOKEN".to_string(), InterpString::parse("user-token"));
+            let mut checks = Vec::new();
+
+            let ok = run_github_token_check_with(
+                &mut checks,
+                &prepared,
+                &resolved,
+                Some(pat_creds()),
+                |_access, _creds| async { Ok(static_token("scoped-token")) },
+                |_slug, _token| async { Ok(()) },
+            )
+            .await;
+
+            assert!(ok, "a GH_TOKEN override warns but does not fail preflight");
+            let warning = checks
+                .iter()
+                .find(|check| check.name == "GH_TOKEN Override")
+                .expect("GH_TOKEN warning should be reported");
+            assert_eq!(warning.status, CheckStatus::Warning);
+        }
+
+        #[tokio::test]
+        async fn missing_origin_fails_for_declared_repositories() {
+            let (prepared, resolved) = {
+                let (mut prepared, resolved) =
+                    declared("https://github.com/acme/widgets", &["acme/keystone"]);
+                prepared.git = None;
+                (prepared, resolved)
+            };
+            let mut checks = Vec::new();
+
+            let ok = run_github_token_check_with(
+                &mut checks,
+                &prepared,
+                &resolved,
+                Some(pat_creds()),
+                |_access, _creds| async { Ok(static_token("scoped-token")) },
+                |_slug, _token| async { Ok(()) },
+            )
+            .await;
+
+            assert!(!ok);
+            assert_eq!(checks.last().unwrap().summary, "missing origin");
+        }
+
+        #[tokio::test]
+        async fn missing_credentials_fail_for_declared_repositories() {
+            let (prepared, resolved) =
+                declared("https://github.com/acme/widgets", &["acme/keystone"]);
+            let mut checks = Vec::new();
+
+            let ok = run_github_token_check_with(
+                &mut checks,
+                &prepared,
+                &resolved,
+                None,
+                |_access, _creds| async { Ok(static_token("scoped-token")) },
+                |_slug, _token| async { Ok(()) },
+            )
+            .await;
+
+            assert!(!ok);
+            assert_eq!(checks.last().unwrap().summary, "missing credentials");
+        }
+
+        #[tokio::test(start_paused = true)]
+        async fn replication_lag_failure_retries_with_the_same_token_and_succeeds() {
+            let attempts = Arc::new(AtomicU64::new(0));
+            let attempts_for_run = Arc::clone(&attempts);
+
+            let result = probe_with_replication_retry(fresh_minted_snapshot(), move || {
+                let attempts = Arc::clone(&attempts_for_run);
+                async move {
+                    if attempts.fetch_add(1, Ordering::SeqCst) == 0 {
+                        Err("remote: Repository not found.".to_string())
+                    } else {
+                        Ok(())
+                    }
+                }
+            })
+            .await;
+
+            assert!(result.is_ok());
+            assert_eq!(attempts.load(Ordering::SeqCst), 2);
+        }
+
+        #[tokio::test(start_paused = true)]
+        async fn static_credential_auth_failures_do_not_retry() {
+            let attempts = Arc::new(AtomicU64::new(0));
+            let attempts_for_run = Arc::clone(&attempts);
+            let static_snapshot = TokenSnapshot {
+                generation: 0,
+                provenance: TokenProvenance::Static,
+            };
+
+            let result = probe_with_replication_retry(static_snapshot, move || {
+                let attempts = Arc::clone(&attempts_for_run);
+                async move {
+                    attempts.fetch_add(1, Ordering::SeqCst);
+                    Err("remote: Repository not found.".to_string())
+                }
+            })
+            .await;
+
+            assert!(result.is_err());
+            assert_eq!(
+                attempts.load(Ordering::SeqCst),
+                1,
+                "a 404 with a static credential cannot become valid by waiting"
             );
         }
     }

--- a/lib/apps/fabro-server/src/run_manifest.rs
+++ b/lib/apps/fabro-server/src/run_manifest.rs
@@ -882,6 +882,9 @@ async fn check_git_remote_ref(
 /// failure to its most useful message: stderr, then stdout, then the exit
 /// status.
 async fn run_ls_remote(mut command: Command) -> std::result::Result<(), String> {
+    // Dropping a timed-out `Command::output` future does not stop the child
+    // unless kill-on-drop is enabled.
+    command.kill_on_drop(true);
     let output = time::timeout(Duration::from_secs(10), command.output())
         .await
         .map_err(|_| "git ls-remote timed out after 10s".to_string())?
@@ -1246,7 +1249,7 @@ where
         Err(err) => {
             return fail_github_token_check(
                 checks,
-                &[],
+                Vec::new(),
                 "invalid permissions",
                 format!("Failed to resolve GitHub permissions: {err}"),
             );
@@ -1290,10 +1293,25 @@ where
         });
     }
 
+    let Some(origin_url) = prepared
+        .git
+        .as_ref()
+        .map(|git| git.origin_url.trim())
+        .filter(|url| !url.is_empty())
+    else {
+        return fail_github_token_check(
+            checks,
+            perm_details,
+            "missing origin",
+            "run.integrations.github.additional_repositories requires a GitHub run origin, but \
+             this run has no repository origin URL"
+                .to_string(),
+        );
+    };
     let Some(creds) = github_app else {
         return fail_github_token_check(
             checks,
-            &perm_details,
+            perm_details,
             "missing credentials",
             "run.integrations.github.additional_repositories requires GitHub credentials, but \
              none are configured on the server"
@@ -1301,10 +1319,9 @@ where
         );
     };
     // The same validated access value runtime initialization constructs, so
-    // preflight and runtime cannot disagree about the effective set. A
-    // missing origin fails inside `new` with the canonical remediation.
+    // preflight and runtime cannot disagree about the effective set.
     let access = match fabro_github::GitHubRepositoryAccess::new(
-        prepared.git.as_ref().map(|git| git.origin_url.as_str()),
+        Some(origin_url),
         &integration.additional_repositories,
         integration.permissions.clone(),
     ) {
@@ -1314,7 +1331,7 @@ where
         Ok(None) => {
             return fail_github_token_check(
                 checks,
-                &perm_details,
+                perm_details,
                 "missing origin",
                 "run.integrations.github.additional_repositories requires a GitHub run origin, \
                  but this run has no repository origin URL"
@@ -1324,7 +1341,7 @@ where
         Err(err) => {
             return fail_github_token_check(
                 checks,
-                &perm_details,
+                perm_details,
                 "invalid repository set",
                 format!("{err:#}"),
             );
@@ -1337,7 +1354,7 @@ where
     let token = match mint_scoped_token(access.clone(), creds).await {
         Ok(token) => token,
         Err(err) => {
-            return fail_github_token_check(checks, &perm_details, "failed", err);
+            return fail_github_token_check(checks, perm_details, "failed", err);
         }
     };
     checks.push(CheckResult {
@@ -1396,7 +1413,7 @@ where
 /// Report one "GitHub Token" preflight failure and fail the check.
 fn fail_github_token_check(
     checks: &mut Vec<CheckResult>,
-    perm_details: &[CheckDetail],
+    perm_details: Vec<CheckDetail>,
     summary: &str,
     remediation: String,
 ) -> bool {
@@ -1404,7 +1421,7 @@ fn fail_github_token_check(
         name:        "GitHub Token".into(),
         status:      CheckStatus::Error,
         summary:     summary.into(),
-        details:     perm_details.to_vec(),
+        details:     perm_details,
         remediation: Some(remediation),
     });
     false
@@ -1412,10 +1429,6 @@ fn fail_github_token_check(
 
 /// Bounded concurrency for per-repository `git ls-remote` probes.
 const REPOSITORY_PROBE_CONCURRENCY: usize = 4;
-
-/// Total probe attempts per repository when failures classify as retryable
-/// (token replication lag or transient infrastructure).
-const REPOSITORY_PROBE_ATTEMPTS: u32 = 3;
 
 async fn check_primary_only_github_token(
     checks: &mut Vec<CheckResult>,
@@ -1459,21 +1472,16 @@ async fn check_primary_only_github_token(
     }
 }
 
-/// Production minter for the multi-repository path:
-/// [`fabro_github::GitHubRepositoryAccess::resolve_verified_token`] over a
-/// source scoped to the effective set. In App mode that resolves every
-/// repository's installation first, so a failure names the repository the
-/// App cannot see (or one on a different installation).
+/// Production minter for the multi-repository path. The source owns the
+/// effective set. In App mode its first resolve checks every repository's
+/// installation before minting the scoped token.
 async fn mint_scoped_github_token(
     access: fabro_github::GitHubRepositoryAccess,
     creds: fabro_github::GitHubCredentials,
 ) -> std::result::Result<ResolvedToken, String> {
     let source =
         InstallationTokenSource::for_access(&creds, &access).map_err(|err| format!("{err:#}"))?;
-    access
-        .resolve_verified_token(&creds, &source)
-        .await
-        .map_err(|err| format!("{err:#}"))
+    source.resolve().await.map_err(|err| format!("{err:#}"))
 }
 
 /// Production per-repository probe: a non-interactive
@@ -1486,37 +1494,31 @@ async fn probe_github_repository(
     slug: fabro_types::GitHubRepositorySlug,
     token: ResolvedToken,
 ) -> std::result::Result<(), String> {
-    let url = format!("https://github.com/{}/{}", slug.owner(), slug.repo());
+    let url = slug.https_url();
     probe_with_replication_retry(token.snapshot, || run_probe_ls_remote(&url, &token)).await
 }
 
 /// Retry auth-shaped failures with the SAME token: replication of a given
 /// token only makes progress, while re-minting would restart the replication
-/// clock. Classification and pacing match the sandbox git retry policy
-/// (`fabro_sandbox::classify_failure` / `fabro_sandbox::replication_backoff`).
+/// clock. The sandbox git retry executor owns attempt limits,
+/// classification, and pacing.
 async fn probe_with_replication_retry<F, Fut>(
     snapshot: TokenSnapshot,
-    run: F,
+    mut run: F,
 ) -> std::result::Result<(), String>
 where
-    F: Fn() -> Fut,
+    F: FnMut() -> Fut,
     Fut: Future<Output = std::result::Result<(), String>>,
 {
     let credential_context = fabro_sandbox::CredentialContext::from_snapshot(Some(&snapshot));
-    let backoff = fabro_sandbox::replication_backoff();
-    let mut attempt = 0u32;
-    loop {
-        attempt += 1;
-        let Err(message) = run().await else {
-            return Ok(());
-        };
-        if attempt >= REPOSITORY_PROBE_ATTEMPTS
-            || fabro_sandbox::classify_failure(&message, credential_context).is_none()
-        {
-            return Err(message);
-        }
-        time::sleep(backoff.delay_for_attempt(attempt)).await;
-    }
+    fabro_sandbox::retry_git_operation(
+        SandboxProviderKind::Local,
+        "repository probe",
+        &fabro_sandbox::RetryPlan::repository_probe(),
+        |_attempt| run(),
+        |message| fabro_sandbox::classify_failure(message, credential_context),
+    )
+    .await
 }
 
 async fn run_probe_ls_remote(url: &str, token: &ResolvedToken) -> std::result::Result<(), String> {
@@ -3494,7 +3496,7 @@ dockerfile = { path = "Dockerfile" }
 
             assert!(!ok);
             let check = checks.last().unwrap();
-            assert_eq!(check.summary, "invalid repository set");
+            assert_eq!(check.summary, "missing origin");
             assert!(
                 check
                     .remediation

--- a/lib/apps/fabro-server/src/run_manifest.rs
+++ b/lib/apps/fabro-server/src/run_manifest.rs
@@ -873,6 +873,15 @@ async fn check_git_remote_ref(
         command.arg(branch);
     }
 
+    run_ls_remote(command)
+        .await
+        .map_err(|message| redact_auth_url(&message, auth_url.as_ref()))
+}
+
+/// Run a prepared `git ls-remote` invocation with a 10s timeout, reducing a
+/// failure to its most useful message: stderr, then stdout, then the exit
+/// status.
+async fn run_ls_remote(mut command: Command) -> std::result::Result<(), String> {
     let output = time::timeout(Duration::from_secs(10), command.output())
         .await
         .map_err(|_| "git ls-remote timed out after 10s".to_string())?
@@ -884,14 +893,13 @@ async fn check_git_remote_ref(
 
     let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
     let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    let message = if !stderr.is_empty() {
+    Err(if !stderr.is_empty() {
         stderr
     } else if !stdout.is_empty() {
         stdout
     } else {
         format!("git ls-remote exited with status {}", output.status)
-    };
-    Err(redact_auth_url(&message, auth_url.as_ref()))
+    })
 }
 
 fn preflight_sandbox_spec(
@@ -1236,14 +1244,12 @@ where
     let integration = match github.resolve_integration() {
         Ok(integration) => integration,
         Err(err) => {
-            checks.push(CheckResult {
-                name:        "GitHub Token".into(),
-                status:      CheckStatus::Error,
-                summary:     "invalid permissions".into(),
-                details:     vec![],
-                remediation: Some(format!("Failed to resolve GitHub permissions: {err}")),
-            });
-            return false;
+            return fail_github_token_check(
+                checks,
+                &[],
+                "invalid permissions",
+                format!("Failed to resolve GitHub permissions: {err}"),
+            );
         }
     };
     let perm_details = integration
@@ -1269,7 +1275,7 @@ where
     // `gh` checks GH_TOKEN before GITHUB_TOKEN, so a user-defined GH_TOKEN
     // bypasses the managed scoped token for gh commands. Warn without
     // failing; the value is the workflow author's responsibility.
-    if resolved_run.environment.env.contains_key("GH_TOKEN") {
+    if resolved_run.environment.env.contains_key(EnvVars::GH_TOKEN) {
         checks.push(CheckResult {
             name:        "GH_TOKEN Override".into(),
             status:      CheckStatus::Warning,
@@ -1284,65 +1290,44 @@ where
         });
     }
 
-    let Some(git) = prepared.git.as_ref() else {
-        checks.push(CheckResult {
-            name:        "GitHub Token".into(),
-            status:      CheckStatus::Error,
-            summary:     "missing origin".into(),
-            details:     perm_details,
-            remediation: Some(
-                "run.integrations.github.additional_repositories requires a GitHub run origin, \
-                 but this run has no repository origin URL"
-                    .to_string(),
-            ),
-        });
-        return false;
-    };
     let Some(creds) = github_app else {
-        checks.push(CheckResult {
-            name:        "GitHub Token".into(),
-            status:      CheckStatus::Error,
-            summary:     "missing credentials".into(),
-            details:     perm_details,
-            remediation: Some(
-                "run.integrations.github.additional_repositories requires GitHub credentials, \
-                 but none are configured on the server"
-                    .to_string(),
-            ),
-        });
-        return false;
+        return fail_github_token_check(
+            checks,
+            &perm_details,
+            "missing credentials",
+            "run.integrations.github.additional_repositories requires GitHub credentials, but \
+             none are configured on the server"
+                .to_string(),
+        );
     };
     // The same validated access value runtime initialization constructs, so
-    // preflight and runtime cannot disagree about the effective set.
+    // preflight and runtime cannot disagree about the effective set. A
+    // missing origin fails inside `new` with the canonical remediation.
     let access = match fabro_github::GitHubRepositoryAccess::new(
-        Some(&git.origin_url),
+        prepared.git.as_ref().map(|git| git.origin_url.as_str()),
         &integration.additional_repositories,
         integration.permissions.clone(),
     ) {
         Ok(Some(access)) => access,
+        // `new` returns `Ok(None)` only when nothing is declared, and the
+        // declared set is non-empty here. Fail closed instead of panicking.
         Ok(None) => {
-            checks.push(CheckResult {
-                name:        "GitHub Token".into(),
-                status:      CheckStatus::Error,
-                summary:     "missing origin".into(),
-                details:     perm_details,
-                remediation: Some(
-                    "run.integrations.github.additional_repositories requires a GitHub run \
-                     origin, but the origin URL is empty"
-                        .to_string(),
-                ),
-            });
-            return false;
+            return fail_github_token_check(
+                checks,
+                &perm_details,
+                "missing origin",
+                "run.integrations.github.additional_repositories requires a GitHub run origin, \
+                 but this run has no repository origin URL"
+                    .to_string(),
+            );
         }
         Err(err) => {
-            checks.push(CheckResult {
-                name:        "GitHub Token".into(),
-                status:      CheckStatus::Error,
-                summary:     "invalid repository set".into(),
-                details:     perm_details,
-                remediation: Some(format!("{err:#}")),
-            });
-            return false;
+            return fail_github_token_check(
+                checks,
+                &perm_details,
+                "invalid repository set",
+                format!("{err:#}"),
+            );
         }
     };
 
@@ -1352,14 +1337,7 @@ where
     let token = match mint_scoped_token(access.clone(), creds).await {
         Ok(token) => token,
         Err(err) => {
-            checks.push(CheckResult {
-                name:        "GitHub Token".into(),
-                status:      CheckStatus::Error,
-                summary:     "failed".into(),
-                details:     perm_details,
-                remediation: Some(err),
-            });
-            return false;
+            return fail_github_token_check(checks, &perm_details, "failed", err);
         }
     };
     checks.push(CheckResult {
@@ -1415,12 +1393,29 @@ where
     ok
 }
 
+/// Report one "GitHub Token" preflight failure and fail the check.
+fn fail_github_token_check(
+    checks: &mut Vec<CheckResult>,
+    perm_details: &[CheckDetail],
+    summary: &str,
+    remediation: String,
+) -> bool {
+    checks.push(CheckResult {
+        name:        "GitHub Token".into(),
+        status:      CheckStatus::Error,
+        summary:     summary.into(),
+        details:     perm_details.to_vec(),
+        remediation: Some(remediation),
+    });
+    false
+}
+
 /// Bounded concurrency for per-repository `git ls-remote` probes.
 const REPOSITORY_PROBE_CONCURRENCY: usize = 4;
 
 /// Total probe attempts per repository when failures classify as retryable
 /// (token replication lag or transient infrastructure).
-const REPOSITORY_PROBE_ATTEMPTS: u64 = 3;
+const REPOSITORY_PROBE_ATTEMPTS: u32 = 3;
 
 async fn check_primary_only_github_token(
     checks: &mut Vec<CheckResult>,
@@ -1464,34 +1459,29 @@ async fn check_primary_only_github_token(
     }
 }
 
-/// Production minter for the multi-repository path: resolve every
-/// repository's installation in App mode (naming any repository the App
-/// cannot see, or one on a different installation), then mint the single
-/// scoped token. A mint rejection after a clean resolution check surfaces
-/// the raw error.
+/// Production minter for the multi-repository path:
+/// [`fabro_github::GitHubRepositoryAccess::resolve_verified_token`] over a
+/// source scoped to the effective set. In App mode that resolves every
+/// repository's installation first, so a failure names the repository the
+/// App cannot see (or one on a different installation).
 async fn mint_scoped_github_token(
     access: fabro_github::GitHubRepositoryAccess,
     creds: fabro_github::GitHubCredentials,
 ) -> std::result::Result<ResolvedToken, String> {
-    if let fabro_github::GitHubCredentials::App(app) = &creds {
-        access
-            .resolve_shared_installation_via_api(app)
-            .await
-            .map_err(|err| format!("{err:#}"))?;
-    }
     let source =
         InstallationTokenSource::for_access(&creds, &access).map_err(|err| format!("{err:#}"))?;
-    source
-        .resolve()
+    access
+        .resolve_verified_token(&creds, &source)
         .await
-        .map_err(|err| format!("Failed to mint GitHub token: {err:#}"))
+        .map_err(|err| format!("{err:#}"))
 }
 
 /// Production per-repository probe: a non-interactive
-/// `git ls-remote <https-url> HEAD` authenticated through a credential
-/// helper that reads `GITHUB_TOKEN` from the child process environment, so
-/// the token never appears in the URL, argv, or rendered errors. Mirrors the
-/// runtime `git_bridge` credential helper in `fabro-workflow`.
+/// `git ls-remote <https-url> HEAD` authenticated through
+/// [`fabro_github::GITHUB_CREDENTIAL_HELPER`] reading `GITHUB_TOKEN` from
+/// the child process environment, so the token never appears in the URL,
+/// argv, or rendered errors — exactly what the runtime `git_bridge`
+/// configures in `fabro-workflow`.
 async fn probe_github_repository(
     slug: fabro_types::GitHubRepositorySlug,
     token: ResolvedToken,
@@ -1502,8 +1492,8 @@ async fn probe_github_repository(
 
 /// Retry auth-shaped failures with the SAME token: replication of a given
 /// token only makes progress, while re-minting would restart the replication
-/// clock. Classification matches the sandbox git retry policy
-/// (`fabro_sandbox::classify_failure`).
+/// clock. Classification and pacing match the sandbox git retry policy
+/// (`fabro_sandbox::classify_failure` / `fabro_sandbox::replication_backoff`).
 async fn probe_with_replication_retry<F, Fut>(
     snapshot: TokenSnapshot,
     run: F,
@@ -1513,7 +1503,8 @@ where
     Fut: Future<Output = std::result::Result<(), String>>,
 {
     let credential_context = fabro_sandbox::CredentialContext::from_snapshot(Some(&snapshot));
-    let mut attempt = 0u64;
+    let backoff = fabro_sandbox::replication_backoff();
+    let mut attempt = 0u32;
     loop {
         attempt += 1;
         let Err(message) = run().await else {
@@ -1524,44 +1515,15 @@ where
         {
             return Err(message);
         }
-        time::sleep(Duration::from_secs(attempt)).await;
+        time::sleep(backoff.delay_for_attempt(attempt)).await;
     }
 }
 
 async fn run_probe_ls_remote(url: &str, token: &ResolvedToken) -> std::result::Result<(), String> {
     let mut command = Command::new("git");
-    command
-        .env("GIT_TERMINAL_PROMPT", "0")
-        .env("GIT_CONFIG_NOSYSTEM", "1")
-        .env("GIT_CONFIG_GLOBAL", "/dev/null")
-        .env("GITHUB_TOKEN", token.token.expose())
-        .env("GIT_CONFIG_COUNT", "1")
-        .env("GIT_CONFIG_KEY_0", "credential.https://github.com.helper")
-        .env(
-            "GIT_CONFIG_VALUE_0",
-            r#"!f() { if [ "$1" = get ]; then echo username=x-access-token; echo "password=$GITHUB_TOKEN"; fi; }; f"#,
-        )
-        .args(["ls-remote", url, "HEAD"]);
-
-    let output = time::timeout(Duration::from_secs(10), command.output())
-        .await
-        .map_err(|_| "git ls-remote timed out after 10s".to_string())?
-        .map_err(|err| format!("Failed to run git ls-remote: {err}"))?;
-    if output.status.success() {
-        return Ok(());
-    }
-    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
-    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    if !stderr.is_empty() {
-        Err(stderr)
-    } else if !stdout.is_empty() {
-        Err(stdout)
-    } else {
-        Err(format!(
-            "git ls-remote exited with status {}",
-            output.status
-        ))
-    }
+    fabro_github::apply_probe_git_env(&mut command, token.token.expose());
+    command.args(["ls-remote", url, "HEAD"]);
+    run_ls_remote(command).await
 }
 
 async fn mint_github_token(
@@ -3531,7 +3493,17 @@ dockerfile = { path = "Dockerfile" }
             .await;
 
             assert!(!ok);
-            assert_eq!(checks.last().unwrap().summary, "missing origin");
+            let check = checks.last().unwrap();
+            assert_eq!(check.summary, "invalid repository set");
+            assert!(
+                check
+                    .remediation
+                    .as_deref()
+                    .unwrap_or_default()
+                    .contains("requires a GitHub run origin"),
+                "{:?}",
+                check.remediation
+            );
         }
 
         #[tokio::test]

--- a/lib/apps/fabro-server/src/server.rs
+++ b/lib/apps/fabro-server/src/server.rs
@@ -4081,15 +4081,15 @@ async fn execute_run_in_process(state: Arc<AppState>, run_id: RunId) {
             return;
         }
     };
-    let github_permissions = match persisted
+    let github_integration = match persisted
         .run_spec()
         .settings
         .run
         .integrations
         .github
-        .resolve_permissions()
+        .resolve_integration()
     {
-        Ok(permissions) => permissions,
+        Ok(integration) => integration,
         Err(err) => {
             tracing::error!(
                 run_id = %run_id,
@@ -4131,7 +4131,7 @@ async fn execute_run_in_process(state: Arc<AppState>, run_id: RunId) {
         artifact_sink: Some(ArtifactSink::Store(state.artifact_store.clone())),
         run_control: None,
         github_app,
-        github_permissions,
+        github_integration,
         vault: Arc::new(AsyncRwLock::new(vault.into_vault())),
         catalog: state.catalog(),
         on_node: None,

--- a/lib/components/fabro-github/Cargo.toml
+++ b/lib/components/fabro-github/Cargo.toml
@@ -25,6 +25,7 @@ fabro-http.workspace = true
 fabro-redact.workspace = true
 fabro-static.workspace = true
 fabro-types = { path = "../../foundation/fabro-types" }
+futures.workspace = true
 jsonwebtoken.workspace = true
 chrono.workspace = true
 tracing.workspace = true

--- a/lib/components/fabro-github/src/access.rs
+++ b/lib/components/fabro-github/src/access.rs
@@ -10,8 +10,10 @@ use std::collections::{BTreeSet, HashMap};
 
 use anyhow::{Context as _, bail};
 use fabro_types::GitHubRepositorySlug;
+use fabro_types::settings::run::RunIntegrationsGithubSettings;
 
-use crate::{GitHubAppCredentials, HttpClient, HttpMethod};
+use crate::token_source::{InstallationTokenSource, ResolvedToken};
+use crate::{GitHubAppCredentials, GitHubCredentials, HttpClient, InstallationLookup};
 
 /// The validated effective repository set for a run: the primary origin
 /// repository plus zero or more distinct additional repositories, all with
@@ -163,54 +165,58 @@ impl GitHubRepositoryAccess {
         client: &impl HttpClient,
         base_url: &str,
     ) -> anyhow::Result<u64> {
-        #[derive(serde::Deserialize)]
-        struct Installation {
-            id: u64,
-        }
-
         let jwt = crate::sign_app_jwt(&creds.app_id, &creds.private_key_pem)?;
-        let auth = format!("Bearer {jwt}");
         let mut shared: Option<(u64, &GitHubRepositorySlug)> = None;
         for slug in self.targets() {
-            let endpoint = format!(
-                "{base_url}/repos/{}/{}/installation",
-                slug.owner(),
-                slug.repo()
-            );
-            let response = client
-                .request(
-                    HttpMethod::Get,
-                    &endpoint,
-                    &crate::github_headers(&auth),
-                    None,
-                )
-                .await
-                .with_context(|| format!("looking up the GitHub App installation for {slug}"))?;
-            match response.status {
-                200 => {}
-                404 => bail!(
+            let lookup =
+                crate::lookup_installation(client, &jwt, base_url, slug.owner(), slug.repo())
+                    .await
+                    .with_context(|| {
+                        format!("looking up the GitHub App installation for {slug}")
+                    })?;
+            let id = match lookup {
+                InstallationLookup::Found(id) => id,
+                InstallationLookup::NotFound => bail!(
                     "the GitHub App installation cannot see repository {slug}; add it to the \
                      installation's repository access"
                 ),
-                status => bail!(
+                InstallationLookup::Failed(status) => bail!(
                     "unexpected status {status} looking up the GitHub App installation for {slug}"
                 ),
-            }
-            let installation: Installation = response
-                .json()
-                .with_context(|| format!("parsing the installation response for {slug}"))?;
+            };
             match shared {
-                None => shared = Some((installation.id, slug)),
-                Some((id, first)) if id != installation.id => bail!(
-                    "repository {slug} belongs to GitHub App installation {} but {first} belongs \
-                     to installation {id}; all repositories must share one installation",
-                    installation.id
+                None => shared = Some((id, slug)),
+                Some((shared_id, first)) if shared_id != id => bail!(
+                    "repository {slug} belongs to GitHub App installation {id} but {first} \
+                     belongs to installation {shared_id}; all repositories must share one \
+                     installation"
                 ),
                 Some(_) => {}
             }
         }
         let (id, _) = shared.expect("the effective repository set always contains the primary");
         Ok(id)
+    }
+
+    /// Prove this access value is usable and produce its token: in App mode,
+    /// first resolve every target's installation
+    /// ([`Self::resolve_shared_installation_via_api`]) so a failure names the
+    /// repository the App cannot see, then resolve `source` once — for App
+    /// credentials that eagerly mints the token scoped to the whole effective
+    /// set. The one choreography server preflight and workflow
+    /// initialization share.
+    pub async fn resolve_verified_token(
+        &self,
+        creds: &GitHubCredentials,
+        source: &InstallationTokenSource,
+    ) -> anyhow::Result<ResolvedToken> {
+        if let GitHubCredentials::App(app) = creds {
+            self.resolve_shared_installation_via_api(app).await?;
+        }
+        source
+            .resolve()
+            .await
+            .context("Failed to resolve the GitHub token for the effective repository set")
     }
 }
 
@@ -224,7 +230,7 @@ fn validate_additional_permissions(permissions: &HashMap<String, String>) -> any
              (`read` or `write`)"
         );
     };
-    if contents != "read" && contents != "write" {
+    if !RunIntegrationsGithubSettings::contents_permission_allows_repository_access(contents) {
         bail!(
             "run.integrations.github.additional_repositories requires `contents = \"read\"` or \
              `contents = \"write\"`, got `{contents}`"

--- a/lib/components/fabro-github/src/access.rs
+++ b/lib/components/fabro-github/src/access.rs
@@ -11,9 +11,13 @@ use std::collections::{BTreeSet, HashMap};
 use anyhow::{Context as _, bail};
 use fabro_types::GitHubRepositorySlug;
 use fabro_types::settings::run::RunIntegrationsGithubSettings;
+use futures::stream::{self, StreamExt as _};
 
-use crate::token_source::{InstallationTokenSource, ResolvedToken};
-use crate::{GitHubAppCredentials, GitHubCredentials, HttpClient, InstallationLookup};
+use crate::{GitHubAppCredentials, HttpClient, InstallationLookup, InstallationToken};
+
+/// Keep GitHub installation lookups bounded while avoiding one network round
+/// trip at a time for large declared repository sets.
+const INSTALLATION_LOOKUP_CONCURRENCY: usize = 4;
 
 /// The validated effective repository set for a run: the primary origin
 /// repository plus zero or more distinct additional repositories, all with
@@ -142,38 +146,29 @@ impl GitHubRepositoryAccess {
         !self.additional.is_empty()
     }
 
-    /// [`Self::resolve_shared_installation`] against the production GitHub
-    /// API with a fresh HTTP client.
-    pub async fn resolve_shared_installation_via_api(
-        &self,
-        creds: &GitHubAppCredentials,
-    ) -> anyhow::Result<u64> {
-        let client = fabro_http::http_client()
-            .map_err(anyhow::Error::new)
-            .context("building HTTP client for installation resolution")?;
-        self.resolve_shared_installation(creds, &client, &crate::github_api_base_url())
-            .await
-    }
-
     /// Resolve every target's App installation and require one shared
     /// installation ID, so a repository the App cannot see — or one that
     /// resolves to a different installation — is named before any token is
     /// minted. Targets are checked in deterministic primary-first order.
-    pub async fn resolve_shared_installation(
+    async fn resolve_shared_installation_with_jwt(
         &self,
-        creds: &GitHubAppCredentials,
         client: &impl HttpClient,
+        jwt: &str,
         base_url: &str,
     ) -> anyhow::Result<u64> {
-        let jwt = crate::sign_app_jwt(&creds.app_id, &creds.private_key_pem)?;
-        let mut shared: Option<(u64, &GitHubRepositorySlug)> = None;
-        for slug in self.targets() {
+        let targets: Vec<GitHubRepositorySlug> = self.targets().into_iter().cloned().collect();
+        let mut lookups = stream::iter(targets.into_iter().map(|slug| async move {
             let lookup =
-                crate::lookup_installation(client, &jwt, base_url, slug.owner(), slug.repo())
+                crate::lookup_installation(client, jwt, base_url, slug.owner(), slug.repo())
                     .await
-                    .with_context(|| {
-                        format!("looking up the GitHub App installation for {slug}")
-                    })?;
+                    .with_context(|| format!("looking up the GitHub App installation for {slug}"));
+            (slug, lookup)
+        }))
+        .buffered(INSTALLATION_LOOKUP_CONCURRENCY);
+
+        let mut shared: Option<(u64, GitHubRepositorySlug)> = None;
+        while let Some((slug, lookup)) = lookups.next().await {
+            let lookup = lookup?;
             let id = match lookup {
                 InstallationLookup::Found(id) => id,
                 InstallationLookup::NotFound => bail!(
@@ -184,9 +179,9 @@ impl GitHubRepositoryAccess {
                     "unexpected status {status} looking up the GitHub App installation for {slug}"
                 ),
             };
-            match shared {
+            match &shared {
                 None => shared = Some((id, slug)),
-                Some((shared_id, first)) if shared_id != id => bail!(
+                Some((shared_id, first)) if *shared_id != id => bail!(
                     "repository {slug} belongs to GitHub App installation {id} but {first} \
                      belongs to installation {shared_id}; all repositories must share one \
                      installation"
@@ -198,25 +193,28 @@ impl GitHubRepositoryAccess {
         Ok(id)
     }
 
-    /// Prove this access value is usable and produce its token: in App mode,
-    /// first resolve every target's installation
-    /// ([`Self::resolve_shared_installation_via_api`]) so a failure names the
-    /// repository the App cannot see, then resolve `source` once — for App
-    /// credentials that eagerly mints the token scoped to the whole effective
-    /// set. The one choreography server preflight and workflow
-    /// initialization share.
-    pub async fn resolve_verified_token(
+    /// Resolve every target to one installation, then mint one token scoped
+    /// to this exact repository set without looking up the primary twice.
+    pub(crate) async fn mint_installation_token(
         &self,
-        creds: &GitHubCredentials,
-        source: &InstallationTokenSource,
-    ) -> anyhow::Result<ResolvedToken> {
-        if let GitHubCredentials::App(app) = creds {
-            self.resolve_shared_installation_via_api(app).await?;
-        }
-        source
-            .resolve()
+        creds: &GitHubAppCredentials,
+        client: &impl HttpClient,
+        base_url: &str,
+    ) -> anyhow::Result<InstallationToken> {
+        let jwt = crate::sign_app_jwt(&creds.app_id, &creds.private_key_pem)?;
+        let installation_id = self
+            .resolve_shared_installation_with_jwt(client, &jwt, base_url)
             .await
-            .context("Failed to resolve the GitHub token for the effective repository set")
+            .context("resolving the shared GitHub App installation")?;
+        crate::mint_installation_token_for_id_with_jwt(
+            client,
+            &jwt,
+            installation_id,
+            &self.repository_names(),
+            base_url,
+            self.permissions_json()?,
+        )
+        .await
     }
 }
 
@@ -436,7 +434,11 @@ mod tests {
         .unwrap();
 
         let err = access
-            .resolve_shared_installation(&creds, &mock, "")
+            .resolve_shared_installation_with_jwt(
+                &mock,
+                &crate::sign_app_jwt(&creds.app_id, &creds.private_key_pem).unwrap(),
+                "",
+            )
             .await
             .unwrap_err();
         let message = err.to_string();
@@ -476,7 +478,11 @@ mod tests {
         .unwrap();
 
         let err = access
-            .resolve_shared_installation(&creds, &mock, "")
+            .resolve_shared_installation_with_jwt(
+                &mock,
+                &crate::sign_app_jwt(&creds.app_id, &creds.private_key_pem).unwrap(),
+                "",
+            )
             .await
             .unwrap_err();
         let message = err.to_string();
@@ -516,9 +522,66 @@ mod tests {
         .unwrap();
 
         let id = access
-            .resolve_shared_installation(&creds, &mock, "")
+            .resolve_shared_installation_with_jwt(
+                &mock,
+                &crate::sign_app_jwt(&creds.app_id, &creds.private_key_pem).unwrap(),
+                "",
+            )
             .await
             .unwrap();
         assert_eq!(id, 7);
+    }
+
+    #[tokio::test]
+    async fn access_mint_reuses_the_resolved_installation_id() {
+        use crate::HttpMethod;
+        use crate::tests_mock::{MockHttpClient, test_rsa_key};
+
+        let mock = MockHttpClient::new()
+            .on(
+                HttpMethod::Get,
+                "/repos/fabro-sh/fabro/installation",
+                200,
+                r#"{"id": 7}"#,
+            )
+            .on(
+                HttpMethod::Get,
+                "/repos/fabro-sh/keystone/installation",
+                200,
+                r#"{"id": 7}"#,
+            )
+            .on(
+                HttpMethod::Post,
+                "/app/installations/7/access_tokens",
+                201,
+                r#"{"token":"scoped","expires_at":"2099-01-01T00:00:00Z"}"#,
+            )
+            .with_req_body(
+                r#"{"repositories":["fabro","keystone"],"permissions":{"contents":"read"}}"#,
+            );
+        let creds = GitHubAppCredentials {
+            app_id:          "test".to_string(),
+            private_key_pem: test_rsa_key().to_string(),
+            slug:            None,
+        };
+        let access = access(
+            "https://github.com/fabro-sh/fabro",
+            &["fabro-sh/keystone"],
+            contents_read(),
+        )
+        .unwrap()
+        .unwrap();
+
+        let token = access
+            .mint_installation_token(&creds, &mock, "")
+            .await
+            .unwrap();
+
+        assert_eq!(token.token, "scoped");
+        assert_eq!(
+            mock.request_count(),
+            3,
+            "each repository should be looked up once before the mint"
+        );
     }
 }

--- a/lib/components/fabro-github/src/access.rs
+++ b/lib/components/fabro-github/src/access.rs
@@ -140,6 +140,19 @@ impl GitHubRepositoryAccess {
         !self.additional.is_empty()
     }
 
+    /// [`Self::resolve_shared_installation`] against the production GitHub
+    /// API with a fresh HTTP client.
+    pub async fn resolve_shared_installation_via_api(
+        &self,
+        creds: &GitHubAppCredentials,
+    ) -> anyhow::Result<u64> {
+        let client = fabro_http::http_client()
+            .map_err(anyhow::Error::new)
+            .context("building HTTP client for installation resolution")?;
+        self.resolve_shared_installation(creds, &client, &crate::github_api_base_url())
+            .await
+    }
+
     /// Resolve every target's App installation and require one shared
     /// installation ID, so a repository the App cannot see — or one that
     /// resolves to a different installation — is named before any token is

--- a/lib/components/fabro-github/src/access.rs
+++ b/lib/components/fabro-github/src/access.rs
@@ -1,0 +1,505 @@
+//! The validated effective repository set for one run's GitHub access.
+//!
+//! [`GitHubRepositoryAccess`] is the single value both server preflight and
+//! workflow initialization construct from the run origin, the declared
+//! additional repositories, and the resolved shared permissions — so the two
+//! paths cannot disagree about which repositories a run's `GITHUB_TOKEN`
+//! covers. It carries no token or key material.
+
+use std::collections::{BTreeSet, HashMap};
+
+use anyhow::{Context as _, bail};
+use fabro_types::GitHubRepositorySlug;
+
+use crate::{GitHubAppCredentials, HttpClient, HttpMethod};
+
+/// The validated effective repository set for a run: the primary origin
+/// repository plus zero or more distinct additional repositories, all with
+/// one shared owner, and the shared permission map that scopes the token.
+///
+/// Secret-free by construction: `Debug` may render everywhere the run
+/// pipeline logs.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GitHubRepositoryAccess {
+    primary:     GitHubRepositorySlug,
+    /// Sorted, deduplicated, primary excluded.
+    additional:  Vec<GitHubRepositorySlug>,
+    permissions: HashMap<String, String>,
+}
+
+impl GitHubRepositoryAccess {
+    /// Build the effective access request.
+    ///
+    /// Returns `Ok(None)` when no origin URL is available and no additional
+    /// repositories are declared — the legacy "nothing to scope" state whose
+    /// handling stays with the caller. Every declared-additional invariant is
+    /// enforced here:
+    ///
+    /// - a declared additional set requires a GitHub origin,
+    /// - the additional set cannot contain the primary repository,
+    /// - every additional repository shares the primary's owner
+    ///   (case-insensitive) because one App installation covers one account,
+    /// - a declared additional set requires interpolated permissions with
+    ///   `contents = "read"` or `contents = "write"`.
+    pub fn new(
+        origin_url: Option<&str>,
+        additional_repositories: &BTreeSet<GitHubRepositorySlug>,
+        permissions: HashMap<String, String>,
+    ) -> anyhow::Result<Option<Self>> {
+        let origin_url = origin_url.map(str::trim).filter(|url| !url.is_empty());
+        let Some(origin_url) = origin_url else {
+            if additional_repositories.is_empty() {
+                return Ok(None);
+            }
+            bail!(
+                "run.integrations.github.additional_repositories requires a GitHub run origin; \
+                 this run has no repository origin URL"
+            );
+        };
+
+        let normalized = crate::normalize_repo_origin_url(origin_url);
+        let (owner, repo) = crate::parse_github_owner_repo(&normalized)
+            .context("parsing GitHub origin for repository access")?;
+        let Some(primary) = GitHubRepositorySlug::try_new(&format!("{owner}/{repo}")) else {
+            bail!("run origin does not name a valid GitHub `owner/repository`: {owner}/{repo}");
+        };
+
+        if !additional_repositories.is_empty() {
+            validate_additional_permissions(&permissions)?;
+        }
+
+        let mut additional = Vec::with_capacity(additional_repositories.len());
+        for slug in additional_repositories {
+            if *slug == primary {
+                bail!(
+                    "run.integrations.github.additional_repositories must not repeat the run \
+                     origin repository `{primary}` — the origin is always included"
+                );
+            }
+            if !slug.same_owner(&primary) {
+                bail!(
+                    "additional repository `{slug}` has owner `{}` but the run origin `{primary}` \
+                     has owner `{}`; all repositories must share one owner because one GitHub App \
+                     installation covers one account",
+                    slug.owner(),
+                    primary.owner()
+                );
+            }
+            additional.push(slug.clone());
+        }
+
+        Ok(Some(Self {
+            primary,
+            additional,
+            permissions,
+        }))
+    }
+
+    #[must_use]
+    pub fn primary(&self) -> &GitHubRepositorySlug {
+        &self.primary
+    }
+
+    /// Every repository in the effective set, primary first, then the
+    /// additional repositories in their deterministic sorted order.
+    #[must_use]
+    pub fn targets(&self) -> Vec<&GitHubRepositorySlug> {
+        std::iter::once(&self.primary)
+            .chain(self.additional.iter())
+            .collect()
+    }
+
+    /// Project each validated slug to its repository-name component for the
+    /// installation-token mint request, which accepts names within the
+    /// selected installation. Every target shares the primary's owner, so the
+    /// projection loses nothing.
+    #[must_use]
+    pub fn repository_names(&self) -> Vec<String> {
+        self.targets()
+            .into_iter()
+            .map(|slug| slug.repo().to_string())
+            .collect()
+    }
+
+    #[must_use]
+    pub fn owner(&self) -> &str {
+        self.primary.owner()
+    }
+
+    #[must_use]
+    pub fn permissions(&self) -> &HashMap<String, String> {
+        &self.permissions
+    }
+
+    pub fn permissions_json(&self) -> anyhow::Result<serde_json::Value> {
+        serde_json::to_value(&self.permissions).context("serializing GitHub permissions")
+    }
+
+    #[must_use]
+    pub fn has_additional_repositories(&self) -> bool {
+        !self.additional.is_empty()
+    }
+
+    /// Resolve every target's App installation and require one shared
+    /// installation ID, so a repository the App cannot see — or one that
+    /// resolves to a different installation — is named before any token is
+    /// minted. Targets are checked in deterministic primary-first order.
+    pub async fn resolve_shared_installation(
+        &self,
+        creds: &GitHubAppCredentials,
+        client: &impl HttpClient,
+        base_url: &str,
+    ) -> anyhow::Result<u64> {
+        #[derive(serde::Deserialize)]
+        struct Installation {
+            id: u64,
+        }
+
+        let jwt = crate::sign_app_jwt(&creds.app_id, &creds.private_key_pem)?;
+        let auth = format!("Bearer {jwt}");
+        let mut shared: Option<(u64, &GitHubRepositorySlug)> = None;
+        for slug in self.targets() {
+            let endpoint = format!(
+                "{base_url}/repos/{}/{}/installation",
+                slug.owner(),
+                slug.repo()
+            );
+            let response = client
+                .request(
+                    HttpMethod::Get,
+                    &endpoint,
+                    &crate::github_headers(&auth),
+                    None,
+                )
+                .await
+                .with_context(|| format!("looking up the GitHub App installation for {slug}"))?;
+            match response.status {
+                200 => {}
+                404 => bail!(
+                    "the GitHub App installation cannot see repository {slug}; add it to the \
+                     installation's repository access"
+                ),
+                status => bail!(
+                    "unexpected status {status} looking up the GitHub App installation for {slug}"
+                ),
+            }
+            let installation: Installation = response
+                .json()
+                .with_context(|| format!("parsing the installation response for {slug}"))?;
+            match shared {
+                None => shared = Some((installation.id, slug)),
+                Some((id, first)) if id != installation.id => bail!(
+                    "repository {slug} belongs to GitHub App installation {} but {first} belongs \
+                     to installation {id}; all repositories must share one installation",
+                    installation.id
+                ),
+                Some(_) => {}
+            }
+        }
+        let (id, _) = shared.expect("the effective repository set always contains the primary");
+        Ok(id)
+    }
+}
+
+/// A non-empty additional set needs a token that can reach repository
+/// contents. Configuration resolution already checked literal values; this
+/// is the runtime re-check after `{{ vars.* }}` interpolation.
+fn validate_additional_permissions(permissions: &HashMap<String, String>) -> anyhow::Result<()> {
+    let Some(contents) = permissions.get("contents") else {
+        bail!(
+            "run.integrations.github.additional_repositories requires the `contents` permission \
+             (`read` or `write`)"
+        );
+    };
+    if contents != "read" && contents != "write" {
+        bail!(
+            "run.integrations.github.additional_repositories requires `contents = \"read\"` or \
+             `contents = \"write\"`, got `{contents}`"
+        );
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn slugs(values: &[&str]) -> BTreeSet<GitHubRepositorySlug> {
+        values
+            .iter()
+            .map(|value| value.parse().expect("test slug should parse"))
+            .collect()
+    }
+
+    fn contents_read() -> HashMap<String, String> {
+        HashMap::from([("contents".to_string(), "read".to_string())])
+    }
+
+    fn access(
+        origin: &str,
+        additional: &[&str],
+        permissions: HashMap<String, String>,
+    ) -> anyhow::Result<Option<GitHubRepositoryAccess>> {
+        GitHubRepositoryAccess::new(Some(origin), &slugs(additional), permissions)
+    }
+
+    #[test]
+    fn https_and_both_ssh_origin_forms_normalize_to_the_same_primary() {
+        let origins = [
+            "https://github.com/fabro-sh/fabro.git",
+            "git@github.com:fabro-sh/fabro.git",
+            "ssh://git@github.com/fabro-sh/fabro.git",
+            "https://github.com/fabro-sh/fabro",
+        ];
+        for origin in origins {
+            let access = access(origin, &[], HashMap::new())
+                .expect(origin)
+                .expect("origin should produce an access value");
+            assert_eq!(access.primary().to_string(), "fabro-sh/fabro", "{origin}");
+        }
+    }
+
+    #[test]
+    fn no_origin_and_no_additional_repositories_is_none() {
+        let access = GitHubRepositoryAccess::new(None, &BTreeSet::new(), HashMap::new()).unwrap();
+        assert!(access.is_none());
+
+        let blank =
+            GitHubRepositoryAccess::new(Some("  "), &BTreeSet::new(), HashMap::new()).unwrap();
+        assert!(blank.is_none());
+    }
+
+    #[test]
+    fn additional_repositories_require_an_origin() {
+        let err =
+            GitHubRepositoryAccess::new(None, &slugs(&["fabro-sh/keystone"]), contents_read())
+                .unwrap_err();
+        assert!(
+            err.to_string().contains("requires a GitHub run origin"),
+            "{err:#}"
+        );
+    }
+
+    #[test]
+    fn additional_repositories_require_a_github_origin() {
+        let err = access(
+            "https://gitlab.com/fabro-sh/fabro",
+            &["fabro-sh/keystone"],
+            contents_read(),
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("repository access"), "{err:#}");
+    }
+
+    #[test]
+    fn rejects_primary_duplication_regardless_of_url_spelling_or_case() {
+        let origins = [
+            "https://github.com/Fabro-SH/Fabro.git",
+            "git@github.com:fabro-sh/fabro.git",
+            "ssh://git@github.com/fabro-sh/fabro",
+        ];
+        for origin in origins {
+            let err = access(origin, &["fabro-sh/FABRO"], contents_read()).unwrap_err();
+            assert!(
+                err.to_string().contains("must not repeat the run origin"),
+                "{origin}: {err:#}"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_an_additional_repository_with_a_different_owner() {
+        let err = access(
+            "https://github.com/fabro-sh/fabro",
+            &["lithoscomputer/conveyor"],
+            contents_read(),
+        )
+        .unwrap_err();
+        let message = err.to_string();
+        assert!(message.contains("lithoscomputer/conveyor"), "{message}");
+        assert!(message.contains("share one owner"), "{message}");
+    }
+
+    #[test]
+    fn rejects_a_declared_set_without_a_contents_permission() {
+        let missing = access(
+            "https://github.com/fabro-sh/fabro",
+            &["fabro-sh/keystone"],
+            HashMap::new(),
+        )
+        .unwrap_err();
+        assert!(
+            missing.to_string().contains("`contents` permission"),
+            "{missing:#}"
+        );
+
+        let wrong_level = access(
+            "https://github.com/fabro-sh/fabro",
+            &["fabro-sh/keystone"],
+            HashMap::from([("contents".to_string(), "admin".to_string())]),
+        )
+        .unwrap_err();
+        assert!(
+            wrong_level.to_string().contains("got `admin`"),
+            "{wrong_level:#}"
+        );
+    }
+
+    #[test]
+    fn targets_retain_every_full_slug_exactly_once_primary_first() {
+        let access = access(
+            "git@github.com:fabro-sh/fabro.git",
+            &["fabro-sh/keystone", "fabro-sh/arc"],
+            contents_read(),
+        )
+        .unwrap()
+        .unwrap();
+
+        let targets: Vec<String> = access.targets().iter().map(ToString::to_string).collect();
+        assert_eq!(targets, vec![
+            "fabro-sh/fabro",
+            "fabro-sh/arc",
+            "fabro-sh/keystone",
+        ]);
+        assert_eq!(access.repository_names(), vec!["fabro", "arc", "keystone"]);
+        assert_eq!(access.owner(), "fabro-sh");
+        assert!(access.has_additional_repositories());
+    }
+
+    #[test]
+    fn debug_output_contains_only_repositories_and_permissions() {
+        let access = access(
+            "https://github.com/fabro-sh/fabro",
+            &["fabro-sh/arc"],
+            contents_read(),
+        )
+        .unwrap()
+        .unwrap();
+
+        let rendered = format!("{access:?}");
+        assert!(rendered.contains("fabro-sh"), "{rendered}");
+        assert!(rendered.contains("contents"), "{rendered}");
+        // The value carries no token or key material by construction; its
+        // fields are exactly the repository slugs and the permission map.
+        assert!(!rendered.to_lowercase().contains("token"), "{rendered}");
+        assert!(!rendered.to_lowercase().contains("key"), "{rendered}");
+    }
+
+    #[tokio::test]
+    async fn resolve_shared_installation_names_the_invisible_repository() {
+        use crate::HttpMethod;
+        use crate::tests_mock::{MockHttpClient, test_rsa_key};
+
+        let mock = MockHttpClient::new()
+            .on(
+                HttpMethod::Get,
+                "/repos/fabro-sh/fabro/installation",
+                200,
+                r#"{"id": 7}"#,
+            )
+            .on(
+                HttpMethod::Get,
+                "/repos/fabro-sh/keystone/installation",
+                404,
+                "{}",
+            );
+        let creds = GitHubAppCredentials {
+            app_id:          "test".to_string(),
+            private_key_pem: test_rsa_key().to_string(),
+            slug:            None,
+        };
+        let access = access(
+            "https://github.com/fabro-sh/fabro",
+            &["fabro-sh/keystone"],
+            contents_read(),
+        )
+        .unwrap()
+        .unwrap();
+
+        let err = access
+            .resolve_shared_installation(&creds, &mock, "")
+            .await
+            .unwrap_err();
+        let message = err.to_string();
+        assert!(message.contains("fabro-sh/keystone"), "{message}");
+        assert!(message.contains("cannot see"), "{message}");
+    }
+
+    #[tokio::test]
+    async fn resolve_shared_installation_requires_one_installation_id() {
+        use crate::HttpMethod;
+        use crate::tests_mock::{MockHttpClient, test_rsa_key};
+
+        let mock = MockHttpClient::new()
+            .on(
+                HttpMethod::Get,
+                "/repos/fabro-sh/fabro/installation",
+                200,
+                r#"{"id": 7}"#,
+            )
+            .on(
+                HttpMethod::Get,
+                "/repos/fabro-sh/keystone/installation",
+                200,
+                r#"{"id": 8}"#,
+            );
+        let creds = GitHubAppCredentials {
+            app_id:          "test".to_string(),
+            private_key_pem: test_rsa_key().to_string(),
+            slug:            None,
+        };
+        let access = access(
+            "https://github.com/fabro-sh/fabro",
+            &["fabro-sh/keystone"],
+            contents_read(),
+        )
+        .unwrap()
+        .unwrap();
+
+        let err = access
+            .resolve_shared_installation(&creds, &mock, "")
+            .await
+            .unwrap_err();
+        let message = err.to_string();
+        assert!(message.contains("installation 8"), "{message}");
+        assert!(message.contains("fabro-sh/keystone"), "{message}");
+    }
+
+    #[tokio::test]
+    async fn resolve_shared_installation_returns_the_shared_id() {
+        use crate::HttpMethod;
+        use crate::tests_mock::{MockHttpClient, test_rsa_key};
+
+        let mock = MockHttpClient::new()
+            .on(
+                HttpMethod::Get,
+                "/repos/fabro-sh/fabro/installation",
+                200,
+                r#"{"id": 7}"#,
+            )
+            .on(
+                HttpMethod::Get,
+                "/repos/fabro-sh/keystone/installation",
+                200,
+                r#"{"id": 7}"#,
+            );
+        let creds = GitHubAppCredentials {
+            app_id:          "test".to_string(),
+            private_key_pem: test_rsa_key().to_string(),
+            slug:            None,
+        };
+        let access = access(
+            "https://github.com/fabro-sh/fabro",
+            &["fabro-sh/keystone"],
+            contents_read(),
+        )
+        .unwrap()
+        .unwrap();
+
+        let id = access
+            .resolve_shared_installation(&creds, &mock, "")
+            .await
+            .unwrap();
+        assert_eq!(id, 7);
+    }
+}

--- a/lib/components/fabro-github/src/lib.rs
+++ b/lib/components/fabro-github/src/lib.rs
@@ -21,6 +21,33 @@ pub use access::GitHubRepositoryAccess;
 
 pub const GITHUB_API_BASE_URL: &str = "https://api.github.com";
 
+/// Git config key that routes github.com HTTPS credentials through
+/// [`GITHUB_CREDENTIAL_HELPER`].
+pub const GITHUB_CREDENTIAL_HELPER_KEY: &str = "credential.https://github.com.helper";
+
+/// Secret-free git credential helper: reads `$GITHUB_TOKEN` from the
+/// invoking git process's environment at invocation time, so the token never
+/// lands in git configuration, argv, or rendered errors. Non-`get`
+/// operations (`store`, `erase`) are ignored. The one definition shared by
+/// the runtime git bridge, server preflight probes, and the live contract
+/// test, so the probes always exercise exactly what the bridge configures.
+pub const GITHUB_CREDENTIAL_HELPER: &str = r#"!f() { if [ "$1" = get ]; then echo username=x-access-token; echo "password=$GITHUB_TOKEN"; fi; }; f"#;
+
+/// Configure a `git` invocation to authenticate to github.com through
+/// [`GITHUB_CREDENTIAL_HELPER`] with `token`, isolated from user/system git
+/// configuration and terminal prompts. The token is passed only through the
+/// child process environment.
+pub fn apply_probe_git_env(command: &mut Command, token: &str) {
+    command
+        .env("GIT_TERMINAL_PROMPT", "0")
+        .env("GIT_CONFIG_NOSYSTEM", "1")
+        .env("GIT_CONFIG_GLOBAL", "/dev/null")
+        .env(EnvVars::GITHUB_TOKEN, token)
+        .env("GIT_CONFIG_COUNT", "1")
+        .env("GIT_CONFIG_KEY_0", GITHUB_CREDENTIAL_HELPER_KEY)
+        .env("GIT_CONFIG_VALUE_0", GITHUB_CREDENTIAL_HELPER);
+}
+
 /// Returns the GitHub API base URL, allowing override via `GITHUB_BASE_URL` env
 /// var.
 #[expect(
@@ -516,6 +543,52 @@ pub async fn create_installation_access_token_with_permissions_and_install_url(
     .map(|token| token.token)
 }
 
+/// Outcome of one GitHub App installation lookup
+/// (`GET /repos/{owner}/{repo}/installation`).
+///
+/// Status interpretation stays with callers because their user guidance
+/// differs: the mint path speaks about the owner's App installation, the
+/// multi-repository resolution names the specific repository.
+pub(crate) enum InstallationLookup {
+    Found(u64),
+    /// 404: the App cannot see the repository (or is not installed at all).
+    NotFound,
+    /// Any other non-200 status.
+    Failed(u16),
+}
+
+/// Look up the App installation covering `owner/repo` and parse its id.
+/// Transport and parse failures carry no caller-specific context; callers
+/// attach their own.
+pub(crate) async fn lookup_installation(
+    client: &impl HttpClient,
+    jwt: &str,
+    base_url: &str,
+    owner: &str,
+    repo: &str,
+) -> anyhow::Result<InstallationLookup> {
+    #[derive(Deserialize)]
+    struct Installation {
+        id: u64,
+    }
+
+    let endpoint = format!("{base_url}/repos/{owner}/{repo}/installation");
+    let auth = format!("Bearer {jwt}");
+    let resp = client
+        .request(HttpMethod::Get, &endpoint, &github_headers(&auth), None)
+        .await?;
+    match resp.status {
+        200 => {
+            let installation: Installation = resp
+                .json()
+                .context("Failed to parse installation response")?;
+            Ok(InstallationLookup::Found(installation.id))
+        }
+        404 => Ok(InstallationLookup::NotFound),
+        status => Ok(InstallationLookup::Failed(status)),
+    }
+}
+
 async fn mint_installation_token_with_jwt(
     client: &impl HttpClient,
     jwt: &str,
@@ -525,11 +598,6 @@ async fn mint_installation_token_with_jwt(
     permissions: serde_json::Value,
     install_url: Option<&str>,
 ) -> anyhow::Result<InstallationToken> {
-    #[derive(Deserialize)]
-    struct Installation {
-        id: u64,
-    }
-
     #[derive(Deserialize)]
     struct AccessToken {
         token:      String,
@@ -544,21 +612,12 @@ async fn mint_installation_token_with_jwt(
     // repository callers resolve every repository's installation up front
     // (`GitHubRepositoryAccess::resolve_shared_installation`), so the
     // primary stands for the whole set here.
-    let installation_endpoint = format!("{base_url}/repos/{owner}/{primary_repo}/installation");
-    let auth = format!("Bearer {jwt}");
-    let resp = client
-        .request(
-            HttpMethod::Get,
-            &installation_endpoint,
-            &github_headers(&auth),
-            None,
-        )
+    let installation_id = match lookup_installation(client, jwt, base_url, owner, primary_repo)
         .await
-        .context("Failed to look up GitHub App installation")?;
-
-    match resp.status {
-        200 => {}
-        404 => {
+        .context("Failed to look up GitHub App installation")?
+    {
+        InstallationLookup::Found(id) => id,
+        InstallationLookup::NotFound => {
             let install_url = install_url.map_or_else(
                 || format!("https://github.com/organizations/{owner}/settings/installations"),
                 str::to_string,
@@ -568,35 +627,26 @@ async fn mint_installation_token_with_jwt(
                  Install it at {install_url}"
             );
         }
-        403 => {
+        InstallationLookup::Failed(403) => {
             bail!(
                 "GitHub App installation is suspended. \
                  Re-enable it in your organization's GitHub App settings."
             );
         }
-        401 => {
+        InstallationLookup::Failed(401) => {
             bail!(
                 "GitHub App authentication failed. \
                  Check that app_id and GITHUB_APP_PRIVATE_KEY are correct."
             );
         }
-        _ => {
-            bail!(
-                "Unexpected status {} looking up GitHub App installation",
-                resp.status
-            );
+        InstallationLookup::Failed(status) => {
+            bail!("Unexpected status {status} looking up GitHub App installation");
         }
-    }
-
-    let installation: Installation = resp
-        .json()
-        .context("Failed to parse installation response")?;
+    };
 
     // Step 2: Create a scoped access token
-    let token_url = format!(
-        "{base_url}/app/installations/{}/access_tokens",
-        installation.id
-    );
+    let auth = format!("Bearer {jwt}");
+    let token_url = format!("{base_url}/app/installations/{installation_id}/access_tokens");
     let body = serde_json::json!({
         "repositories": repos,
         "permissions": permissions,

--- a/lib/components/fabro-github/src/lib.rs
+++ b/lib/components/fabro-github/src/lib.rs
@@ -9,10 +9,15 @@ use fabro_types::settings::run::MergeStrategy;
 use serde::Deserialize;
 use tokio::process::Command;
 
+pub mod access;
 pub mod token_source;
 
 #[cfg(any(test, feature = "test-support"))]
 pub mod test_support;
+#[cfg(test)]
+pub(crate) mod tests_mock;
+
+pub use access::GitHubRepositoryAccess;
 
 pub const GITHUB_API_BASE_URL: &str = "https://api.github.com";
 
@@ -152,6 +157,29 @@ impl GitHubAppCredentials {
         permissions: serde_json::Value,
         install_url: Option<&str>,
     ) -> anyhow::Result<InstallationToken> {
+        self.mint_installation_token_for_repositories(
+            client,
+            owner,
+            &[repo.to_string()],
+            base_url,
+            permissions,
+            install_url,
+        )
+        .await
+    }
+
+    /// Mint one installation token scoped to every repository in
+    /// `repository_names` (names within `owner`'s installation, primary
+    /// first) with the shared `permissions`.
+    pub async fn mint_installation_token_for_repositories(
+        &self,
+        client: &impl HttpClient,
+        owner: &str,
+        repository_names: &[String],
+        base_url: &str,
+        permissions: serde_json::Value,
+        install_url: Option<&str>,
+    ) -> anyhow::Result<InstallationToken> {
         let jwt = sign_app_jwt(&self.app_id, &self.private_key_pem)?;
         let default_install_url = self.installation_url(owner);
         let install_url = install_url.or(default_install_url.as_deref());
@@ -159,7 +187,7 @@ impl GitHubAppCredentials {
             client,
             &jwt,
             owner,
-            repo,
+            repository_names,
             base_url,
             permissions,
             install_url,
@@ -475,16 +503,24 @@ pub async fn create_installation_access_token_with_permissions_and_install_url(
     permissions: serde_json::Value,
     install_url: Option<&str>,
 ) -> anyhow::Result<String> {
-    mint_installation_token_with_jwt(client, jwt, owner, repo, base_url, permissions, install_url)
-        .await
-        .map(|token| token.token)
+    mint_installation_token_with_jwt(
+        client,
+        jwt,
+        owner,
+        &[repo.to_string()],
+        base_url,
+        permissions,
+        install_url,
+    )
+    .await
+    .map(|token| token.token)
 }
 
 async fn mint_installation_token_with_jwt(
     client: &impl HttpClient,
     jwt: &str,
     owner: &str,
-    repo: &str,
+    repos: &[String],
     base_url: &str,
     permissions: serde_json::Value,
     install_url: Option<&str>,
@@ -500,8 +536,15 @@ async fn mint_installation_token_with_jwt(
         expires_at: DateTime<Utc>,
     }
 
-    // Step 1: Find the installation for this repo
-    let installation_endpoint = format!("{base_url}/repos/{owner}/{repo}/installation");
+    let Some(primary_repo) = repos.first() else {
+        bail!("installation token mint requires at least one repository");
+    };
+
+    // Step 1: Find the installation via the primary repository. Multi-
+    // repository callers resolve every repository's installation up front
+    // (`GitHubRepositoryAccess::resolve_shared_installation`), so the
+    // primary stands for the whole set here.
+    let installation_endpoint = format!("{base_url}/repos/{owner}/{primary_repo}/installation");
     let auth = format!("Bearer {jwt}");
     let resp = client
         .request(
@@ -555,7 +598,7 @@ async fn mint_installation_token_with_jwt(
         installation.id
     );
     let body = serde_json::json!({
-        "repositories": [repo],
+        "repositories": repos,
         "permissions": permissions,
     });
 
@@ -573,8 +616,9 @@ async fn mint_installation_token_with_jwt(
         201 => {}
         422 => {
             bail!(
-                "GitHub App does not have access to repository {repo}. \
-                 Update the installation's repository permissions to include it."
+                "GitHub App does not have access to every requested repository ({}). \
+                 Update the installation's repository permissions to include them.",
+                repos.join(", ")
             );
         }
         401 => {
@@ -1715,7 +1759,7 @@ mod tests {
     // -----------------------------------------------------------------------
 
     fn test_rsa_key() -> &'static str {
-        include_str!("testdata/rsa_private.pem")
+        tests_mock::test_rsa_key()
     }
 
     #[test]
@@ -1769,89 +1813,7 @@ mod tests {
     // MockHttpClient
     // -----------------------------------------------------------------------
 
-    struct MockRoute {
-        method:           HttpMethod,
-        path:             String,
-        status:           u16,
-        response_body:    String,
-        assert_header:    Option<(String, MockHeaderCheck)>,
-        assert_body_json: Option<serde_json::Value>,
-    }
-
-    enum MockHeaderCheck {
-        Equals(String),
-    }
-
-    struct MockHttpClient {
-        routes: Vec<MockRoute>,
-    }
-
-    impl MockHttpClient {
-        fn new() -> Self {
-            Self { routes: vec![] }
-        }
-
-        fn on(mut self, method: HttpMethod, path: &str, status: u16, body: &str) -> Self {
-            self.routes.push(MockRoute {
-                method,
-                path: path.to_string(),
-                status,
-                response_body: body.to_string(),
-                assert_header: None,
-                assert_body_json: None,
-            });
-            self
-        }
-
-        fn with_req_header(mut self, name: &str, value: &str) -> Self {
-            self.routes.last_mut().unwrap().assert_header =
-                Some((name.to_string(), MockHeaderCheck::Equals(value.to_string())));
-            self
-        }
-
-        fn with_req_body(mut self, json_str: &str) -> Self {
-            self.routes.last_mut().unwrap().assert_body_json =
-                Some(serde_json::from_str(json_str).unwrap());
-            self
-        }
-    }
-
-    impl HttpClient for MockHttpClient {
-        async fn request(
-            &self,
-            method: HttpMethod,
-            url: &str,
-            headers: &[(&str, &str)],
-            body: Option<&serde_json::Value>,
-        ) -> anyhow::Result<HttpResponse> {
-            for route in &self.routes {
-                if method == route.method && url.ends_with(&route.path) {
-                    if let Some((name, MockHeaderCheck::Equals(expected))) = &route.assert_header {
-                        let (_, v) = headers
-                            .iter()
-                            .find(|(k, _)| *k == name.as_str())
-                            .unwrap_or_else(|| {
-                                panic!("Expected header '{name}' not found in request to {url}")
-                            });
-                        assert_eq!(*v, expected.as_str(), "Header '{name}' mismatch for {url}");
-                    }
-                    if let Some(expected_body) = &route.assert_body_json {
-                        let actual = body.expect("Expected request body");
-                        assert_eq!(actual, expected_body, "Request body mismatch for {url}");
-                    }
-                    return Ok(HttpResponse::new(route.status, route.response_body.clone()));
-                }
-            }
-            panic!(
-                "No mock route for {:?} {url}\nRegistered routes: {:?}",
-                method,
-                self.routes
-                    .iter()
-                    .map(|r| format!("{:?} {}", r.method, r.path))
-                    .collect::<Vec<_>>()
-            );
-        }
-    }
+    use crate::tests_mock::{self, MockHttpClient};
 
     // -----------------------------------------------------------------------
     // create_installation_access_token — success
@@ -1899,6 +1861,62 @@ mod tests {
                 .parse::<chrono::DateTime<chrono::Utc>>()
                 .unwrap()
         );
+    }
+
+    /// The multi-repository mint sends one request listing every projected
+    /// repository name exactly once, primary first, with the shared
+    /// permissions; the installation lookup uses the primary repository.
+    #[tokio::test]
+    async fn multi_repository_mint_lists_every_repository_name_once() {
+        let access = GitHubRepositoryAccess::new(
+            Some("git@github.com:owner/repo.git"),
+            &[
+                "owner/keystone".parse().unwrap(),
+                "owner/arc".parse().unwrap(),
+            ]
+            .into_iter()
+            .collect(),
+            std::collections::HashMap::from([("contents".to_string(), "read".to_string())]),
+        )
+        .unwrap()
+        .expect("origin should produce an access value");
+
+        let mock = MockHttpClient::new()
+            .on(
+                HttpMethod::Get,
+                "/repos/owner/repo/installation",
+                200,
+                r#"{"id": 123}"#,
+            )
+            .on(
+                HttpMethod::Post,
+                "/app/installations/123/access_tokens",
+                201,
+                r#"{"token": "ghs_multi", "expires_at": "2026-01-01T12:00:00Z"}"#,
+            )
+            .with_req_body(
+                r#"{"permissions":{"contents":"read"},"repositories":["repo","arc","keystone"]}"#,
+            );
+
+        let creds = GitHubAppCredentials {
+            app_id:          "test".to_string(),
+            private_key_pem: test_rsa_key().to_string(),
+            slug:            None,
+        };
+
+        let token = creds
+            .mint_installation_token_for_repositories(
+                &mock,
+                access.owner(),
+                &access.repository_names(),
+                "",
+                access.permissions_json().unwrap(),
+                None,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(token.token, "ghs_multi");
     }
 
     #[tokio::test]

--- a/lib/components/fabro-github/src/lib.rs
+++ b/lib/components/fabro-github/src/lib.rs
@@ -598,12 +598,6 @@ async fn mint_installation_token_with_jwt(
     permissions: serde_json::Value,
     install_url: Option<&str>,
 ) -> anyhow::Result<InstallationToken> {
-    #[derive(Deserialize)]
-    struct AccessToken {
-        token:      String,
-        expires_at: DateTime<Utc>,
-    }
-
     let Some(primary_repo) = repos.first() else {
         bail!("installation token mint requires at least one repository");
     };
@@ -644,7 +638,33 @@ async fn mint_installation_token_with_jwt(
         }
     };
 
-    // Step 2: Create a scoped access token
+    mint_installation_token_for_id_with_jwt(
+        client,
+        jwt,
+        installation_id,
+        repos,
+        base_url,
+        permissions,
+    )
+    .await
+}
+
+/// Create a repository-scoped token for an installation already resolved by
+/// the caller.
+pub(crate) async fn mint_installation_token_for_id_with_jwt(
+    client: &impl HttpClient,
+    jwt: &str,
+    installation_id: u64,
+    repos: &[String],
+    base_url: &str,
+    permissions: serde_json::Value,
+) -> anyhow::Result<InstallationToken> {
+    #[derive(Deserialize)]
+    struct AccessToken {
+        token:      String,
+        expires_at: DateTime<Utc>,
+    }
+
     let auth = format!("Bearer {jwt}");
     let token_url = format!("{base_url}/app/installations/{installation_id}/access_tokens");
     let body = serde_json::json!({
@@ -1159,25 +1179,24 @@ pub async fn check_app_installed(
     repo: &str,
     base_url: &str,
 ) -> anyhow::Result<bool> {
-    let url = format!("{base_url}/repos/{owner}/{repo}/installation");
-    let auth = format!("Bearer {jwt}");
-    let resp = client
-        .request(HttpMethod::Get, &url, &github_headers(&auth), None)
+    let lookup = lookup_installation(client, jwt, base_url, owner, repo)
         .await
         .context("Failed to check GitHub App installation")?;
 
-    match resp.status {
-        200 => Ok(true),
-        404 => Ok(false),
-        401 => bail!(
+    match lookup {
+        InstallationLookup::Found(_) => Ok(true),
+        InstallationLookup::NotFound => Ok(false),
+        InstallationLookup::Failed(401) => bail!(
             "GitHub App authentication failed. \
              Check that app_id and GITHUB_APP_PRIVATE_KEY are correct."
         ),
-        403 => bail!(
+        InstallationLookup::Failed(403) => bail!(
             "GitHub App installation is suspended. \
              Re-enable it in your organization's GitHub App settings."
         ),
-        status => bail!("Unexpected status {status} checking GitHub App installation"),
+        InstallationLookup::Failed(status) => {
+            bail!("Unexpected status {status} checking GitHub App installation")
+        }
     }
 }
 

--- a/lib/components/fabro-github/src/tests_mock.rs
+++ b/lib/components/fabro-github/src/tests_mock.rs
@@ -1,0 +1,93 @@
+//! Crate-internal test doubles shared by the `lib.rs` and `access` test
+//! modules: a scripted [`HttpClient`] and a throwaway RSA key for JWT
+//! signing.
+
+use crate::{HttpClient, HttpMethod, HttpResponse};
+
+pub(crate) fn test_rsa_key() -> &'static str {
+    include_str!("testdata/rsa_private.pem")
+}
+
+pub(crate) struct MockRoute {
+    method:           HttpMethod,
+    path:             String,
+    status:           u16,
+    response_body:    String,
+    assert_header:    Option<(String, MockHeaderCheck)>,
+    assert_body_json: Option<serde_json::Value>,
+}
+
+pub(crate) enum MockHeaderCheck {
+    Equals(String),
+}
+
+pub(crate) struct MockHttpClient {
+    routes: Vec<MockRoute>,
+}
+
+impl MockHttpClient {
+    pub(crate) fn new() -> Self {
+        Self { routes: vec![] }
+    }
+
+    pub(crate) fn on(mut self, method: HttpMethod, path: &str, status: u16, body: &str) -> Self {
+        self.routes.push(MockRoute {
+            method,
+            path: path.to_string(),
+            status,
+            response_body: body.to_string(),
+            assert_header: None,
+            assert_body_json: None,
+        });
+        self
+    }
+
+    pub(crate) fn with_req_header(mut self, name: &str, value: &str) -> Self {
+        self.routes.last_mut().unwrap().assert_header =
+            Some((name.to_string(), MockHeaderCheck::Equals(value.to_string())));
+        self
+    }
+
+    pub(crate) fn with_req_body(mut self, json_str: &str) -> Self {
+        self.routes.last_mut().unwrap().assert_body_json =
+            Some(serde_json::from_str(json_str).unwrap());
+        self
+    }
+}
+
+impl HttpClient for MockHttpClient {
+    async fn request(
+        &self,
+        method: HttpMethod,
+        url: &str,
+        headers: &[(&str, &str)],
+        body: Option<&serde_json::Value>,
+    ) -> anyhow::Result<HttpResponse> {
+        for route in &self.routes {
+            if method == route.method && url.ends_with(&route.path) {
+                if let Some((name, MockHeaderCheck::Equals(expected))) = &route.assert_header {
+                    let (_, v) = headers
+                        .iter()
+                        .find(|(k, _)| *k == name.as_str())
+                        .unwrap_or_else(|| {
+                            panic!("Expected header '{name}' not found in request to {url}")
+                        });
+                    assert_eq!(*v, expected.as_str(), "Header '{name}' mismatch for {url}");
+                }
+                if let Some(expected_body) = &route.assert_body_json {
+                    let actual = body.expect("Expected request body");
+                    assert_eq!(actual, expected_body, "Request body mismatch for {url}");
+                }
+                return Ok(HttpResponse::new(route.status, route.response_body.clone()));
+            }
+        }
+        panic!(
+            "No mock route for {:?} {url}\nRegistered routes: {:?}",
+            method,
+            self.routes
+                .iter()
+                .map(|r| format!("{:?} {}", r.method, r.path))
+                .collect::<Vec<_>>()
+        );
+    }
+}

--- a/lib/components/fabro-github/src/tests_mock.rs
+++ b/lib/components/fabro-github/src/tests_mock.rs
@@ -2,6 +2,8 @@
 //! modules: a scripted [`HttpClient`] and a throwaway RSA key for JWT
 //! signing.
 
+use std::sync::atomic::{AtomicUsize, Ordering};
+
 use crate::{HttpClient, HttpMethod, HttpResponse};
 
 pub(crate) fn test_rsa_key() -> &'static str {
@@ -22,12 +24,16 @@ pub(crate) enum MockHeaderCheck {
 }
 
 pub(crate) struct MockHttpClient {
-    routes: Vec<MockRoute>,
+    routes:        Vec<MockRoute>,
+    request_count: AtomicUsize,
 }
 
 impl MockHttpClient {
     pub(crate) fn new() -> Self {
-        Self { routes: vec![] }
+        Self {
+            routes:        vec![],
+            request_count: AtomicUsize::new(0),
+        }
     }
 
     pub(crate) fn on(mut self, method: HttpMethod, path: &str, status: u16, body: &str) -> Self {
@@ -53,6 +59,10 @@ impl MockHttpClient {
             Some(serde_json::from_str(json_str).unwrap());
         self
     }
+
+    pub(crate) fn request_count(&self) -> usize {
+        self.request_count.load(Ordering::SeqCst)
+    }
 }
 
 impl HttpClient for MockHttpClient {
@@ -63,6 +73,7 @@ impl HttpClient for MockHttpClient {
         headers: &[(&str, &str)],
         body: Option<&serde_json::Value>,
     ) -> anyhow::Result<HttpResponse> {
+        self.request_count.fetch_add(1, Ordering::SeqCst);
         for route in &self.routes {
             if method == route.method && url.ends_with(&route.path) {
                 if let Some((name, MockHeaderCheck::Equals(expected))) = &route.assert_header {

--- a/lib/components/fabro-github/src/token_source.rs
+++ b/lib/components/fabro-github/src/token_source.rs
@@ -146,31 +146,54 @@ pub(crate) trait InstallationTokenMinter: Send + Sync {
     async fn mint(&self) -> anyhow::Result<InstallationToken>;
 }
 
-/// Real minter backed by GitHub App credentials. `repos` lists repository
-/// names within the owner's installation, primary first; the minted token is
-/// scoped to exactly that set.
+/// Repository scope an App-backed source owns.
+enum AppTokenScope {
+    /// A single-repository source that resolves its installation during each
+    /// mint.
+    Repository {
+        owner:       String,
+        repo:        String,
+        permissions: serde_json::Value,
+    },
+    /// A validated declared set. Each mint resolves every target to one App
+    /// installation before creating the token.
+    Access(crate::GitHubRepositoryAccess),
+}
+
+/// Real minter backed by GitHub App credentials.
 struct AppTokenMinter {
-    creds:       GitHubAppCredentials,
-    http:        fabro_http::HttpClient,
-    owner:       String,
-    repos:       Vec<String>,
-    base_url:    String,
-    permissions: serde_json::Value,
+    creds:    GitHubAppCredentials,
+    http:     fabro_http::HttpClient,
+    base_url: String,
+    scope:    AppTokenScope,
 }
 
 #[async_trait::async_trait]
 impl InstallationTokenMinter for AppTokenMinter {
     async fn mint(&self) -> anyhow::Result<InstallationToken> {
-        self.creds
-            .mint_installation_token_for_repositories(
-                &self.http,
-                &self.owner,
-                &self.repos,
-                &self.base_url,
-                self.permissions.clone(),
-                None,
-            )
-            .await
+        match &self.scope {
+            AppTokenScope::Repository {
+                owner,
+                repo,
+                permissions,
+            } => {
+                self.creds
+                    .mint_installation_token(
+                        &self.http,
+                        owner,
+                        repo,
+                        &self.base_url,
+                        permissions.clone(),
+                        None,
+                    )
+                    .await
+            }
+            AppTokenScope::Access(access) => {
+                access
+                    .mint_installation_token(&self.creds, &self.http, &self.base_url)
+                    .await
+            }
+        }
     }
 }
 
@@ -222,6 +245,17 @@ pub struct InstallationTokenSource {
     state: SourceState,
 }
 
+fn repository_set_display(owner: &str, repos: &[String]) -> anyhow::Result<String> {
+    match repos {
+        [primary] => Ok(format!("{owner}/{primary}")),
+        [primary, additional @ ..] => Ok(format!(
+            "{owner}/{primary} (+{} additional)",
+            additional.len()
+        )),
+        [] => bail!("token source requires at least one repository"),
+    }
+}
+
 impl InstallationTokenSource {
     /// Build a source for `creds` against the repository in `origin_url`.
     ///
@@ -245,38 +279,33 @@ impl InstallationTokenSource {
         repo: String,
         permissions: serde_json::Value,
     ) -> anyhow::Result<Arc<Self>> {
-        Self::for_repositories(creds, owner, vec![repo], permissions)
+        let repo_display = format!("{owner}/{repo}");
+        Self::with_app_scope(creds, repo_display, AppTokenScope::Repository {
+            owner,
+            repo,
+            permissions,
+        })
     }
 
     /// Build a source for a validated effective repository set. Minted
     /// tokens are scoped to every repository in the set with the shared
-    /// permissions; caching, refresh margin, and single-flight behavior are
-    /// identical to the single-repository source.
+    /// permissions. App-backed sources also resolve every repository to one
+    /// shared installation before each mint. Caching, refresh margin, and
+    /// single-flight behavior are identical to the single-repository source.
     pub fn for_access(
         creds: &GitHubCredentials,
         access: &crate::GitHubRepositoryAccess,
     ) -> anyhow::Result<Arc<Self>> {
-        Self::for_repositories(
-            creds,
-            access.owner().to_string(),
-            access.repository_names(),
-            access.permissions_json()?,
-        )
+        let repository_names = access.repository_names();
+        let repo_display = repository_set_display(access.owner(), &repository_names)?;
+        Self::with_app_scope(creds, repo_display, AppTokenScope::Access(access.clone()))
     }
 
-    fn for_repositories(
+    fn with_app_scope(
         creds: &GitHubCredentials,
-        owner: String,
-        repos: Vec<String>,
-        permissions: serde_json::Value,
+        repo_display: String,
+        scope: AppTokenScope,
     ) -> anyhow::Result<Arc<Self>> {
-        let repo_display = match repos.as_slice() {
-            [primary] => format!("{owner}/{primary}"),
-            [primary, additional @ ..] => {
-                format!("{owner}/{primary} (+{} additional)", additional.len())
-            }
-            [] => bail!("token source requires at least one repository"),
-        };
         let state = match creds {
             GitHubCredentials::Pat(token) => SourceState::Pat(SecretString::new(token.clone())),
             GitHubCredentials::Installation(token) => SourceState::Installation(token.clone()),
@@ -288,10 +317,8 @@ impl InstallationTokenSource {
                     minter: Box::new(AppTokenMinter {
                         creds: app.clone(),
                         http,
-                        owner,
-                        repos,
                         base_url: crate::github_api_base_url(),
-                        permissions,
+                        scope,
                     }),
                     cache:  Mutex::new(None),
                 }

--- a/lib/components/fabro-github/src/token_source.rs
+++ b/lib/components/fabro-github/src/token_source.rs
@@ -15,7 +15,7 @@ use std::fmt;
 use std::sync::Arc;
 use std::time::Duration;
 
-use anyhow::Context as _;
+use anyhow::{Context as _, bail};
 use chrono::{DateTime, Utc};
 use tokio::sync::Mutex;
 
@@ -146,12 +146,14 @@ pub(crate) trait InstallationTokenMinter: Send + Sync {
     async fn mint(&self) -> anyhow::Result<InstallationToken>;
 }
 
-/// Real minter backed by GitHub App credentials.
+/// Real minter backed by GitHub App credentials. `repos` lists repository
+/// names within the owner's installation, primary first; the minted token is
+/// scoped to exactly that set.
 struct AppTokenMinter {
     creds:       GitHubAppCredentials,
     http:        fabro_http::HttpClient,
     owner:       String,
-    repo:        String,
+    repos:       Vec<String>,
     base_url:    String,
     permissions: serde_json::Value,
 }
@@ -160,10 +162,10 @@ struct AppTokenMinter {
 impl InstallationTokenMinter for AppTokenMinter {
     async fn mint(&self) -> anyhow::Result<InstallationToken> {
         self.creds
-            .mint_installation_token(
+            .mint_installation_token_for_repositories(
                 &self.http,
                 &self.owner,
-                &self.repo,
+                &self.repos,
                 &self.base_url,
                 self.permissions.clone(),
                 None,
@@ -243,7 +245,38 @@ impl InstallationTokenSource {
         repo: String,
         permissions: serde_json::Value,
     ) -> anyhow::Result<Arc<Self>> {
-        let repo_display = format!("{owner}/{repo}");
+        Self::for_repositories(creds, owner, vec![repo], permissions)
+    }
+
+    /// Build a source for a validated effective repository set. Minted
+    /// tokens are scoped to every repository in the set with the shared
+    /// permissions; caching, refresh margin, and single-flight behavior are
+    /// identical to the single-repository source.
+    pub fn for_access(
+        creds: &GitHubCredentials,
+        access: &crate::GitHubRepositoryAccess,
+    ) -> anyhow::Result<Arc<Self>> {
+        Self::for_repositories(
+            creds,
+            access.owner().to_string(),
+            access.repository_names(),
+            access.permissions_json()?,
+        )
+    }
+
+    fn for_repositories(
+        creds: &GitHubCredentials,
+        owner: String,
+        repos: Vec<String>,
+        permissions: serde_json::Value,
+    ) -> anyhow::Result<Arc<Self>> {
+        let repo_display = match repos.as_slice() {
+            [primary] => format!("{owner}/{primary}"),
+            [primary, additional @ ..] => {
+                format!("{owner}/{primary} (+{} additional)", additional.len())
+            }
+            [] => bail!("token source requires at least one repository"),
+        };
         let state = match creds {
             GitHubCredentials::Pat(token) => SourceState::Pat(SecretString::new(token.clone())),
             GitHubCredentials::Installation(token) => SourceState::Installation(token.clone()),
@@ -256,7 +289,7 @@ impl InstallationTokenSource {
                         creds: app.clone(),
                         http,
                         owner,
-                        repo,
+                        repos,
                         base_url: crate::github_api_base_url(),
                         permissions,
                     }),
@@ -500,6 +533,31 @@ mod tests {
         assert_eq!(resolved.snapshot.generation, 0);
         assert!(resolved.snapshot.is_static());
         assert!(!source.mints_installation_tokens());
+    }
+
+    /// A source built from a validated multi-repository access value uses the
+    /// same state machine as the single-repository constructor: static
+    /// credentials pass through, and App credentials share the cache
+    /// machinery exercised by the `with_minter` tests below.
+    #[tokio::test]
+    async fn for_access_source_resolves_like_the_single_repository_source() {
+        let access = crate::GitHubRepositoryAccess::new(
+            Some("https://github.com/owner/repo.git"),
+            &["owner/keystone".parse().unwrap()].into_iter().collect(),
+            std::collections::HashMap::from([("contents".to_string(), "read".to_string())]),
+        )
+        .unwrap()
+        .expect("origin should produce an access value");
+
+        let source = InstallationTokenSource::for_access(
+            &GitHubCredentials::Pat("ghp_pat".to_string()),
+            &access,
+        )
+        .unwrap();
+
+        let resolved = source.resolve().await.unwrap();
+        assert_eq!(resolved.token.expose(), "ghp_pat");
+        assert!(resolved.snapshot.is_static());
     }
 
     #[tokio::test]

--- a/lib/components/fabro-github/tests/live_access.rs
+++ b/lib/components/fabro-github/tests/live_access.rs
@@ -1,0 +1,146 @@
+//! Opt-in live GitHub App test for additional-repository access.
+//!
+//! Verifies against the real GitHub API that one installation token scoped
+//! to the primary repository plus one declared additional repository grants
+//! Git read access to both. Runs only in live mode with these variables set
+//! (it skips clearly otherwise):
+//!
+//! - `FABRO_TEST_GITHUB_APP_ID` — GitHub App id
+//! - `GITHUB_APP_PRIVATE_KEY` — App private key (PEM, or base64-encoded PEM)
+//! - `FABRO_TEST_GITHUB_ORIGIN` — HTTPS origin URL of the primary repository
+//! - `FABRO_TEST_GITHUB_ADDITIONAL_REPO` — an `owner/repository` slug the
+//!   installation can see, ideally private, sharing the origin's owner
+//!
+//! The repositories come from the environment so no private slug is baked
+//! into durable test output, and the minted token is only ever passed to
+//! `git` through the child process environment.
+
+use std::collections::BTreeSet;
+use std::process::Stdio;
+use std::time::Duration;
+
+use base64::engine::general_purpose::STANDARD;
+use fabro_github::token_source::InstallationTokenSource;
+use fabro_github::{GitHubAppCredentials, GitHubCredentials, GitHubRepositoryAccess};
+use fabro_types::GitHubRepositorySlug;
+use tokio::process::Command;
+use tokio::time::sleep;
+
+fn env_var(name: &str) -> String {
+    #[expect(
+        clippy::disallowed_methods,
+        reason = "live e2e configuration comes from the process environment by design"
+    )]
+    std::env::var(name).unwrap_or_else(|_| panic!("{name} must be set for this live test"))
+}
+
+fn private_key_pem() -> String {
+    let raw = env_var("GITHUB_APP_PRIVATE_KEY");
+    if raw.starts_with("-----") {
+        return raw;
+    }
+    let bytes = base64::Engine::decode(&STANDARD, &raw)
+        .expect("GITHUB_APP_PRIVATE_KEY is not valid base64");
+    String::from_utf8(bytes).expect("GITHUB_APP_PRIVATE_KEY decoded to invalid UTF-8")
+}
+
+async fn ls_remote_with_token(slug: &GitHubRepositorySlug, token: &str) -> bool {
+    let url = format!("https://github.com/{}/{}", slug.owner(), slug.repo());
+    let output = Command::new("git")
+        .env("GIT_TERMINAL_PROMPT", "0")
+        .env("GIT_CONFIG_NOSYSTEM", "1")
+        .env("GIT_CONFIG_GLOBAL", "/dev/null")
+        .env("GITHUB_TOKEN", token)
+        .env("GIT_CONFIG_COUNT", "1")
+        .env("GIT_CONFIG_KEY_0", "credential.https://github.com.helper")
+        .env(
+            "GIT_CONFIG_VALUE_0",
+            r#"!f() { if [ "$1" = get ]; then echo username=x-access-token; echo "password=$GITHUB_TOKEN"; fi; }; f"#,
+        )
+        .args(["ls-remote", &url, "HEAD"])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .output()
+        .await
+        .expect("git should run");
+    output.status.success()
+}
+
+#[fabro_macros::e2e_test(
+    live("FABRO_TEST_GITHUB_APP_ID"),
+    live("GITHUB_APP_PRIVATE_KEY"),
+    live("FABRO_TEST_GITHUB_ORIGIN"),
+    live("FABRO_TEST_GITHUB_ADDITIONAL_REPO")
+)]
+async fn scoped_token_reaches_the_declared_additional_repository() {
+    let app = GitHubAppCredentials {
+        app_id:          env_var("FABRO_TEST_GITHUB_APP_ID"),
+        private_key_pem: private_key_pem(),
+        slug:            None,
+    };
+    let origin = env_var("FABRO_TEST_GITHUB_ORIGIN");
+    let additional: GitHubRepositorySlug = env_var("FABRO_TEST_GITHUB_ADDITIONAL_REPO")
+        .parse()
+        .expect("FABRO_TEST_GITHUB_ADDITIONAL_REPO must be an owner/repository slug");
+    let additional_set: BTreeSet<GitHubRepositorySlug> = [additional.clone()].into_iter().collect();
+
+    let access = GitHubRepositoryAccess::new(
+        Some(&origin),
+        &additional_set,
+        std::collections::HashMap::from([("contents".to_string(), "read".to_string())]),
+    )
+    .expect("access request should validate")
+    .expect("origin should produce an access value");
+
+    // Every target resolves to one shared installation.
+    access
+        .resolve_shared_installation_via_api(&app)
+        .await
+        .expect("all repositories should share one App installation");
+
+    // One mint scoped to the whole effective set.
+    let source = InstallationTokenSource::for_access(&GitHubCredentials::App(app.clone()), &access)
+        .expect("token source should build");
+    let resolved = source.resolve().await.expect("scoped mint should succeed");
+    let token = resolved.token.expose();
+
+    // The one token reads both the primary and the additional repository.
+    // A freshly minted token can hit GitHub's replication lag, so retry a
+    // few times with the same token before failing.
+    for slug in access.targets() {
+        let mut reachable = false;
+        for _ in 0..3 {
+            if ls_remote_with_token(slug, token).await {
+                reachable = true;
+                break;
+            }
+            sleep(Duration::from_secs(2)).await;
+        }
+        assert!(
+            reachable,
+            "scoped token should read every declared repository"
+        );
+    }
+
+    // Negative scope check: a token minted for the primary alone must not
+    // read the additional repository (proves server-side scoping, not just
+    // possession of a token).
+    let primary_only = GitHubRepositoryAccess::new(
+        Some(&origin),
+        &BTreeSet::new(),
+        std::collections::HashMap::from([("contents".to_string(), "read".to_string())]),
+    )
+    .expect("primary-only access should validate")
+    .expect("origin should produce an access value");
+    let narrow_source =
+        InstallationTokenSource::for_access(&GitHubCredentials::App(app), &primary_only)
+            .expect("primary-only token source should build");
+    let narrow = narrow_source
+        .resolve()
+        .await
+        .expect("primary-only mint should succeed");
+    assert!(
+        !ls_remote_with_token(&additional, narrow.token.expose()).await,
+        "a primary-only token must not read the additional repository"
+    );
+}

--- a/lib/components/fabro-github/tests/live_access.rs
+++ b/lib/components/fabro-github/tests/live_access.rs
@@ -19,7 +19,6 @@ use std::collections::BTreeSet;
 use std::process::Stdio;
 use std::time::Duration;
 
-use base64::engine::general_purpose::STANDARD;
 use fabro_github::token_source::InstallationTokenSource;
 use fabro_github::{GitHubAppCredentials, GitHubCredentials, GitHubRepositoryAccess};
 use fabro_types::GitHubRepositorySlug;
@@ -35,28 +34,16 @@ fn env_var(name: &str) -> String {
 }
 
 fn private_key_pem() -> String {
-    let raw = env_var("GITHUB_APP_PRIVATE_KEY");
-    if raw.starts_with("-----") {
-        return raw;
-    }
-    let bytes = base64::Engine::decode(&STANDARD, &raw)
-        .expect("GITHUB_APP_PRIVATE_KEY is not valid base64");
-    String::from_utf8(bytes).expect("GITHUB_APP_PRIVATE_KEY decoded to invalid UTF-8")
+    GitHubAppCredentials::private_key_from_env()
+        .expect("GITHUB_APP_PRIVATE_KEY should decode as PEM or base64 PEM")
+        .expect("GITHUB_APP_PRIVATE_KEY must be set for this live test")
 }
 
 async fn ls_remote_with_token(slug: &GitHubRepositorySlug, token: &str) -> bool {
     let url = format!("https://github.com/{}/{}", slug.owner(), slug.repo());
-    let output = Command::new("git")
-        .env("GIT_TERMINAL_PROMPT", "0")
-        .env("GIT_CONFIG_NOSYSTEM", "1")
-        .env("GIT_CONFIG_GLOBAL", "/dev/null")
-        .env("GITHUB_TOKEN", token)
-        .env("GIT_CONFIG_COUNT", "1")
-        .env("GIT_CONFIG_KEY_0", "credential.https://github.com.helper")
-        .env(
-            "GIT_CONFIG_VALUE_0",
-            r#"!f() { if [ "$1" = get ]; then echo username=x-access-token; echo "password=$GITHUB_TOKEN"; fi; }; f"#,
-        )
+    let mut command = Command::new("git");
+    fabro_github::apply_probe_git_env(&mut command, token);
+    let output = command
         .args(["ls-remote", &url, "HEAD"])
         .stdout(Stdio::null())
         .stderr(Stdio::null())
@@ -92,16 +79,15 @@ async fn scoped_token_reaches_the_declared_additional_repository() {
     .expect("access request should validate")
     .expect("origin should produce an access value");
 
-    // Every target resolves to one shared installation.
-    access
-        .resolve_shared_installation_via_api(&app)
+    // The production choreography: every target resolves to one shared
+    // installation, then one mint scoped to the whole effective set.
+    let creds = GitHubCredentials::App(app.clone());
+    let source =
+        InstallationTokenSource::for_access(&creds, &access).expect("token source should build");
+    let resolved = access
+        .resolve_verified_token(&creds, &source)
         .await
-        .expect("all repositories should share one App installation");
-
-    // One mint scoped to the whole effective set.
-    let source = InstallationTokenSource::for_access(&GitHubCredentials::App(app.clone()), &access)
-        .expect("token source should build");
-    let resolved = source.resolve().await.expect("scoped mint should succeed");
+        .expect("scoped mint should succeed");
     let token = resolved.token.expose();
 
     // The one token reads both the primary and the additional repository.

--- a/lib/components/fabro-github/tests/live_access.rs
+++ b/lib/components/fabro-github/tests/live_access.rs
@@ -33,14 +33,8 @@ fn env_var(name: &str) -> String {
     std::env::var(name).unwrap_or_else(|_| panic!("{name} must be set for this live test"))
 }
 
-fn private_key_pem() -> String {
-    GitHubAppCredentials::private_key_from_env()
-        .expect("GITHUB_APP_PRIVATE_KEY should decode as PEM or base64 PEM")
-        .expect("GITHUB_APP_PRIVATE_KEY must be set for this live test")
-}
-
 async fn ls_remote_with_token(slug: &GitHubRepositorySlug, token: &str) -> bool {
-    let url = format!("https://github.com/{}/{}", slug.owner(), slug.repo());
+    let url = slug.https_url();
     let mut command = Command::new("git");
     fabro_github::apply_probe_git_env(&mut command, token);
     let output = command
@@ -60,11 +54,10 @@ async fn ls_remote_with_token(slug: &GitHubRepositorySlug, token: &str) -> bool 
     live("FABRO_TEST_GITHUB_ADDITIONAL_REPO")
 )]
 async fn scoped_token_reaches_the_declared_additional_repository() {
-    let app = GitHubAppCredentials {
-        app_id:          env_var("FABRO_TEST_GITHUB_APP_ID"),
-        private_key_pem: private_key_pem(),
-        slug:            None,
-    };
+    let app_id = env_var("FABRO_TEST_GITHUB_APP_ID");
+    let app = GitHubAppCredentials::from_env(Some(&app_id))
+        .expect("GITHUB_APP_PRIVATE_KEY should decode as PEM or base64 PEM")
+        .expect("GITHUB_APP_PRIVATE_KEY must be set for this live test");
     let origin = env_var("FABRO_TEST_GITHUB_ORIGIN");
     let additional: GitHubRepositorySlug = env_var("FABRO_TEST_GITHUB_ADDITIONAL_REPO")
         .parse()
@@ -84,10 +77,7 @@ async fn scoped_token_reaches_the_declared_additional_repository() {
     let creds = GitHubCredentials::App(app.clone());
     let source =
         InstallationTokenSource::for_access(&creds, &access).expect("token source should build");
-    let resolved = access
-        .resolve_verified_token(&creds, &source)
-        .await
-        .expect("scoped mint should succeed");
+    let resolved = source.resolve().await.expect("scoped mint should succeed");
     let token = resolved.token.expose();
 
     // The one token reads both the primary and the additional repository.

--- a/lib/components/fabro-sandbox/src/daytona/mod.rs
+++ b/lib/components/fabro-sandbox/src/daytona/mod.rs
@@ -1612,7 +1612,7 @@ impl Sandbox for DaytonaSandbox {
                 })?;
 
                 let clone_plan = git_retry::RetryPlan::clone_default(None);
-                let clone_result = git_retry::retry_clone(
+                let clone_result = git_retry::retry_git_operation(
                     SandboxProviderKind::Daytona,
                     "clone",
                     &clone_plan,

--- a/lib/components/fabro-sandbox/src/docker.rs
+++ b/lib/components/fabro-sandbox/src/docker.rs
@@ -811,7 +811,7 @@ impl DockerSandbox {
         auth_url: Option<&fabro_redact::DisplaySafeUrl>,
     ) -> Result<(), DockerCloneFailure> {
         let plan = git_retry::RetryPlan::clone_default(Some(clone_deadline));
-        git_retry::retry_clone(
+        git_retry::retry_git_operation(
             SandboxProviderKind::Docker,
             op,
             &plan,

--- a/lib/components/fabro-sandbox/src/git_retry.rs
+++ b/lib/components/fabro-sandbox/src/git_retry.rs
@@ -198,8 +198,11 @@ pub fn classify_failure(message: &str, cred: CredentialContext) -> Option<GitRet
 ///
 /// GitHub's guidance for token replication is to wait a few seconds and retry
 /// with the same token. Sub-second delays land inside the same replication
-/// window and spend an attempt for nothing.
-fn clone_backoff() -> BackoffPolicy {
+/// window and spend an attempt for nothing. Exported so other retried git
+/// operations against a freshly minted token (e.g. server preflight probes)
+/// pace themselves by the same policy.
+#[must_use]
+pub fn replication_backoff() -> BackoffPolicy {
     BackoffPolicy {
         initial_delay: Duration::from_secs(3),
         factor:        3.0,
@@ -236,7 +239,7 @@ impl RetryPlan {
     pub fn clone_default(outer_deadline: Option<time::Instant>) -> Self {
         Self {
             max_attempts: 3,
-            backoff: clone_backoff(),
+            backoff: replication_backoff(),
             max_elapsed: None,
             per_attempt_timeout: None,
             outer_deadline,
@@ -249,7 +252,7 @@ impl RetryPlan {
     pub fn checkpoint_push() -> Self {
         Self {
             max_attempts:        3,
-            backoff:             clone_backoff(),
+            backoff:             replication_backoff(),
             max_elapsed:         Some(Duration::from_secs(90)),
             per_attempt_timeout: Some(Duration::from_mins(1)),
             outer_deadline:      None,
@@ -736,7 +739,7 @@ mod tests {
         let attempts = Attempts::default();
         let plan = RetryPlan {
             max_attempts:        5,
-            backoff:             clone_backoff(),
+            backoff:             replication_backoff(),
             max_elapsed:         Some(Duration::from_secs(4)),
             per_attempt_timeout: None,
             outer_deadline:      None,

--- a/lib/components/fabro-sandbox/src/git_retry.rs
+++ b/lib/components/fabro-sandbox/src/git_retry.rs
@@ -198,11 +198,8 @@ pub fn classify_failure(message: &str, cred: CredentialContext) -> Option<GitRet
 ///
 /// GitHub's guidance for token replication is to wait a few seconds and retry
 /// with the same token. Sub-second delays land inside the same replication
-/// window and spend an attempt for nothing. Exported so other retried git
-/// operations against a freshly minted token (e.g. server preflight probes)
-/// pace themselves by the same policy.
-#[must_use]
-pub fn replication_backoff() -> BackoffPolicy {
+/// window and spend an attempt for nothing.
+fn replication_backoff() -> BackoffPolicy {
     BackoffPolicy {
         initial_delay: Duration::from_secs(3),
         factor:        3.0,
@@ -232,6 +229,13 @@ pub struct RetryPlan {
 }
 
 impl RetryPlan {
+    /// Host-side repository probes use the same attempt count and pacing as
+    /// clone operations against a freshly minted token.
+    #[must_use]
+    pub fn repository_probe() -> Self {
+        Self::clone_default(None)
+    }
+
     /// The clone policy both providers already trust: 3 attempts, 3s/9s
     /// backoff, no plan-level bounds. Docker supplies its existing absolute
     /// five-minute deadline through `outer_deadline`; Daytona supplies none.
@@ -319,13 +323,13 @@ impl RetryPlan {
     }
 }
 
-/// Run a clone operation, repeating it while the failure looks transient.
+/// Run a git operation, repeating it while the failure looks transient.
 ///
 /// `attempt` receives the 1-based attempt number. `classify` decides whether
 /// an error is worth repeating; `None` returns it to the caller untouched.
 /// A retry starts only when its backoff fits before the plan's effective
 /// deadline. The final error is returned as-is.
-pub(crate) async fn retry_clone<T, E, Attempt, Fut, Classify>(
+pub async fn retry_git_operation<T, E, Attempt, Fut, Classify>(
     provider: SandboxProviderKind,
     op: &str,
     plan: &RetryPlan,
@@ -598,7 +602,7 @@ mod tests {
     async fn first_success_runs_one_attempt() {
         let attempts = Attempts::default();
 
-        let result = retry_clone(
+        let result = retry_git_operation(
             SandboxProviderKind::Docker,
             "clone",
             &RetryPlan::clone_default(None),
@@ -618,7 +622,7 @@ mod tests {
     async fn retries_until_a_later_attempt_succeeds() {
         let attempts = Attempts::default();
 
-        let result = retry_clone(
+        let result = retry_git_operation(
             SandboxProviderKind::Docker,
             "clone",
             &RetryPlan::clone_default(None),
@@ -644,7 +648,7 @@ mod tests {
     async fn exhausted_attempts_return_the_final_error() {
         let attempts = Attempts::default();
 
-        let result = retry_clone(
+        let result = retry_git_operation(
             SandboxProviderKind::Docker,
             "clone",
             &RetryPlan::clone_default(None),
@@ -668,7 +672,7 @@ mod tests {
     async fn unretryable_failure_stops_immediately() {
         let attempts = Attempts::default();
 
-        let result = retry_clone(
+        let result = retry_git_operation(
             SandboxProviderKind::Docker,
             "clone",
             &RetryPlan::clone_default(None),
@@ -695,7 +699,7 @@ mod tests {
         let attempts = Attempts::default();
         let deadline = time::Instant::now() + Duration::from_secs(2);
 
-        let result = retry_clone(
+        let result = retry_git_operation(
             SandboxProviderKind::Docker,
             "clone",
             &RetryPlan::clone_default(Some(deadline)),
@@ -718,7 +722,7 @@ mod tests {
     async fn unbounded_plan_runs_all_attempts() {
         let attempts = Attempts::default();
 
-        let result = retry_clone(
+        let result = retry_git_operation(
             SandboxProviderKind::Daytona,
             "clone",
             &RetryPlan::clone_default(None),
@@ -745,7 +749,7 @@ mod tests {
             outer_deadline:      None,
         };
 
-        let result = retry_clone(
+        let result = retry_git_operation(
             SandboxProviderKind::Docker,
             "push",
             &plan,

--- a/lib/components/fabro-sandbox/src/lib.rs
+++ b/lib/components/fabro-sandbox/src/lib.rs
@@ -43,7 +43,9 @@ pub use fabro_github::token_source::{
     InstallationTokenSource, ResolvedToken, TokenProvenance, TokenSnapshot,
 };
 pub use fabro_types::{RunSandboxInstance, SandboxProviderKind};
-pub use git_retry::{CredentialContext, GitRetryReason, RetryPlan, classify_failure};
+pub use git_retry::{
+    CredentialContext, GitRetryReason, RetryPlan, classify_failure, replication_backoff,
+};
 pub use local::LocalSandbox;
 #[cfg(feature = "daytona")]
 pub use provider::daytona::DaytonaSandboxProvider;

--- a/lib/components/fabro-sandbox/src/lib.rs
+++ b/lib/components/fabro-sandbox/src/lib.rs
@@ -44,7 +44,7 @@ pub use fabro_github::token_source::{
 };
 pub use fabro_types::{RunSandboxInstance, SandboxProviderKind};
 pub use git_retry::{
-    CredentialContext, GitRetryReason, RetryPlan, classify_failure, replication_backoff,
+    CredentialContext, GitRetryReason, RetryPlan, classify_failure, retry_git_operation,
 };
 pub use local::LocalSandbox;
 #[cfg(feature = "daytona")]

--- a/lib/components/fabro-workflow/src/git_bridge.rs
+++ b/lib/components/fabro-workflow/src/git_bridge.rs
@@ -1,0 +1,448 @@
+//! Secret-free Git bridging environment for additional-repository access.
+//!
+//! When a run declares additional GitHub repositories, every resolved
+//! command/tool/ACP environment receives `GIT_CONFIG_COUNT` /
+//! `GIT_CONFIG_KEY_n` / `GIT_CONFIG_VALUE_n` entries that make plain Git
+//! commands work against the declared set through the managed
+//! `GITHUB_TOKEN`:
+//!
+//! - a credential helper for `https://github.com` that reads `$GITHUB_TOKEN`
+//!   from the invoking Git process's environment at invocation time, so token
+//!   refresh flows through per-stage environment resolution with no bridging
+//!   update;
+//! - per-repository `url.<https>.insteadOf` rewrites for the
+//!   `git@github.com:owner/repo[.git]` and
+//!   `ssh://git@github.com/owner/repo[.git]` SSH spellings of each effective
+//!   repository.
+//!
+//! None of the values contain a secret; the token lives only in
+//! `GITHUB_TOKEN`.
+//!
+//! The credential helper is host-scoped to `https://github.com`, not
+//! path-scoped. This is safe because the token is scoped server-side to the
+//! declared repository set and is only ever offered to github.com. It does
+//! change one failure mode for *undeclared* repositories: public HTTPS
+//! clones are unaffected (Git tries unauthenticated first), while private
+//! undeclared HTTPS repositories fail with a GitHub authorization error
+//! instead of a missing-credential error. Both fail; only the diagnostic
+//! differs.
+//!
+//! `insteadOf` matches by string prefix, not exactly: a rule for
+//! `owner/repo` also matches `owner/repo-other`. An undeclared repository
+//! that shares a declared prefix is therefore rewritten to HTTPS; the scoped
+//! token is invalid for it at GitHub, so authority is unchanged, but its Git
+//! transport changes from SSH to HTTPS.
+
+use std::collections::HashMap;
+
+use fabro_types::GitHubRepositorySlug;
+
+use crate::error::Error;
+
+/// Section base for the effective repositories' HTTPS routes.
+const GITHUB_HTTPS_BASE: &str = "https://github.com/";
+
+const CREDENTIAL_HELPER_KEY: &str = "credential.https://github.com.helper";
+/// Reads the invoking process's `$GITHUB_TOKEN` at invocation time; contains
+/// no secret itself. Non-`get` operations (`store`, `erase`) are ignored.
+const CREDENTIAL_HELPER: &str = r#"!f() { if [ "$1" = get ]; then echo username=x-access-token; echo "password=$GITHUB_TOKEN"; fi; }; f"#;
+
+/// Merge the bridging entries into `env` for the effective repository set
+/// (primary first). Appends after any valid user-provided `GIT_CONFIG_COUNT`
+/// overlay without overwriting it, and fails with a configuration error when
+/// the user overlay is malformed rather than silently replacing it.
+pub(crate) fn merge_git_bridge_env(
+    env: &mut HashMap<String, String>,
+    targets: &[&GitHubRepositorySlug],
+) -> Result<(), Error> {
+    let start = user_git_config_count(env)?;
+    for (offset, (key, value)) in bridge_entries(targets, GITHUB_HTTPS_BASE)
+        .into_iter()
+        .enumerate()
+    {
+        let index = start + offset;
+        env.insert(format!("GIT_CONFIG_KEY_{index}"), key);
+        env.insert(format!("GIT_CONFIG_VALUE_{index}"), value);
+    }
+    let total = start + bridge_entry_count(targets);
+    env.insert("GIT_CONFIG_COUNT".to_string(), total.to_string());
+    // Fail instead of hanging when access is missing or invalid; a user who
+    // explicitly configured prompting keeps their value.
+    env.entry("GIT_TERMINAL_PROMPT".to_string())
+        .or_insert_with(|| "0".to_string());
+    Ok(())
+}
+
+fn bridge_entry_count(targets: &[&GitHubRepositorySlug]) -> usize {
+    1 + targets.len() * 2
+}
+
+/// The bridge's Git config entries in order: the credential helper, then two
+/// SSH-to-HTTPS rewrites per repository. `https_base` is
+/// [`GITHUB_HTTPS_BASE`] in production; contract tests substitute a local
+/// `file://` root to prove real Git applies the generated entries without
+/// touching the network.
+fn bridge_entries(targets: &[&GitHubRepositorySlug], https_base: &str) -> Vec<(String, String)> {
+    let mut entries = Vec::with_capacity(bridge_entry_count(targets));
+    entries.push((
+        CREDENTIAL_HELPER_KEY.to_string(),
+        CREDENTIAL_HELPER.to_string(),
+    ));
+    for slug in targets {
+        let owner = slug.owner();
+        let repo = slug.repo();
+        let https = format!("{https_base}{owner}/{repo}");
+        // One prefix rule per SSH spelling covers both the bare and `.git`
+        // suffixed forms.
+        entries.push((
+            format!("url.{https}.insteadOf"),
+            format!("git@github.com:{owner}/{repo}"),
+        ));
+        entries.push((
+            format!("url.{https}.insteadOf"),
+            format!("ssh://git@github.com/{owner}/{repo}"),
+        ));
+    }
+    entries
+}
+
+/// Validate and measure a user-provided `GIT_CONFIG_COUNT` overlay so the
+/// bridge appends after it. Orphaned `GIT_CONFIG_KEY_n` entries without a
+/// count are inert to Git and are treated as absent.
+fn user_git_config_count(env: &HashMap<String, String>) -> Result<usize, Error> {
+    let Some(raw) = env.get("GIT_CONFIG_COUNT") else {
+        return Ok(0);
+    };
+    let count: usize = raw.trim().parse().map_err(|_| {
+        Error::Precondition(format!(
+            "environment variable GIT_CONFIG_COUNT must be a non-negative integer to combine \
+             with Fabro's Git bridging entries, got `{raw}`"
+        ))
+    })?;
+    for index in 0..count {
+        let key = format!("GIT_CONFIG_KEY_{index}");
+        let value = format!("GIT_CONFIG_VALUE_{index}");
+        if !env.contains_key(&key) || !env.contains_key(&value) {
+            return Err(Error::Precondition(format!(
+                "GIT_CONFIG_COUNT is {count} but {key} or {value} is missing; fix the indexed \
+                 Git config overlay so Fabro can append its bridging entries after it"
+            )));
+        }
+    }
+    Ok(count)
+}
+
+#[cfg(test)]
+#[expect(
+    clippy::disallowed_methods,
+    clippy::disallowed_types,
+    reason = "contract tests drive the installed git binary synchronously in non-async tests"
+)]
+mod tests {
+    use std::path::Path;
+    use std::process::Command;
+
+    use super::*;
+
+    fn slug(value: &str) -> GitHubRepositorySlug {
+        value.parse().expect("test slug should parse")
+    }
+
+    fn bridged_env(
+        base_env: HashMap<String, String>,
+        targets: &[&GitHubRepositorySlug],
+    ) -> HashMap<String, String> {
+        let mut env = base_env;
+        merge_git_bridge_env(&mut env, targets).expect("bridge entries should merge");
+        env
+    }
+
+    /// Run `git` with ONLY the bridge-relevant environment: the inherited
+    /// user/system/global Git config is disabled so assertions observe just
+    /// the generated entries.
+    fn git(args: &[&str], env: &HashMap<String, String>, cwd: &Path) -> std::process::Output {
+        let mut command = Command::new("git");
+        command
+            .args(args)
+            .current_dir(cwd)
+            .env("GIT_CONFIG_NOSYSTEM", "1")
+            .env("GIT_CONFIG_GLOBAL", "/dev/null")
+            .env("GIT_TERMINAL_PROMPT", "0")
+            .env("GIT_ASKPASS", "true");
+        for (key, value) in env {
+            command.env(key, value);
+        }
+        command.output().expect("git should run")
+    }
+
+    /// Create a bare fixture answering both the bare and `.git`-suffixed
+    /// routes, the way GitHub serves both HTTPS spellings.
+    fn init_bare_fixture(root: &Path, owner_repo: &str) -> String {
+        let fixture = root.join(format!("{owner_repo}.git"));
+        std::fs::create_dir_all(&fixture).unwrap();
+        let init = Command::new("git")
+            .args(["init", "--bare", "--initial-branch=main"])
+            .arg(&fixture)
+            .output()
+            .expect("git init should run");
+        assert!(init.status.success(), "{init:?}");
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(&fixture, root.join(owner_repo)).unwrap();
+        format!("file://{}/", root.display())
+    }
+
+    #[test]
+    fn no_targets_means_no_bridge_call_and_empty_env_stays_empty() {
+        // The caller only bridges when the additional set is non-empty; the
+        // pure entry builder is still total for the primary-only case.
+        assert_eq!(bridge_entry_count(&[]), 1);
+        let env: HashMap<String, String> = HashMap::new();
+        assert!(!env.contains_key("GIT_CONFIG_COUNT"));
+    }
+
+    #[test]
+    fn merges_helper_rewrites_count_and_terminal_prompt() {
+        let keystone = slug("fabro-sh/keystone");
+        let fabro = slug("fabro-sh/fabro");
+        let env = bridged_env(HashMap::new(), &[&fabro, &keystone]);
+
+        assert_eq!(env.get("GIT_CONFIG_COUNT").map(String::as_str), Some("5"));
+        assert_eq!(
+            env.get("GIT_CONFIG_KEY_0").map(String::as_str),
+            Some("credential.https://github.com.helper")
+        );
+        assert_eq!(
+            env.get("GIT_CONFIG_KEY_1").map(String::as_str),
+            Some("url.https://github.com/fabro-sh/fabro.insteadOf")
+        );
+        assert_eq!(
+            env.get("GIT_CONFIG_VALUE_1").map(String::as_str),
+            Some("git@github.com:fabro-sh/fabro")
+        );
+        assert_eq!(
+            env.get("GIT_CONFIG_VALUE_2").map(String::as_str),
+            Some("ssh://git@github.com/fabro-sh/fabro")
+        );
+        assert_eq!(
+            env.get("GIT_TERMINAL_PROMPT").map(String::as_str),
+            Some("0")
+        );
+
+        // No secrets anywhere in the generated values.
+        for (key, value) in &env {
+            assert!(!value.contains("ghs_"), "{key}={value}");
+        }
+    }
+
+    #[test]
+    fn respects_an_explicit_user_terminal_prompt() {
+        let keystone = slug("fabro-sh/keystone");
+        let env = bridged_env(
+            HashMap::from([("GIT_TERMINAL_PROMPT".to_string(), "1".to_string())]),
+            &[&keystone],
+        );
+        assert_eq!(
+            env.get("GIT_TERMINAL_PROMPT").map(String::as_str),
+            Some("1")
+        );
+    }
+
+    #[test]
+    fn appends_after_a_valid_user_git_config_overlay() {
+        let keystone = slug("fabro-sh/keystone");
+        let env = bridged_env(
+            HashMap::from([
+                ("GIT_CONFIG_COUNT".to_string(), "1".to_string()),
+                ("GIT_CONFIG_KEY_0".to_string(), "user.name".to_string()),
+                ("GIT_CONFIG_VALUE_0".to_string(), "Overlay User".to_string()),
+            ]),
+            &[&keystone],
+        );
+
+        assert_eq!(env.get("GIT_CONFIG_COUNT").map(String::as_str), Some("4"));
+        assert_eq!(
+            env.get("GIT_CONFIG_KEY_0").map(String::as_str),
+            Some("user.name"),
+            "user entry must survive at its original index"
+        );
+        assert_eq!(
+            env.get("GIT_CONFIG_KEY_1").map(String::as_str),
+            Some("credential.https://github.com.helper")
+        );
+
+        // Real Git sees both the user's entry and the appended bridge entry.
+        let dir = tempfile::tempdir().unwrap();
+        let output = git(&["config", "--list"], &env, dir.path());
+        assert!(output.status.success(), "{output:?}");
+        let listed = String::from_utf8_lossy(&output.stdout);
+        assert!(listed.contains("user.name=Overlay User"), "{listed}");
+        assert!(
+            listed.contains("credential.https://github.com.helper"),
+            "{listed}"
+        );
+    }
+
+    #[test]
+    fn rejects_a_malformed_user_git_config_overlay() {
+        let keystone = slug("fabro-sh/keystone");
+
+        let mut non_numeric = HashMap::from([("GIT_CONFIG_COUNT".to_string(), "two".to_string())]);
+        let err = merge_git_bridge_env(&mut non_numeric, &[&keystone]).unwrap_err();
+        assert!(err.to_string().contains("GIT_CONFIG_COUNT"), "{err}");
+
+        let mut missing_index = HashMap::from([
+            ("GIT_CONFIG_COUNT".to_string(), "2".to_string()),
+            ("GIT_CONFIG_KEY_0".to_string(), "user.name".to_string()),
+            ("GIT_CONFIG_VALUE_0".to_string(), "Overlay".to_string()),
+        ]);
+        let err = merge_git_bridge_env(&mut missing_index, &[&keystone]).unwrap_err();
+        assert!(err.to_string().contains("GIT_CONFIG_KEY_1"), "{err}");
+    }
+
+    /// With the bridge active, `git credential fill` for github.com resolves
+    /// through the generated helper and reads `$GITHUB_TOKEN` from the
+    /// invoking process environment at invocation time.
+    #[test]
+    fn credential_helper_reads_github_token_at_invocation_time() {
+        use std::io::Write as _;
+
+        let keystone = slug("fabro-sh/keystone");
+        let mut env = bridged_env(HashMap::new(), &[&keystone]);
+        env.insert("GITHUB_TOKEN".to_string(), "test-token-value".to_string());
+
+        let dir = tempfile::tempdir().unwrap();
+        let mut command = Command::new("git");
+        command
+            .args(["credential", "fill"])
+            .current_dir(dir.path())
+            .env("GIT_CONFIG_NOSYSTEM", "1")
+            .env("GIT_CONFIG_GLOBAL", "/dev/null")
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped());
+        for (key, value) in &env {
+            command.env(key, value);
+        }
+        let mut child = command.spawn().expect("git credential fill should spawn");
+        child
+            .stdin
+            .as_mut()
+            .unwrap()
+            .write_all(b"protocol=https\nhost=github.com\npath=fabro-sh/keystone\n\n")
+            .unwrap();
+        let output = child.wait_with_output().unwrap();
+
+        assert!(output.status.success(), "{output:?}");
+        let filled = String::from_utf8_lossy(&output.stdout);
+        assert!(filled.contains("username=x-access-token"), "{filled}");
+        assert!(filled.contains("password=test-token-value"), "{filled}");
+    }
+
+    /// Real Git applies the generated `insteadOf` rewrites: the exact SSH
+    /// spellings of a declared repository resolve to their HTTPS-analog
+    /// route (a local `file://` fixture here, so no network is involved),
+    /// while `GIT_SSH_COMMAND=false` proves SSH is never attempted.
+    #[test]
+    fn declared_ssh_urls_rewrite_to_the_https_route() {
+        let root = tempfile::tempdir().unwrap();
+        let base = init_bare_fixture(root.path(), "fabro-sh/keystone");
+        let keystone = slug("fabro-sh/keystone");
+
+        let mut env: HashMap<String, String> = HashMap::new();
+        for (offset, (key, value)) in bridge_entries(&[&keystone], &base).into_iter().enumerate() {
+            env.insert(format!("GIT_CONFIG_KEY_{offset}"), key);
+            env.insert(format!("GIT_CONFIG_VALUE_{offset}"), value);
+        }
+        env.insert("GIT_CONFIG_COUNT".to_string(), "3".to_string());
+        env.insert("GIT_SSH_COMMAND".to_string(), "false".to_string());
+
+        for url in [
+            "ssh://git@github.com/fabro-sh/keystone.git",
+            "ssh://git@github.com/fabro-sh/keystone",
+            "git@github.com:fabro-sh/keystone.git",
+            "git@github.com:fabro-sh/keystone",
+        ] {
+            let output = git(&["ls-remote", url], &env, root.path());
+            assert!(
+                output.status.success(),
+                "{url} should rewrite to the fixture route: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+    }
+
+    /// An undeclared SSH URL that shares no declared prefix is not
+    /// rewritten: Git still routes it to SSH, where the scripted
+    /// `GIT_SSH_COMMAND=false` fails immediately without network access.
+    #[test]
+    fn undeclared_ssh_urls_are_not_rewritten() {
+        let root = tempfile::tempdir().unwrap();
+        let base = init_bare_fixture(root.path(), "fabro-sh/keystone");
+        let keystone = slug("fabro-sh/keystone");
+
+        let mut env: HashMap<String, String> = HashMap::new();
+        for (offset, (key, value)) in bridge_entries(&[&keystone], &base).into_iter().enumerate() {
+            env.insert(format!("GIT_CONFIG_KEY_{offset}"), key);
+            env.insert(format!("GIT_CONFIG_VALUE_{offset}"), value);
+        }
+        env.insert("GIT_CONFIG_COUNT".to_string(), "3".to_string());
+        env.insert("GIT_SSH_COMMAND".to_string(), "false".to_string());
+        env.insert("GITHUB_TOKEN".to_string(), "test-token-value".to_string());
+
+        let output = git(
+            &["ls-remote", "git@github.com:fabro-sh/undeclared"],
+            &env,
+            root.path(),
+        );
+        assert!(!output.status.success(), "{output:?}");
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        // Not rewritten: the failure never mentions the local HTTPS-analog
+        // fixture route, so Git still chose the SSH transport.
+        assert!(
+            !stderr.contains(&root.path().display().to_string()),
+            "undeclared URL must not be rewritten to the fixture route: {stderr}"
+        );
+        assert!(!stderr.contains("test-token-value"), "{stderr}");
+    }
+
+    /// Prefix collision: with `fabro-sh/keystone` declared, both SSH
+    /// spellings of `fabro-sh/keystone-other` are rewritten to the HTTPS
+    /// route (prefix match), where access fails — at GitHub this is an
+    /// authorization error for the scoped token — and no token leaks into
+    /// the output.
+    #[test]
+    fn prefix_colliding_undeclared_repositories_rewrite_and_fail_without_token_leak() {
+        let root = tempfile::tempdir().unwrap();
+        let base = init_bare_fixture(root.path(), "fabro-sh/keystone");
+        let keystone = slug("fabro-sh/keystone");
+
+        let mut env: HashMap<String, String> = HashMap::new();
+        for (offset, (key, value)) in bridge_entries(&[&keystone], &base).into_iter().enumerate() {
+            env.insert(format!("GIT_CONFIG_KEY_{offset}"), key);
+            env.insert(format!("GIT_CONFIG_VALUE_{offset}"), value);
+        }
+        env.insert("GIT_CONFIG_COUNT".to_string(), "3".to_string());
+        env.insert("GIT_SSH_COMMAND".to_string(), "false".to_string());
+        env.insert("GITHUB_TOKEN".to_string(), "test-token-value".to_string());
+
+        for url in [
+            "git@github.com:fabro-sh/keystone-other",
+            "ssh://git@github.com/fabro-sh/keystone-other.git",
+        ] {
+            let output = git(&["ls-remote", url], &env, root.path());
+            assert!(!output.status.success(), "{url}: {output:?}");
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            // The failure names the (missing) HTTPS-analog fixture route,
+            // proving the prefix rule rewrote the URL away from SSH.
+            assert!(
+                stderr.contains("keystone-other"),
+                "{url} must be rewritten away from SSH, got: {stderr}"
+            );
+            assert!(
+                stderr.contains(&root.path().display().to_string()),
+                "{url} must land on the rewritten route, got: {stderr}"
+            );
+            assert!(!stderr.contains("test-token-value"), "{stderr}");
+        }
+    }
+}

--- a/lib/components/fabro-workflow/src/git_bridge.rs
+++ b/lib/components/fabro-workflow/src/git_bridge.rs
@@ -35,17 +35,13 @@
 
 use std::collections::HashMap;
 
+use fabro_github::{GITHUB_CREDENTIAL_HELPER, GITHUB_CREDENTIAL_HELPER_KEY};
 use fabro_types::GitHubRepositorySlug;
 
 use crate::error::Error;
 
 /// Section base for the effective repositories' HTTPS routes.
 const GITHUB_HTTPS_BASE: &str = "https://github.com/";
-
-const CREDENTIAL_HELPER_KEY: &str = "credential.https://github.com.helper";
-/// Reads the invoking process's `$GITHUB_TOKEN` at invocation time; contains
-/// no secret itself. Non-`get` operations (`store`, `erase`) are ignored.
-const CREDENTIAL_HELPER: &str = r#"!f() { if [ "$1" = get ]; then echo username=x-access-token; echo "password=$GITHUB_TOKEN"; fi; }; f"#;
 
 /// Merge the bridging entries into `env` for the effective repository set
 /// (primary first). Appends after any valid user-provided `GIT_CONFIG_COUNT`
@@ -56,15 +52,13 @@ pub(crate) fn merge_git_bridge_env(
     targets: &[&GitHubRepositorySlug],
 ) -> Result<(), Error> {
     let start = user_git_config_count(env)?;
-    for (offset, (key, value)) in bridge_entries(targets, GITHUB_HTTPS_BASE)
-        .into_iter()
-        .enumerate()
-    {
+    let entries = bridge_entries(targets, GITHUB_HTTPS_BASE);
+    let total = start + entries.len();
+    for (offset, (key, value)) in entries.into_iter().enumerate() {
         let index = start + offset;
         env.insert(format!("GIT_CONFIG_KEY_{index}"), key);
         env.insert(format!("GIT_CONFIG_VALUE_{index}"), value);
     }
-    let total = start + bridge_entry_count(targets);
     env.insert("GIT_CONFIG_COUNT".to_string(), total.to_string());
     // Fail instead of hanging when access is missing or invalid; a user who
     // explicitly configured prompting keeps their value.
@@ -73,20 +67,16 @@ pub(crate) fn merge_git_bridge_env(
     Ok(())
 }
 
-fn bridge_entry_count(targets: &[&GitHubRepositorySlug]) -> usize {
-    1 + targets.len() * 2
-}
-
 /// The bridge's Git config entries in order: the credential helper, then two
 /// SSH-to-HTTPS rewrites per repository. `https_base` is
 /// [`GITHUB_HTTPS_BASE`] in production; contract tests substitute a local
 /// `file://` root to prove real Git applies the generated entries without
 /// touching the network.
 fn bridge_entries(targets: &[&GitHubRepositorySlug], https_base: &str) -> Vec<(String, String)> {
-    let mut entries = Vec::with_capacity(bridge_entry_count(targets));
+    let mut entries = Vec::with_capacity(1 + targets.len() * 2);
     entries.push((
-        CREDENTIAL_HELPER_KEY.to_string(),
-        CREDENTIAL_HELPER.to_string(),
+        GITHUB_CREDENTIAL_HELPER_KEY.to_string(),
+        GITHUB_CREDENTIAL_HELPER.to_string(),
     ));
     for slug in targets {
         let owner = slug.owner();
@@ -195,7 +185,7 @@ mod tests {
     fn no_targets_means_no_bridge_call_and_empty_env_stays_empty() {
         // The caller only bridges when the additional set is non-empty; the
         // pure entry builder is still total for the primary-only case.
-        assert_eq!(bridge_entry_count(&[]), 1);
+        assert_eq!(bridge_entries(&[], GITHUB_HTTPS_BASE).len(), 1);
         let env: HashMap<String, String> = HashMap::new();
         assert!(!env.contains_key("GIT_CONFIG_COUNT"));
     }

--- a/lib/components/fabro-workflow/src/handler/llm/acp.rs
+++ b/lib/components/fabro-workflow/src/handler/llm/acp.rs
@@ -473,8 +473,9 @@ impl AgentAcpBackend {
             emitter.notice(
                 RunNoticeLevel::Info,
                 RunNoticeCode::GithubTokenRefreshLimited,
-                "ACP agent stages receive workflow env at process launch; stages running beyond \
-                 token expiry may need to be retried.",
+                "ACP agent stages receive workflow env at process launch; GITHUB_TOKEN access to \
+                 every declared repository expires together, so stages running beyond token \
+                 expiry may need to be retried.",
             );
         }
         provider

--- a/lib/components/fabro-workflow/src/lib.rs
+++ b/lib/components/fabro-workflow/src/lib.rs
@@ -293,6 +293,7 @@ pub mod error;
 pub mod event;
 pub mod file_resolver;
 pub mod git;
+pub(crate) mod git_bridge;
 pub(crate) mod graph;
 pub mod handler;
 mod hook_context;

--- a/lib/components/fabro-workflow/src/operations/start.rs
+++ b/lib/components/fabro-workflow/src/operations/start.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::path::Path;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
@@ -17,7 +17,7 @@ use fabro_sandbox::{DockerSandboxOptions, SandboxSpec};
 use fabro_static::EnvVars;
 use fabro_types::settings::run::{
     ApprovalMode, McpServerSettings as ResolvedMcpServerSettings, PullRequestSettings,
-    ResolvedMcpEntry, RunMode, RunNamespace as ResolvedRunSettings,
+    ResolvedGithubIntegration, ResolvedMcpEntry, RunMode, RunNamespace as ResolvedRunSettings,
     RunPrepareSettings as ResolvedRunPrepareSettings,
 };
 use fabro_types::{ManifestPath, RunId, RunRunnableSource, SandboxProviderKind};
@@ -104,9 +104,10 @@ pub struct StartServices {
     pub artifact_sink:      Option<ArtifactSink>,
     pub run_control:        Option<Arc<RunControlState>>,
     pub github_app:         Option<fabro_github::GitHubCredentials>,
-    /// Server-resolved GitHub integration permissions to inject into the
-    /// sandbox env. Empty when github integration has no permissions.
-    pub github_permissions: HashMap<String, String>,
+    /// The resolved GitHub integration request (interpolated permissions
+    /// plus declared additional repositories) to inject into the sandbox
+    /// env. Empty when the github integration requests no token.
+    pub github_integration: ResolvedGithubIntegration,
     pub vault:              Arc<AsyncRwLock<Vault>>,
     pub catalog:            Arc<Catalog>,
     pub on_node:            crate::OnNodeCallback,
@@ -452,11 +453,13 @@ impl RunSession {
             .environment
             .resolve_env(secret_lookup)
             .map_err(|err| Error::engine_with_source("failed to resolve run environment", err))?;
-        let github_permissions: Option<HashMap<String, String>> =
-            (!services.github_permissions.is_empty()).then(|| services.github_permissions.clone());
+        let github_integration = services
+            .github_integration
+            .is_token_requested()
+            .then(|| services.github_integration.clone());
         let sandbox_env = SandboxEnvSpec {
             toml_env,
-            github_permissions,
+            github_integration,
             origin_url: record.repo_origin_url().map(str::to_string),
         };
 
@@ -1725,7 +1728,7 @@ reasoning = false
             artifact_sink: None,
             run_control: None,
             github_app: None,
-            github_permissions: HashMap::new(),
+            github_integration: ResolvedGithubIntegration::default(),
             vault: Arc::new(AsyncRwLock::new(start_vault(&[]))),
             catalog: test_catalog(),
             on_node: None,

--- a/lib/components/fabro-workflow/src/pipeline/execute/tests.rs
+++ b/lib/components/fabro-workflow/src/pipeline/execute/tests.rs
@@ -287,7 +287,7 @@ async fn execute_test_run_with_options(
             hooks: HookSettings { hooks: vec![] },
             sandbox_env: SandboxEnvSpec {
                 toml_env:           HashMap::new(),
-                github_permissions: None,
+                github_integration: None,
                 origin_url:         None,
             },
             vault: auth_test_support::empty_vault(),
@@ -349,7 +349,7 @@ async fn execute_runs_start_to_exit_and_returns_final_context() {
             hooks: HookSettings { hooks: vec![] },
             sandbox_env: SandboxEnvSpec {
                 toml_env:           HashMap::new(),
-                github_permissions: None,
+                github_integration: None,
                 origin_url:         None,
             },
             vault: auth_test_support::empty_vault(),
@@ -488,7 +488,7 @@ async fn resumed_in_flight_node_starts_a_new_stage_execution() {
             hooks: HookSettings { hooks: vec![] },
             sandbox_env: SandboxEnvSpec {
                 toml_env:           HashMap::new(),
-                github_permissions: None,
+                github_integration: None,
                 origin_url:         None,
             },
             vault: auth_test_support::empty_vault(),
@@ -599,7 +599,7 @@ async fn run_with_lifecycle(
             hooks: HookSettings { hooks: vec![] },
             sandbox_env: SandboxEnvSpec {
                 toml_env:           HashMap::new(),
-                github_permissions: None,
+                github_integration: None,
                 origin_url:         None,
             },
             vault: auth_test_support::empty_vault(),

--- a/lib/components/fabro-workflow/src/pipeline/initialize.rs
+++ b/lib/components/fabro-workflow/src/pipeline/initialize.rs
@@ -143,20 +143,20 @@ fn build_sandbox_env(
             None
         };
 
-    let github_token = match creds {
-        fabro_github::GitHubCredentials::Pat(token) => {
-            Some(InstallationTokenSource::pat(token.clone()))
-        }
-        fabro_github::GitHubCredentials::Installation(token) => {
-            Some(InstallationTokenSource::installation(token.clone()))
-        }
-        fabro_github::GitHubCredentials::App(_) => match github_access.as_ref() {
-            Some(access) => Some(InstallationTokenSource::for_access(creds, access).map_err(
-                |err| Error::engine_with_anyhow("Failed to build GitHub token source", err),
-            )?),
-            // No origin URL and nothing declared: keep the legacy
+    let github_token = match github_access.as_ref() {
+        Some(access) => Some(InstallationTokenSource::for_access(creds, access).map_err(
+            |err| Error::engine_with_anyhow("Failed to build GitHub token source", err),
+        )?),
+        None => match creds {
+            fabro_github::GitHubCredentials::Pat(token) => {
+                Some(InstallationTokenSource::pat(token.clone()))
+            }
+            fabro_github::GitHubCredentials::Installation(token) => {
+                Some(InstallationTokenSource::installation(token.clone()))
+            }
+            // No origin URL and nothing declared: keep the legacy App-mode
             // best-effort skip.
-            None => None,
+            fabro_github::GitHubCredentials::App(_) => None,
         },
     };
 
@@ -174,40 +174,34 @@ fn build_sandbox_env(
     })
 }
 
-/// When additional repositories are declared, prove the whole effective set
-/// is reachable before the first workflow stage
-/// ([`fabro_github::GitHubRepositoryAccess::resolve_verified_token`]).
-/// Legacy permissions-only runs skip this and keep their best-effort
-/// behavior.
-async fn validate_declared_repository_access(
-    built: &BuiltSandboxEnv,
-    github_app: Option<&fabro_github::GitHubCredentials>,
-) -> Result<(), Error> {
-    let Some(access) = built
+/// When additional repositories are declared, resolve their token before the
+/// first workflow stage. App-backed sources first check that every target is
+/// on one installation. Static credentials resolve locally; the first Git
+/// operation remains their access check. Legacy permissions-only runs skip
+/// eager resolution.
+async fn resolve_declared_repository_token(built: &BuiltSandboxEnv) -> Result<(), Error> {
+    let Some(_) = built
         .github_access
         .as_ref()
         .filter(|access| access.has_additional_repositories())
     else {
         return Ok(());
     };
-    // `build_sandbox_env` guarantees credentials and a token source whenever
-    // additional repositories are declared; fail closed if that ever breaks.
-    let (Some(creds), Some(source)) = (github_app, built.github_token.as_ref()) else {
+    // `build_sandbox_env` guarantees a token source whenever additional
+    // repositories are declared; fail closed if that ever breaks.
+    let Some(source) = built.github_token.as_ref() else {
         return Err(Error::Precondition(
             "run.integrations.github.additional_repositories requires GitHub credentials, but \
              none are configured"
                 .to_string(),
         ));
     };
-    access
-        .resolve_verified_token(creds, source)
-        .await
-        .map_err(|err| {
-            Error::engine_with_anyhow(
-                "Failed to verify GitHub access for the declared repository set",
-                err,
-            )
-        })?;
+    source.resolve().await.map_err(|err| {
+        Error::engine_with_anyhow(
+            "Failed to resolve the GitHub token for the declared repository set",
+            err,
+        )
+    })?;
     Ok(())
 }
 
@@ -530,8 +524,7 @@ pub async fn initialize(
         &options.sandbox_env,
         options.run_options.github_app.as_ref(),
     )?;
-    validate_declared_repository_access(&built_env, options.run_options.github_app.as_ref())
-        .await?;
+    resolve_declared_repository_token(&built_env).await?;
     let BuiltSandboxEnv {
         env: base_env,
         github_token,
@@ -1617,7 +1610,7 @@ mod tests {
 
     mod github_integration_env {
         //! Focused tests for `build_sandbox_env` /
-        //! `validate_declared_repository_access` around declared additional
+        //! `resolve_declared_repository_token` around declared additional
         //! repositories. Installation-resolution failure naming is covered
         //! by `fabro_github::access` tests; these prove the initialization
         //! wiring: hard errors for declared sets, best-effort behavior for
@@ -1758,10 +1751,7 @@ mod tests {
                 github_access: access,
             };
 
-            let creds = GitHubCredentials::Pat("ghp_x".to_string());
-            let err = validate_declared_repository_access(&built, Some(&creds))
-                .await
-                .unwrap_err();
+            let err = resolve_declared_repository_token(&built).await.unwrap_err();
             let message = err.to_string();
             assert!(message.contains("declared repository set"), "{message}");
         }
@@ -1777,7 +1767,7 @@ mod tests {
                 github_access: None,
             };
 
-            validate_declared_repository_access(&built, None)
+            resolve_declared_repository_token(&built)
                 .await
                 .expect("legacy permissions-only runs must not resolve eagerly");
         }

--- a/lib/components/fabro-workflow/src/pipeline/initialize.rs
+++ b/lib/components/fabro-workflow/src/pipeline/initialize.rs
@@ -175,10 +175,10 @@ fn build_sandbox_env(
 }
 
 /// When additional repositories are declared, prove the whole effective set
-/// is reachable before the first workflow stage: resolve every repository's
-/// App installation (naming any repository the App cannot see), then resolve
-/// the token once eagerly. Legacy permissions-only runs skip this and keep
-/// their best-effort behavior.
+/// is reachable before the first workflow stage
+/// ([`fabro_github::GitHubRepositoryAccess::resolve_verified_token`]).
+/// Legacy permissions-only runs skip this and keep their best-effort
+/// behavior.
 async fn validate_declared_repository_access(
     built: &BuiltSandboxEnv,
     github_app: Option<&fabro_github::GitHubCredentials>,
@@ -190,25 +190,24 @@ async fn validate_declared_repository_access(
     else {
         return Ok(());
     };
-    if let Some(fabro_github::GitHubCredentials::App(app)) = github_app {
-        access
-            .resolve_shared_installation_via_api(app)
-            .await
-            .map_err(|err| {
-                Error::engine_with_anyhow(
-                    "Declared additional GitHub repository is not accessible",
-                    err,
-                )
-            })?;
-    }
-    if let Some(source) = built.github_token.as_ref() {
-        source.resolve().await.map_err(|err| {
+    // `build_sandbox_env` guarantees credentials and a token source whenever
+    // additional repositories are declared; fail closed if that ever breaks.
+    let (Some(creds), Some(source)) = (github_app, built.github_token.as_ref()) else {
+        return Err(Error::Precondition(
+            "run.integrations.github.additional_repositories requires GitHub credentials, but \
+             none are configured"
+                .to_string(),
+        ));
+    };
+    access
+        .resolve_verified_token(creds, source)
+        .await
+        .map_err(|err| {
             Error::engine_with_anyhow(
-                "Failed to resolve GitHub access for the declared repository set",
+                "Failed to verify GitHub access for the declared repository set",
                 err,
             )
         })?;
-    }
     Ok(())
 }
 
@@ -1759,7 +1758,8 @@ mod tests {
                 github_access: access,
             };
 
-            let err = validate_declared_repository_access(&built, None)
+            let creds = GitHubCredentials::Pat("ghp_x".to_string());
+            let err = validate_declared_repository_access(&built, Some(&creds))
                 .await
                 .unwrap_err();
             let message = err.to_string();

--- a/lib/components/fabro-workflow/src/pipeline/initialize.rs
+++ b/lib/components/fabro-workflow/src/pipeline/initialize.rs
@@ -24,6 +24,7 @@ use super::types::{InitOptions, Initialized, LlmSpec, Persisted, SandboxEnvSpec}
 use crate::error::Error;
 use crate::event::{Event, RunNoticeCode, RunNoticeLevel};
 use crate::git::GitAuthor;
+use crate::git_bridge;
 use crate::handler::llm::{AgentAcpBackend, AgentApiBackend, BackendRouter, routing};
 use crate::handler::{HandlerRegistry, default_registry};
 #[cfg(test)]
@@ -37,10 +38,14 @@ use crate::services::{
 use crate::stage_execution::{StageExecutionSeed, StageExecutionTracker};
 use crate::steering_hub::SteeringHub;
 
-type BuiltSandboxEnv = (
-    HashMap<String, String>,
-    Option<Arc<InstallationTokenSource>>,
-);
+struct BuiltSandboxEnv {
+    env:           HashMap<String, String>,
+    github_token:  Option<Arc<InstallationTokenSource>>,
+    /// The validated effective repository set behind `github_token`.
+    /// Present only in App mode or when additional repositories are
+    /// declared; drives the eager access validation at initialization.
+    github_access: Option<fabro_github::GitHubRepositoryAccess>,
+}
 
 async fn run_hooks(
     hook_runner: Option<&HookRunner>,
@@ -91,41 +96,120 @@ fn build_sandbox_env(
     spec: &SandboxEnvSpec,
     github_app: Option<&fabro_github::GitHubCredentials>,
 ) -> Result<BuiltSandboxEnv, Error> {
-    let env = spec.toml_env.clone();
+    let mut env = spec.toml_env.clone();
 
-    let Some(permissions) = spec.github_permissions.as_ref().filter(|p| !p.is_empty()) else {
-        return Ok((env, None));
+    let no_token = |env| BuiltSandboxEnv {
+        env,
+        github_token: None,
+        github_access: None,
     };
+    let Some(integration) = spec
+        .github_integration
+        .as_ref()
+        .filter(|integration| integration.is_token_requested())
+    else {
+        return Ok(no_token(env));
+    };
+    let declares_additional = integration.has_additional_repositories();
     let Some(creds) = github_app else {
-        return Ok((env, None));
+        if declares_additional {
+            // Legacy permissions-only configuration stays best-effort, but a
+            // declared additional set is an explicit access requirement.
+            return Err(Error::Precondition(
+                "run.integrations.github.additional_repositories requires GitHub credentials, \
+                 but none are configured"
+                    .to_string(),
+            ));
+        }
+        return Ok(no_token(env));
     };
 
-    let source = match creds {
+    // Validate the effective repository set whenever it matters: App mode
+    // scopes the mint to it, and any declared additional set must hold its
+    // invariants regardless of credential kind. Legacy PAT/static
+    // permissions-only runs skip it to preserve their origin-agnostic
+    // behavior.
+    let github_access =
+        if declares_additional || matches!(creds, fabro_github::GitHubCredentials::App(_)) {
+            fabro_github::GitHubRepositoryAccess::new(
+                spec.origin_url.as_deref(),
+                &integration.additional_repositories,
+                integration.permissions.clone(),
+            )
+            .map_err(|err| {
+                Error::engine_with_anyhow("Failed to validate GitHub repository access", err)
+            })?
+        } else {
+            None
+        };
+
+    let github_token = match creds {
         fabro_github::GitHubCredentials::Pat(token) => {
             Some(InstallationTokenSource::pat(token.clone()))
         }
         fabro_github::GitHubCredentials::Installation(token) => {
             Some(InstallationTokenSource::installation(token.clone()))
         }
-        fabro_github::GitHubCredentials::App(_) => {
-            let Some(origin_url) = spec.origin_url.as_deref() else {
-                return Ok((env, None));
-            };
-            let https_url = fabro_github::ssh_url_to_https(origin_url);
-            let (owner, repo) = fabro_github::parse_github_owner_repo(&https_url)
-                .map_err(|err| Error::engine_with_anyhow("Failed to parse GitHub origin", err))?;
-            let permissions = serde_json::to_value(permissions).map_err(|err| {
-                Error::engine_with_source("Failed to serialize GitHub permissions", err)
-            })?;
-            Some(
-                InstallationTokenSource::for_repository(creds, owner, repo, permissions).map_err(
-                    |err| Error::engine_with_anyhow("Failed to build GitHub token source", err),
-                )?,
-            )
-        }
+        fabro_github::GitHubCredentials::App(_) => match github_access.as_ref() {
+            Some(access) => Some(InstallationTokenSource::for_access(creds, access).map_err(
+                |err| Error::engine_with_anyhow("Failed to build GitHub token source", err),
+            )?),
+            // No origin URL and nothing declared: keep the legacy
+            // best-effort skip.
+            None => None,
+        },
     };
 
-    Ok((env, source))
+    if declares_additional {
+        let access = github_access
+            .as_ref()
+            .expect("access is always constructed when additional repositories are declared");
+        git_bridge::merge_git_bridge_env(&mut env, &access.targets())?;
+    }
+
+    Ok(BuiltSandboxEnv {
+        env,
+        github_token,
+        github_access,
+    })
+}
+
+/// When additional repositories are declared, prove the whole effective set
+/// is reachable before the first workflow stage: resolve every repository's
+/// App installation (naming any repository the App cannot see), then resolve
+/// the token once eagerly. Legacy permissions-only runs skip this and keep
+/// their best-effort behavior.
+async fn validate_declared_repository_access(
+    built: &BuiltSandboxEnv,
+    github_app: Option<&fabro_github::GitHubCredentials>,
+) -> Result<(), Error> {
+    let Some(access) = built
+        .github_access
+        .as_ref()
+        .filter(|access| access.has_additional_repositories())
+    else {
+        return Ok(());
+    };
+    if let Some(fabro_github::GitHubCredentials::App(app)) = github_app {
+        access
+            .resolve_shared_installation_via_api(app)
+            .await
+            .map_err(|err| {
+                Error::engine_with_anyhow(
+                    "Declared additional GitHub repository is not accessible",
+                    err,
+                )
+            })?;
+    }
+    if let Some(source) = built.github_token.as_ref() {
+        source.resolve().await.map_err(|err| {
+            Error::engine_with_anyhow(
+                "Failed to resolve GitHub access for the declared repository set",
+                err,
+            )
+        })?;
+    }
+    Ok(())
 }
 
 async fn build_registry(
@@ -443,10 +527,17 @@ pub async fn initialize(
         });
     }
 
-    let (base_env, github_token) = build_sandbox_env(
+    let built_env = build_sandbox_env(
         &options.sandbox_env,
         options.run_options.github_app.as_ref(),
     )?;
+    validate_declared_repository_access(&built_env, options.run_options.github_app.as_ref())
+        .await?;
+    let BuiltSandboxEnv {
+        env: base_env,
+        github_token,
+        github_access: _,
+    } = built_env;
     let tool_env_provider = Arc::new(WorkflowToolEnvProvider {
         base_env:     base_env.clone(),
         github_token: github_token.clone(),
@@ -818,7 +909,7 @@ mod tests {
             hooks: fabro_hooks::HookSettings { hooks: vec![] },
             sandbox_env: SandboxEnvSpec {
                 toml_env:           HashMap::new(),
-                github_permissions: None,
+                github_integration: None,
                 origin_url:         None,
             },
             vault: auth_test_support::empty_vault(),
@@ -948,7 +1039,7 @@ mod tests {
         let initialized = initialize(persisted, InitOptions {
             sandbox_env: SandboxEnvSpec {
                 toml_env:           HashMap::from([("TEST_KEY".to_string(), "value".to_string())]),
-                github_permissions: None,
+                github_integration: None,
                 origin_url:         None,
             },
             ..test_init_options(
@@ -1271,7 +1362,7 @@ mod tests {
             hooks: fabro_hooks::HookSettings { hooks: vec![] },
             sandbox_env: SandboxEnvSpec {
                 toml_env:           HashMap::new(),
-                github_permissions: None,
+                github_integration: None,
                 origin_url:         None,
             },
             vault,
@@ -1366,7 +1457,7 @@ mod tests {
             hooks:             fabro_hooks::HookSettings { hooks: vec![] },
             sandbox_env:       SandboxEnvSpec {
                 toml_env:           HashMap::new(),
-                github_permissions: None,
+                github_integration: None,
                 origin_url:         None,
             },
             vault:             auth_test_support::empty_vault(),
@@ -1508,7 +1599,7 @@ mod tests {
             hooks: fabro_hooks::HookSettings { hooks: vec![] },
             sandbox_env: SandboxEnvSpec {
                 toml_env:           HashMap::new(),
-                github_permissions: None,
+                github_integration: None,
                 origin_url:         None,
             },
             vault: auth_test_support::empty_vault(),
@@ -1523,5 +1614,172 @@ mod tests {
         .await;
 
         assert!(matches!(result, Err(Error::Cancelled)));
+    }
+
+    mod github_integration_env {
+        //! Focused tests for `build_sandbox_env` /
+        //! `validate_declared_repository_access` around declared additional
+        //! repositories. Installation-resolution failure naming is covered
+        //! by `fabro_github::access` tests; these prove the initialization
+        //! wiring: hard errors for declared sets, best-effort behavior for
+        //! legacy permissions-only configuration.
+
+        use fabro_github::test_support::{InstallationTokenMinter, installation_token_source};
+        use fabro_github::{GitHubAppCredentials, GitHubCredentials, InstallationToken};
+        use fabro_types::settings::run::ResolvedGithubIntegration;
+
+        use super::*;
+
+        fn integration(additional: &[&str]) -> ResolvedGithubIntegration {
+            ResolvedGithubIntegration {
+                permissions:             HashMap::from([(
+                    "contents".to_string(),
+                    "read".to_string(),
+                )]),
+                additional_repositories: additional
+                    .iter()
+                    .map(|value| value.parse().expect("test slug should parse"))
+                    .collect(),
+            }
+        }
+
+        fn spec(
+            origin: Option<&str>,
+            github_integration: Option<ResolvedGithubIntegration>,
+        ) -> SandboxEnvSpec {
+            SandboxEnvSpec {
+                toml_env: HashMap::new(),
+                github_integration,
+                origin_url: origin.map(str::to_string),
+            }
+        }
+
+        #[test]
+        fn declared_additional_repositories_require_credentials() {
+            let spec = spec(
+                Some("https://github.com/fabro-sh/fabro"),
+                Some(integration(&["fabro-sh/keystone"])),
+            );
+            let Err(err) = build_sandbox_env(&spec, None) else {
+                panic!("declared additional repositories without credentials must fail");
+            };
+            assert!(
+                err.to_string().contains("requires GitHub credentials"),
+                "{err}"
+            );
+        }
+
+        #[test]
+        fn declared_additional_repositories_require_an_origin() {
+            let spec = spec(None, Some(integration(&["fabro-sh/keystone"])));
+            let creds = GitHubCredentials::Pat("ghp_x".to_string());
+            let Err(err) = build_sandbox_env(&spec, Some(&creds)) else {
+                panic!("declared additional repositories without an origin must fail");
+            };
+            assert!(
+                err.to_string().contains("GitHub repository access"),
+                "{err}"
+            );
+        }
+
+        #[test]
+        fn declared_repositories_inject_bridge_entries_and_keep_the_pat_source() {
+            let spec = spec(
+                Some("https://github.com/fabro-sh/fabro"),
+                Some(integration(&["fabro-sh/keystone"])),
+            );
+            let creds = GitHubCredentials::Pat("ghp_x".to_string());
+            let built = build_sandbox_env(&spec, Some(&creds)).unwrap();
+
+            assert!(built.github_token.is_some());
+            let access = built.github_access.expect("access should be constructed");
+            assert!(access.has_additional_repositories());
+            // Helper entry plus two SSH rewrites for each of the two
+            // effective repositories (origin + declared additional).
+            assert_eq!(
+                built.env.get("GIT_CONFIG_COUNT").map(String::as_str),
+                Some("5")
+            );
+            assert_eq!(
+                built.env.get("GIT_CONFIG_KEY_0").map(String::as_str),
+                Some("credential.https://github.com.helper")
+            );
+            assert_eq!(
+                built.env.get("GIT_TERMINAL_PROMPT").map(String::as_str),
+                Some("0")
+            );
+        }
+
+        #[test]
+        fn legacy_permissions_only_configuration_stays_best_effort() {
+            // No credentials: no error, no token source, no bridge entries.
+            let no_creds = spec(
+                Some("https://github.com/fabro-sh/fabro"),
+                Some(integration(&[])),
+            );
+            let built = build_sandbox_env(&no_creds, None).unwrap();
+            assert!(built.github_token.is_none());
+            assert!(!built.env.contains_key("GIT_CONFIG_COUNT"));
+
+            // App credentials without an origin: legacy best-effort skip.
+            let creds = GitHubCredentials::App(GitHubAppCredentials {
+                app_id:          "1".to_string(),
+                private_key_pem: "unused".to_string(),
+                slug:            None,
+            });
+            let no_origin = spec(None, Some(integration(&[])));
+            let built = build_sandbox_env(&no_origin, Some(&creds)).unwrap();
+            assert!(built.github_token.is_none());
+            assert!(built.github_access.is_none());
+        }
+
+        struct FailingMinter;
+
+        #[async_trait::async_trait]
+        impl InstallationTokenMinter for FailingMinter {
+            async fn mint(&self) -> anyhow::Result<InstallationToken> {
+                Err(anyhow::anyhow!("scripted mint failure"))
+            }
+        }
+
+        #[tokio::test]
+        async fn eager_validation_fails_when_the_declared_token_cannot_resolve() {
+            let access = fabro_github::GitHubRepositoryAccess::new(
+                Some("https://github.com/fabro-sh/fabro"),
+                &["fabro-sh/keystone".parse().unwrap()].into_iter().collect(),
+                HashMap::from([("contents".to_string(), "read".to_string())]),
+            )
+            .unwrap();
+            let built = BuiltSandboxEnv {
+                env:           HashMap::new(),
+                github_token:  Some(installation_token_source(
+                    "fabro-sh/fabro (+1 additional)",
+                    Arc::new(FailingMinter),
+                )),
+                github_access: access,
+            };
+
+            let err = validate_declared_repository_access(&built, None)
+                .await
+                .unwrap_err();
+            let message = err.to_string();
+            assert!(message.contains("declared repository set"), "{message}");
+        }
+
+        #[tokio::test]
+        async fn eager_validation_skips_legacy_permissions_only_runs() {
+            let built = BuiltSandboxEnv {
+                env:           HashMap::new(),
+                github_token:  Some(installation_token_source(
+                    "fabro-sh/fabro",
+                    Arc::new(FailingMinter),
+                )),
+                github_access: None,
+            };
+
+            validate_declared_repository_access(&built, None)
+                .await
+                .expect("legacy permissions-only runs must not resolve eagerly");
+        }
     }
 }

--- a/lib/components/fabro-workflow/src/pipeline/types.rs
+++ b/lib/components/fabro-workflow/src/pipeline/types.rs
@@ -8,7 +8,9 @@ use fabro_mcp::config::McpServerSettings;
 use fabro_model::{Catalog, ProviderId};
 use fabro_sandbox::SandboxSpec;
 use fabro_template::TemplateContext;
-use fabro_types::settings::run::{PullRequestSettings, RunModelControls};
+use fabro_types::settings::run::{
+    PullRequestSettings, ResolvedGithubIntegration, RunModelControls,
+};
 use fabro_types::{ManifestPath, RunId, RunProjection};
 use fabro_validate::{Diagnostic, Severity};
 use fabro_vault::Vault;
@@ -246,7 +248,10 @@ pub struct LlmSpec {
 #[derive(Clone)]
 pub struct SandboxEnvSpec {
     pub toml_env:           HashMap<String, String>,
-    pub github_permissions: Option<HashMap<String, String>>,
+    /// The resolved GitHub integration request (interpolated permissions
+    /// plus declared additional repositories). `None` when the run requests
+    /// no `GITHUB_TOKEN`.
+    pub github_integration: Option<ResolvedGithubIntegration>,
     pub origin_url:         Option<String>,
 }
 

--- a/lib/foundation/fabro-api/build.rs
+++ b/lib/foundation/fabro-api/build.rs
@@ -208,6 +208,19 @@ fn main() {
         ("DiffSummary", "fabro_types::DiffSummary", &[]),
         ("RepositoryRef", "fabro_types::RepositoryRef", &[]),
         ("WorkflowSettings", "fabro_types::WorkflowSettings", &[]),
+        // Run-level GitHub integration settings reuse the canonical resolved
+        // types instead of generating parallel API DTOs; the wire shape is
+        // identical (InterpString serializes as its source string).
+        (
+            "RunIntegrationsSettings",
+            "fabro_types::settings::run::RunIntegrationsSettings",
+            &[],
+        ),
+        (
+            "RunIntegrationsGithubSettings",
+            "fabro_types::settings::run::RunIntegrationsGithubSettings",
+            &[],
+        ),
         ("ServerSettings", "fabro_types::ServerSettings", &[]),
         (
             "ServerNamespace",

--- a/lib/foundation/fabro-api/src/lib.rs
+++ b/lib/foundation/fabro-api/src/lib.rs
@@ -25,7 +25,10 @@ pub mod types {
         ReasoningEffortFeature, Speed as BillingSpeed, TokenCounts as CompletionUsage,
     };
     pub use fabro_types::run_event::AgentSessionActivatedProps;
-    pub use fabro_types::settings::run::{McpHttpProtocol, RunModelControls, RunModelSettings};
+    pub use fabro_types::settings::run::{
+        McpHttpProtocol, RunIntegrationsGithubSettings, RunIntegrationsSettings, RunModelControls,
+        RunModelSettings,
+    };
     pub use fabro_types::settings::server::{
         GithubIntegrationSettings, GithubIntegrationStrategy, IntegrationWebhooksSettings,
         LogDestination, ObjectStoreSettings, ServerApiSettings, ServerArtifactsSettings,

--- a/lib/foundation/fabro-api/tests/run_integrations_round_trip.rs
+++ b/lib/foundation/fabro-api/tests/run_integrations_round_trip.rs
@@ -1,8 +1,10 @@
-//! JSON parity test for `RunIntegrationsGithubSettings`.
+//! JSON parity and type-identity tests for `RunIntegrationsGithubSettings`.
 //!
-//! Asserts that the API-side generated `RunIntegrationsGithubSettings` and
-//! the canonical Rust resolved type round-trip through the same JSON shape.
-//! Covers both the populated and empty-permissions cases.
+//! Asserts that the API-side `RunIntegrationsGithubSettings` is the
+//! canonical Rust resolved type (via `with_replacement` in `build.rs`) and
+//! that both names round-trip through the same JSON shape. Covers the
+//! populated and empty permissions cases as well as populated and empty
+//! `additional_repositories` sets.
 
 use fabro_api::types::{
     RunIntegrationsGithubSettings as ApiRunIntegrationsGithubSettings,
@@ -10,6 +12,22 @@ use fabro_api::types::{
 };
 use fabro_types::settings::run::{RunIntegrationsGithubSettings, RunIntegrationsSettings};
 use serde_json::json;
+
+/// Type-identity witnesses: the generated API names are the canonical Rust
+/// types, not parallel DTOs. Compiles only when they are the same type.
+#[expect(dead_code, reason = "compile-time type-identity witness")]
+fn github_settings_type_identity(
+    value: ApiRunIntegrationsGithubSettings,
+) -> RunIntegrationsGithubSettings {
+    value
+}
+
+#[expect(dead_code, reason = "compile-time type-identity witness")]
+fn integrations_settings_type_identity(
+    value: ApiRunIntegrationsSettings,
+) -> RunIntegrationsSettings {
+    value
+}
 
 #[test]
 fn run_integrations_github_settings_round_trips_with_permissions() {
@@ -42,6 +60,43 @@ fn run_integrations_github_settings_round_trips_empty_permissions() {
 
     assert_eq!(serde_json::to_value(&api).unwrap(), json_value);
     assert_eq!(serde_json::to_value(&canonical).unwrap(), json_value);
+}
+
+#[test]
+fn run_integrations_github_settings_round_trips_additional_repositories() {
+    let json_value = json!({
+        "permissions": { "contents": "read" },
+        "additional_repositories": ["fabro-sh/arc", "fabro-sh/keystone"],
+    });
+
+    let api: ApiRunIntegrationsGithubSettings =
+        serde_json::from_value(json_value.clone()).expect("api type should parse repositories");
+    let canonical: RunIntegrationsGithubSettings =
+        serde_json::from_value(json_value.clone()).expect("canonical type should parse");
+
+    assert_eq!(serde_json::to_value(&api).unwrap(), json_value);
+    assert_eq!(serde_json::to_value(&canonical).unwrap(), json_value);
+}
+
+#[test]
+fn run_integrations_github_settings_omits_an_empty_repository_set() {
+    // An absent field and an explicit empty array both deserialize to the
+    // empty set, and the empty set serializes back with the field omitted —
+    // keeping single-repository settings byte-identical to older releases.
+    let empty_array = json!({
+        "permissions": {},
+        "additional_repositories": [],
+    });
+    let omitted = json!({ "permissions": {} });
+
+    let api: ApiRunIntegrationsGithubSettings =
+        serde_json::from_value(empty_array).expect("api type should parse an empty array");
+    let canonical: RunIntegrationsGithubSettings =
+        serde_json::from_value(omitted.clone()).expect("canonical type should parse");
+
+    assert!(api.additional_repositories.is_empty());
+    assert_eq!(serde_json::to_value(&api).unwrap(), omitted);
+    assert_eq!(serde_json::to_value(&canonical).unwrap(), omitted);
 }
 
 #[test]

--- a/lib/foundation/fabro-config/src/layers/run.rs
+++ b/lib/foundation/fabro-config/src/layers/run.rs
@@ -88,13 +88,23 @@ pub struct RunIntegrationsLayer {
 #[serde(deny_unknown_fields)]
 pub struct RunIntegrationsGithubLayer {
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub permissions: Option<HashMap<String, InterpString>>,
+    pub permissions:             Option<HashMap<String, InterpString>>,
+    /// Extra `owner/repository` slugs the minted `GITHUB_TOKEN` must cover in
+    /// addition to the implicit run origin. Kept as raw strings in this
+    /// sparse layer; slug validation happens at resolve time so diagnostics
+    /// can carry indexed paths. The higher-precedence list replaces the lower
+    /// one wholesale (`Some(vec![])` is an explicit clear); no `...` splice.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub additional_repositories: Option<Vec<String>>,
 }
 
 impl Combine for RunIntegrationsGithubLayer {
     fn combine(self, other: Self) -> Self {
         Self {
-            permissions: self.permissions.or(other.permissions),
+            permissions:             self.permissions.or(other.permissions),
+            additional_repositories: self
+                .additional_repositories
+                .or(other.additional_repositories),
         }
     }
 }

--- a/lib/foundation/fabro-config/src/resolve/run.rs
+++ b/lib/foundation/fabro-config/src/resolve/run.rs
@@ -1,6 +1,8 @@
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 
+use fabro_types::GitHubRepositorySlug;
 use fabro_types::settings::InterpString;
+use fabro_types::settings::interp::ResolveCtx;
 use fabro_types::settings::run::{
     ArtifactsSettings, GitAuthorSettings, HookDefinition, HookType, InterviewProviderSettings,
     McpServerSettings, McpTransport, MergeStrategy, NotificationProviderSettings,
@@ -17,9 +19,9 @@ use crate::{
     EnvironmentLayer, HookAgentMarker, HookEntry, HookTlsMode, InterviewProviderLayer,
     InterviewsLayer, McpEntryLayer, MergeMap, ModelRefOrSplice, NotificationProviderLayer,
     NotificationRouteLayer, RunAgentLayer, RunArtifactsLayer, RunCheckpointLayer, RunCloneLayer,
-    RunExecutionLayer, RunGitLayer, RunGoalLayer, RunIntegrationsLayer, RunLayer,
-    RunMetaBranchLayer, RunModelLayer, RunPrepareLayer, RunPullRequestLayer, RunRunBranchLayer,
-    RunScmLayer, StickyMap, StringOrSplice,
+    RunExecutionLayer, RunGitLayer, RunGoalLayer, RunIntegrationsGithubLayer, RunIntegrationsLayer,
+    RunLayer, RunMetaBranchLayer, RunModelLayer, RunPrepareLayer, RunPullRequestLayer,
+    RunRunBranchLayer, RunScmLayer, StickyMap, StringOrSplice,
 };
 
 pub fn resolve_run(
@@ -85,21 +87,138 @@ pub fn resolve_run(
         scm: resolve_scm(layer.scm.as_ref()),
         pull_request,
         artifacts: resolve_artifacts(layer.artifacts.as_ref(), errors),
-        integrations: resolve_integrations(layer.integrations.as_ref()),
+        integrations: resolve_integrations(layer.integrations.as_ref(), errors),
     }
 }
 
-fn resolve_integrations(layer: Option<&RunIntegrationsLayer>) -> RunIntegrationsSettings {
+fn resolve_integrations(
+    layer: Option<&RunIntegrationsLayer>,
+    errors: &mut Vec<ResolveError>,
+) -> RunIntegrationsSettings {
     let github = layer
         .and_then(|integrations| integrations.github.as_ref())
-        .map(|github| RunIntegrationsGithubSettings {
-            // Collapse `Option<HashMap<...>>` -> `HashMap<...>`: both `None`
-            // and `Some({})` resolve to an empty map (no token requested).
-            // The presence distinction is only meaningful at merge time.
-            permissions: github.permissions.clone().unwrap_or_default(),
-        })
+        .map(|github| resolve_integrations_github(github, errors))
         .unwrap_or_default();
     RunIntegrationsSettings { github }
+}
+
+/// GitHub caps one installation token at 500 repositories; the implicit run
+/// origin takes one slot.
+const MAX_ADDITIONAL_REPOSITORIES: usize = 499;
+
+fn resolve_integrations_github(
+    github: &RunIntegrationsGithubLayer,
+    errors: &mut Vec<ResolveError>,
+) -> RunIntegrationsGithubSettings {
+    // Collapse `Option<HashMap<...>>` -> `HashMap<...>`: both `None`
+    // and `Some({})` resolve to an empty map (no token requested).
+    // The presence distinction is only meaningful at merge time. The same
+    // collapse applies to `additional_repositories` (`Some(vec![])` is an
+    // explicit clear that resolves to the empty set).
+    let permissions = github.permissions.clone().unwrap_or_default();
+    let raw_repositories = github
+        .additional_repositories
+        .as_deref()
+        .unwrap_or_default();
+
+    if raw_repositories.len() > MAX_ADDITIONAL_REPOSITORIES {
+        errors.push(ResolveError::Invalid {
+            path:   "run.integrations.github.additional_repositories".to_string(),
+            reason: format!(
+                "at most {MAX_ADDITIONAL_REPOSITORIES} additional repositories are supported (the \
+                 run origin takes the remaining slot of GitHub's 500-repository token limit), got \
+                 {}",
+                raw_repositories.len()
+            ),
+        });
+    }
+
+    let mut additional_repositories: BTreeSet<GitHubRepositorySlug> = BTreeSet::new();
+    for (index, value) in raw_repositories.iter().enumerate() {
+        let path = format!("run.integrations.github.additional_repositories[{index}]");
+        let Ok(slug) = value.parse::<GitHubRepositorySlug>() else {
+            errors.push(ResolveError::Invalid {
+                path,
+                reason: format!(
+                    "`{value}` is not a full GitHub `owner/repository` slug (no scheme, host, \
+                     ref, or extra path component)"
+                ),
+            });
+            continue;
+        };
+        if let Some(existing) = additional_repositories.get(&slug) {
+            errors.push(ResolveError::Invalid {
+                path,
+                reason: format!(
+                    "`{value}` duplicates `{existing}` (repository identity is case-insensitive)"
+                ),
+            });
+            continue;
+        }
+        if let Some(first) = additional_repositories.first() {
+            if !first.same_owner(&slug) {
+                errors.push(ResolveError::Invalid {
+                    path,
+                    reason: format!(
+                        "`{value}` has owner `{}` but `{first}` has owner `{}`; all repositories \
+                         must share one owner because one GitHub App installation covers one \
+                         account",
+                        slug.owner(),
+                        first.owner()
+                    ),
+                });
+                continue;
+            }
+        }
+        additional_repositories.insert(slug);
+    }
+
+    if !additional_repositories.is_empty() {
+        validate_additional_repository_permissions(&permissions, errors);
+    }
+
+    RunIntegrationsGithubSettings {
+        permissions,
+        additional_repositories,
+    }
+}
+
+/// A non-empty additional-repository set needs a token that can reach
+/// repository contents. Only a literal `contents` value is checked here; a
+/// templated value is re-checked after interpolation at the runtime boundary.
+fn validate_additional_repository_permissions(
+    permissions: &HashMap<String, InterpString>,
+    errors: &mut Vec<ResolveError>,
+) {
+    if permissions.is_empty() {
+        errors.push(ResolveError::Invalid {
+            path:   "run.integrations.github.additional_repositories".to_string(),
+            reason: "additional repositories require [run.integrations.github.permissions] with \
+                     a `contents` permission; a higher layer may have cleared the permissions"
+                .to_string(),
+        });
+        return;
+    }
+    let Some(contents) = permissions.get("contents") else {
+        errors.push(ResolveError::Invalid {
+            path:   "run.integrations.github.permissions".to_string(),
+            reason: "additional repositories require the `contents` permission (`read` or \
+                     `write`)"
+                .to_string(),
+        });
+        return;
+    };
+    if let Ok(literal) = contents.resolve_with(&mut ResolveCtx::new()) {
+        if literal != "read" && literal != "write" {
+            errors.push(ResolveError::Invalid {
+                path:   "run.integrations.github.permissions.contents".to_string(),
+                reason: format!(
+                    "additional repositories require `contents = \"read\"` or `contents = \
+                     \"write\"`, got `{literal}`"
+                ),
+            });
+        }
+    }
 }
 
 fn resolve_goal(goal: Option<&RunGoalLayer>) -> Option<RunGoal> {

--- a/lib/foundation/fabro-config/src/resolve/run.rs
+++ b/lib/foundation/fabro-config/src/resolve/run.rs
@@ -209,7 +209,7 @@ fn validate_additional_repository_permissions(
         return;
     };
     if let Ok(literal) = contents.resolve_with(&mut ResolveCtx::new()) {
-        if literal != "read" && literal != "write" {
+        if !RunIntegrationsGithubSettings::contents_permission_allows_repository_access(&literal) {
             errors.push(ResolveError::Invalid {
                 path:   "run.integrations.github.permissions.contents".to_string(),
                 reason: format!(

--- a/lib/foundation/fabro-config/src/tests/resolve_run.rs
+++ b/lib/foundation/fabro-config/src/tests/resolve_run.rs
@@ -879,6 +879,447 @@ issues = "{{ env.GH_PERM_LEVEL }}"
     }
 }
 
+mod run_integrations_github_additional_repositories {
+    //! Layer + resolver tests for
+    //! `[run.integrations.github].additional_repositories`.
+    //!
+    //! The list replaces wholesale across layers (`[]` is an explicit clear),
+    //! resolves independently from `permissions`, and validates each entry as
+    //! a full `owner/repository` slug with indexed error paths.
+
+    use crate::SettingsLayer;
+    use crate::layers::Combine;
+
+    fn parse_settings(source: &str) -> SettingsLayer {
+        source
+            .parse::<SettingsLayer>()
+            .expect("fixture should parse via SettingsLayer")
+    }
+
+    fn invalid_paths_and_reasons(error: crate::Error) -> Vec<(String, String)> {
+        let errors = match error {
+            crate::Error::Resolve { errors, .. } => errors,
+            other => panic!("expected structured resolve errors, got {other:#}"),
+        };
+        errors
+            .into_iter()
+            .map(|error| match error {
+                crate::ResolveError::Invalid { path, reason } => (path, reason),
+                other => panic!("expected invalid-value error, got {other}"),
+            })
+            .collect()
+    }
+
+    fn resolved_repositories(settings: &fabro_types::WorkflowSettings) -> Vec<String> {
+        settings
+            .run
+            .integrations
+            .github
+            .additional_repositories
+            .iter()
+            .map(ToString::to_string)
+            .collect()
+    }
+
+    #[test]
+    fn resolves_one_and_multiple_repositories() {
+        let one = super::workflow_settings_from_toml(
+            r#"
+_version = 1
+
+[run.integrations.github]
+additional_repositories = ["fabro-sh/keystone"]
+permissions = { contents = "read" }
+"#,
+        )
+        .expect("one additional repository should resolve");
+        assert_eq!(resolved_repositories(&one), vec!["fabro-sh/keystone"]);
+        assert!(one.run.integrations.github.has_additional_repositories());
+
+        let many = super::workflow_settings_from_toml(
+            r#"
+_version = 1
+
+[run.integrations.github]
+additional_repositories = ["fabro-sh/keystone", "fabro-sh/arc"]
+permissions = { contents = "write" }
+"#,
+        )
+        .expect("multiple additional repositories should resolve");
+        assert_eq!(resolved_repositories(&many), vec![
+            "fabro-sh/arc",
+            "fabro-sh/keystone",
+        ]);
+    }
+
+    #[test]
+    fn rejects_malformed_slugs_with_indexed_paths() {
+        let error = super::workflow_settings_from_toml(
+            r#"
+_version = 1
+
+[run.integrations.github]
+additional_repositories = [
+    "fabro-sh/keystone",
+    "https://github.com/fabro-sh/arc",
+    "git@github.com:fabro-sh/arc.git",
+    "fabro-sh/arc@main",
+    "not-a-slug",
+]
+permissions = { contents = "read" }
+"#,
+        )
+        .expect_err("malformed slugs should not resolve");
+
+        let invalid = invalid_paths_and_reasons(error);
+        assert_eq!(
+            invalid
+                .iter()
+                .map(|(path, _)| path.as_str())
+                .collect::<Vec<_>>(),
+            vec![
+                "run.integrations.github.additional_repositories[1]",
+                "run.integrations.github.additional_repositories[2]",
+                "run.integrations.github.additional_repositories[3]",
+                "run.integrations.github.additional_repositories[4]",
+            ]
+        );
+        assert!(
+            invalid[0].1.contains("owner/repository"),
+            "reason should explain the slug grammar: {}",
+            invalid[0].1
+        );
+    }
+
+    #[test]
+    fn rejects_duplicate_and_case_variant_duplicate_slugs() {
+        let error = super::workflow_settings_from_toml(
+            r#"
+_version = 1
+
+[run.integrations.github]
+additional_repositories = ["fabro-sh/keystone", "Fabro-SH/Keystone"]
+permissions = { contents = "read" }
+"#,
+        )
+        .expect_err("case-variant duplicate slugs should not resolve");
+
+        let invalid = invalid_paths_and_reasons(error);
+        assert_eq!(
+            invalid
+                .iter()
+                .map(|(path, _)| path.as_str())
+                .collect::<Vec<_>>(),
+            vec!["run.integrations.github.additional_repositories[1]"]
+        );
+        assert!(
+            invalid[0].1.contains("case-insensitive"),
+            "reason should mention case-insensitive identity: {}",
+            invalid[0].1
+        );
+    }
+
+    #[test]
+    fn rejects_cross_owner_additional_repositories() {
+        let error = super::workflow_settings_from_toml(
+            r#"
+_version = 1
+
+[run.integrations.github]
+additional_repositories = ["fabro-sh/keystone", "lithoscomputer/conveyor"]
+permissions = { contents = "read" }
+"#,
+        )
+        .expect_err("cross-owner additional repositories should not resolve");
+
+        let invalid = invalid_paths_and_reasons(error);
+        assert_eq!(
+            invalid
+                .iter()
+                .map(|(path, _)| path.as_str())
+                .collect::<Vec<_>>(),
+            vec!["run.integrations.github.additional_repositories[1]"]
+        );
+        assert!(
+            invalid[0].1.contains("share one owner"),
+            "reason should explain the single-owner requirement: {}",
+            invalid[0].1
+        );
+    }
+
+    #[test]
+    fn rejects_more_than_the_installation_token_repository_limit() {
+        let repositories = (0..500)
+            .map(|index| format!("\"owner/repo-{index}\""))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let error = super::workflow_settings_from_toml(&format!(
+            r#"
+_version = 1
+
+[run.integrations.github]
+additional_repositories = [{repositories}]
+permissions = {{ contents = "read" }}
+"#,
+        ))
+        .expect_err("500 additional repositories should not resolve");
+
+        let invalid = invalid_paths_and_reasons(error);
+        assert_eq!(
+            invalid[0].0,
+            "run.integrations.github.additional_repositories"
+        );
+        assert!(invalid[0].1.contains("499"), "{}", invalid[0].1);
+    }
+
+    #[test]
+    fn rejects_additional_repositories_without_permissions() {
+        let error = super::workflow_settings_from_toml(
+            r#"
+_version = 1
+
+[run.integrations.github]
+additional_repositories = ["fabro-sh/keystone"]
+"#,
+        )
+        .expect_err("additional repositories without permissions should not resolve");
+
+        let invalid = invalid_paths_and_reasons(error);
+        assert_eq!(
+            invalid
+                .iter()
+                .map(|(path, _)| path.as_str())
+                .collect::<Vec<_>>(),
+            vec!["run.integrations.github.additional_repositories"]
+        );
+    }
+
+    #[test]
+    fn rejects_additional_repositories_without_the_contents_permission() {
+        let error = super::workflow_settings_from_toml(
+            r#"
+_version = 1
+
+[run.integrations.github]
+additional_repositories = ["fabro-sh/keystone"]
+permissions = { issues = "read" }
+"#,
+        )
+        .expect_err("additional repositories require the contents permission");
+
+        let invalid = invalid_paths_and_reasons(error);
+        assert_eq!(
+            invalid
+                .iter()
+                .map(|(path, _)| path.as_str())
+                .collect::<Vec<_>>(),
+            vec!["run.integrations.github.permissions"]
+        );
+    }
+
+    #[test]
+    fn rejects_a_literal_contents_permission_that_is_not_read_or_write() {
+        let error = super::workflow_settings_from_toml(
+            r#"
+_version = 1
+
+[run.integrations.github]
+additional_repositories = ["fabro-sh/keystone"]
+permissions = { contents = "admin" }
+"#,
+        )
+        .expect_err("literal contents permission must be read or write");
+
+        let invalid = invalid_paths_and_reasons(error);
+        assert_eq!(
+            invalid
+                .iter()
+                .map(|(path, _)| path.as_str())
+                .collect::<Vec<_>>(),
+            vec!["run.integrations.github.permissions.contents"]
+        );
+    }
+
+    #[test]
+    fn defers_a_templated_contents_permission_to_the_runtime_boundary() {
+        let settings = super::workflow_settings_from_toml(
+            r#"
+_version = 1
+
+[run.integrations.github]
+additional_repositories = ["fabro-sh/keystone"]
+permissions = { contents = "{{ vars.GH_CONTENTS }}" }
+"#,
+        )
+        .expect("templated contents permission resolves; the value is re-checked at runtime");
+
+        assert_eq!(resolved_repositories(&settings), vec!["fabro-sh/keystone"]);
+    }
+
+    #[test]
+    fn higher_layer_replaces_the_repository_list_wholesale() {
+        let workflow = parse_settings(
+            r#"
+_version = 1
+
+[run.integrations.github]
+additional_repositories = ["fabro-sh/keystone"]
+"#,
+        );
+        let user = parse_settings(
+            r#"
+_version = 1
+
+[run.integrations.github]
+additional_repositories = ["fabro-sh/arc", "fabro-sh/widgets"]
+permissions = { contents = "read" }
+"#,
+        );
+        let merged = workflow.combine(user);
+
+        let resolved =
+            super::workflow_settings_from_layer(merged).expect("merged settings should resolve");
+
+        // The lists never union: the higher layer's single entry wins, while
+        // the permission map inherits independently from the lower layer.
+        assert_eq!(resolved_repositories(&resolved), vec!["fabro-sh/keystone"]);
+        assert_eq!(
+            resolved.run.integrations.github.permissions.len(),
+            1,
+            "permissions should inherit from the lower layer"
+        );
+    }
+
+    #[test]
+    fn absent_higher_layer_inherits_the_lower_repository_list() {
+        let workflow = parse_settings("_version = 1\n");
+        let user = parse_settings(
+            r#"
+_version = 1
+
+[run.integrations.github]
+additional_repositories = ["fabro-sh/keystone"]
+permissions = { contents = "read" }
+"#,
+        );
+        let merged = workflow.combine(user);
+
+        let resolved =
+            super::workflow_settings_from_layer(merged).expect("merged settings should resolve");
+        assert_eq!(resolved_repositories(&resolved), vec!["fabro-sh/keystone"]);
+    }
+
+    #[test]
+    fn empty_higher_layer_list_clears_inherited_repositories() {
+        let workflow = parse_settings(
+            r"
+_version = 1
+
+[run.integrations.github]
+additional_repositories = []
+",
+        );
+        let user = parse_settings(
+            r#"
+_version = 1
+
+[run.integrations.github]
+additional_repositories = ["fabro-sh/keystone"]
+permissions = { contents = "read" }
+"#,
+        );
+        let merged = workflow.combine(user);
+
+        let resolved =
+            super::workflow_settings_from_layer(merged).expect("merged settings should resolve");
+
+        assert!(
+            resolved
+                .run
+                .integrations
+                .github
+                .additional_repositories
+                .is_empty(),
+            "explicit [] should clear the inherited repository list"
+        );
+        // Permissions survive the repository clear: each field resolves
+        // independently.
+        assert!(resolved.run.integrations.github.is_token_requested());
+    }
+
+    #[test]
+    fn rejects_repositories_that_survive_a_cross_layer_permission_clear() {
+        let workflow = parse_settings(
+            r"
+_version = 1
+
+[run.integrations.github]
+permissions = {}
+",
+        );
+        let user = parse_settings(
+            r#"
+_version = 1
+
+[run.integrations.github]
+additional_repositories = ["fabro-sh/keystone"]
+permissions = { contents = "read" }
+"#,
+        );
+        let merged = workflow.combine(user);
+
+        let error = super::workflow_settings_from_layer(merged)
+            .map(|_| ())
+            .expect_err("repositories with cleared permissions should not resolve");
+
+        let message = error.to_string();
+        assert!(
+            message.contains("additional_repositories"),
+            "error should name the invalid combination: {message}"
+        );
+    }
+
+    #[test]
+    fn permissions_only_and_fully_empty_shapes_are_preserved() {
+        let permissions_only = super::workflow_settings_from_toml(
+            r#"
+_version = 1
+
+[run.integrations.github.permissions]
+issues = "read"
+"#,
+        )
+        .expect("permissions-only settings should resolve");
+        assert!(
+            permissions_only
+                .run
+                .integrations
+                .github
+                .additional_repositories
+                .is_empty()
+        );
+        assert!(
+            permissions_only
+                .run
+                .integrations
+                .github
+                .is_token_requested()
+        );
+
+        let empty = super::workflow_settings_from_toml("_version = 1\n")
+            .expect("empty settings should resolve");
+        assert!(
+            empty
+                .run
+                .integrations
+                .github
+                .additional_repositories
+                .is_empty()
+        );
+        assert!(!empty.run.integrations.github.is_token_requested());
+    }
+}
+
 mod run_agent {
     use crate::SettingsLayer;
     use crate::layers::Combine;

--- a/lib/foundation/fabro-types/src/repository.rs
+++ b/lib/foundation/fabro-types/src/repository.rs
@@ -65,6 +65,12 @@ impl GitHubRepositorySlug {
         &self.repo
     }
 
+    /// Canonical credential-free HTTPS URL for this GitHub repository.
+    #[must_use]
+    pub fn https_url(&self) -> String {
+        format!("https://github.com/{self}")
+    }
+
     /// Whether `other` names the same repository owner, ignoring ASCII case.
     /// Owner and repository names are validated ASCII, so ASCII folding is
     /// exact.
@@ -354,6 +360,14 @@ mod tests {
         let mut ordered = std::collections::BTreeSet::new();
         ordered.insert(mixed);
         assert!(!ordered.insert(lower), "case variants share ordering");
+    }
+
+    #[test]
+    fn slug_https_url_preserves_spelling_and_has_no_credentials() {
+        let slug: GitHubRepositorySlug = "Fabro-SH/Keystone".parse().unwrap();
+
+        assert_eq!(slug.https_url(), "https://github.com/Fabro-SH/Keystone");
+        assert!(!slug.https_url().contains('@'));
     }
 
     #[test]

--- a/lib/foundation/fabro-types/src/repository.rs
+++ b/lib/foundation/fabro-types/src/repository.rs
@@ -72,13 +72,12 @@ impl GitHubRepositorySlug {
     pub fn same_owner(&self, other: &Self) -> bool {
         self.owner.eq_ignore_ascii_case(&other.owner)
     }
+}
 
-    fn canonical_key(&self) -> (String, String) {
-        (
-            self.owner.to_ascii_lowercase(),
-            self.repo.to_ascii_lowercase(),
-        )
-    }
+/// Case-folded bytes for identity comparisons without allocating; owner and
+/// repository names are validated ASCII, so ASCII folding is exact.
+fn folded_bytes(value: &str) -> impl Iterator<Item = u8> + '_ {
+    value.bytes().map(|byte| byte.to_ascii_lowercase())
 }
 
 impl PartialEq for GitHubRepositorySlug {
@@ -97,13 +96,23 @@ impl PartialOrd for GitHubRepositorySlug {
 
 impl Ord for GitHubRepositorySlug {
     fn cmp(&self, other: &Self) -> Ordering {
-        self.canonical_key().cmp(&other.canonical_key())
+        folded_bytes(&self.owner)
+            .cmp(folded_bytes(&other.owner))
+            .then_with(|| folded_bytes(&self.repo).cmp(folded_bytes(&other.repo)))
     }
 }
 
 impl Hash for GitHubRepositorySlug {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        self.canonical_key().hash(state);
+        for byte in folded_bytes(&self.owner) {
+            state.write_u8(byte);
+        }
+        // `/` cannot appear in a validated owner, so the folded
+        // `owner/repo` encoding stays unambiguous.
+        state.write_u8(b'/');
+        for byte in folded_bytes(&self.repo) {
+            state.write_u8(byte);
+        }
     }
 }
 

--- a/lib/foundation/fabro-types/src/repository.rs
+++ b/lib/foundation/fabro-types/src/repository.rs
@@ -1,3 +1,8 @@
+use std::cmp::Ordering;
+use std::fmt;
+use std::hash::{Hash, Hasher};
+use std::str::FromStr;
+
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -25,8 +30,10 @@ impl RepositoryRef {
 ///
 /// Construction enforces GitHub's owner and repository name syntax on the
 /// exact submitted bytes; no trimming, case folding, or other normalization
-/// is performed.
-#[derive(Debug, Clone, PartialEq, Eq)]
+/// is performed. The original spelling is preserved for `Display` and
+/// serialization, while identity (`Eq`, `Ord`, `Hash`) is case-insensitive
+/// to match GitHub's treatment of owner and repository names.
+#[derive(Debug, Clone)]
 pub struct GitHubRepositorySlug {
     owner: String,
     repo:  String,
@@ -56,6 +63,90 @@ impl GitHubRepositorySlug {
     #[must_use]
     pub fn repo(&self) -> &str {
         &self.repo
+    }
+
+    /// Whether `other` names the same repository owner, ignoring ASCII case.
+    /// Owner and repository names are validated ASCII, so ASCII folding is
+    /// exact.
+    #[must_use]
+    pub fn same_owner(&self, other: &Self) -> bool {
+        self.owner.eq_ignore_ascii_case(&other.owner)
+    }
+
+    fn canonical_key(&self) -> (String, String) {
+        (
+            self.owner.to_ascii_lowercase(),
+            self.repo.to_ascii_lowercase(),
+        )
+    }
+}
+
+impl PartialEq for GitHubRepositorySlug {
+    fn eq(&self, other: &Self) -> bool {
+        self.owner.eq_ignore_ascii_case(&other.owner) && self.repo.eq_ignore_ascii_case(&other.repo)
+    }
+}
+
+impl Eq for GitHubRepositorySlug {}
+
+impl PartialOrd for GitHubRepositorySlug {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for GitHubRepositorySlug {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.canonical_key().cmp(&other.canonical_key())
+    }
+}
+
+impl Hash for GitHubRepositorySlug {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.canonical_key().hash(state);
+    }
+}
+
+impl fmt::Display for GitHubRepositorySlug {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}/{}", self.owner, self.repo)
+    }
+}
+
+/// Parse failure for [`GitHubRepositorySlug`]. The offending input is not
+/// echoed back because config surfaces already attach the value and its path.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[error(
+    "expected a GitHub `owner/repository` slug with no scheme, host, ref, or extra path component"
+)]
+pub struct GitHubRepositorySlugError;
+
+impl FromStr for GitHubRepositorySlug {
+    type Err = GitHubRepositorySlugError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Self::try_new(value).ok_or(GitHubRepositorySlugError)
+    }
+}
+
+impl Serialize for GitHubRepositorySlug {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.collect_str(self)
+    }
+}
+
+impl<'de> Deserialize<'de> for GitHubRepositorySlug {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        use serde::de::Error as _;
+
+        let value = String::deserialize(deserializer)?;
+        value.parse().map_err(D::Error::custom)
     }
 }
 
@@ -232,6 +323,69 @@ mod tests {
         let over_repo = format!("owner/{}", "b".repeat(101));
         assert!(GitHubRepositorySlug::try_new(&over_owner).is_none());
         assert!(GitHubRepositorySlug::try_new(&over_repo).is_none());
+    }
+
+    #[test]
+    fn slug_identity_is_case_insensitive_but_display_preserves_case() {
+        let mixed: GitHubRepositorySlug = "Fabro-SH/Keystone".parse().unwrap();
+        let lower: GitHubRepositorySlug = "fabro-sh/keystone".parse().unwrap();
+
+        assert_eq!(mixed, lower);
+        assert_eq!(mixed.cmp(&lower), std::cmp::Ordering::Equal);
+        assert!(mixed.same_owner(&lower));
+        assert_eq!(mixed.to_string(), "Fabro-SH/Keystone");
+
+        let mut hashes = std::collections::HashSet::new();
+        hashes.insert(mixed.clone());
+        assert!(
+            !hashes.insert(lower.clone()),
+            "case variants share identity"
+        );
+
+        let mut ordered = std::collections::BTreeSet::new();
+        ordered.insert(mixed);
+        assert!(!ordered.insert(lower), "case variants share ordering");
+    }
+
+    #[test]
+    fn slug_ordering_sorts_by_canonical_form() {
+        let mut slugs: Vec<GitHubRepositorySlug> = ["owner/Zeta", "Owner/alpha", "owner/Beta"]
+            .iter()
+            .map(|value| value.parse().unwrap())
+            .collect();
+        slugs.sort();
+        let rendered: Vec<String> = slugs.iter().map(ToString::to_string).collect();
+        assert_eq!(rendered, ["Owner/alpha", "owner/Beta", "owner/Zeta"]);
+    }
+
+    #[test]
+    fn slug_from_str_rejects_urls_and_hosts() {
+        let cases = [
+            "https://github.com/owner/repo",
+            "git@github.com:owner/repo.git",
+            "ssh://git@github.com/owner/repo",
+            "github.com/owner/repo",
+            "owner/repo@main",
+            "owner/repo#ref",
+            " owner/repo",
+            "owner/repo ",
+        ];
+        for input in cases {
+            assert!(input.parse::<GitHubRepositorySlug>().is_err(), "{input}");
+        }
+    }
+
+    #[test]
+    fn slug_serde_round_trips_as_a_string() {
+        let slug: GitHubRepositorySlug = "Fabro-SH/Keystone".parse().unwrap();
+        let json = serde_json::to_string(&slug).unwrap();
+        assert_eq!(json, "\"Fabro-SH/Keystone\"");
+
+        let parsed: GitHubRepositorySlug = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, slug);
+
+        let err = serde_json::from_str::<GitHubRepositorySlug>("\"not a slug\"").unwrap_err();
+        assert!(err.to_string().contains("owner/repository"), "{err}");
     }
 
     #[test]

--- a/lib/foundation/fabro-types/src/settings/run.rs
+++ b/lib/foundation/fabro-types/src/settings/run.rs
@@ -6,7 +6,7 @@
 //! notifications, interviews, agent knobs, hooks, SCM targeting, pull-request
 //! behavior, and artifact collection.
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::path::PathBuf;
 use std::time::Duration as StdDuration;
 
@@ -603,9 +603,19 @@ pub struct RunIntegrationsSettings {
 /// presence-vs-clear distinction is only meaningful at the layer-merge
 /// stage; the resolved form collapses both `None` and `Some({})` into an
 /// empty map.
+///
+/// `additional_repositories` lists repositories, beyond the implicit run
+/// origin, that the minted `GITHUB_TOKEN` must cover. Configuration
+/// resolution guarantees a non-empty set comes with a non-empty permission
+/// map that includes `contents`; runs persisted before the field existed
+/// deserialize to an empty set via the serde default.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct RunIntegrationsGithubSettings {
-    pub permissions: HashMap<String, InterpString>,
+    pub permissions:             HashMap<String, InterpString>,
+    /// Omitted when empty so settings serialized by this release stay
+    /// byte-identical to earlier releases for single-repository runs.
+    #[serde(default, skip_serializing_if = "BTreeSet::is_empty")]
+    pub additional_repositories: BTreeSet<crate::GitHubRepositorySlug>,
 }
 
 impl RunIntegrationsGithubSettings {
@@ -614,6 +624,11 @@ impl RunIntegrationsGithubSettings {
     /// resolved-form sentinel for this state.
     pub fn is_token_requested(&self) -> bool {
         !self.permissions.is_empty()
+    }
+
+    /// Whether the run declares additional repositories beyond the origin.
+    pub fn has_additional_repositories(&self) -> bool {
+        !self.additional_repositories.is_empty()
     }
 
     /// Resolve every `permissions` value. `{{ vars.* }}` is substituted
@@ -627,6 +642,42 @@ impl RunIntegrationsGithubSettings {
             .map(|(name, value)| Ok((name.clone(), value.resolve_with(&mut ctx)?)))
             .collect()
     }
+
+    /// Resolve the whole runtime integration request: interpolated
+    /// permissions plus the declared additional repositories, produced
+    /// together so consumers cannot pick up one without the other.
+    pub fn resolve_integration(&self) -> Result<ResolvedGithubIntegration, ResolveError> {
+        Ok(ResolvedGithubIntegration {
+            permissions:             self.resolve_permissions()?,
+            additional_repositories: self.additional_repositories.clone(),
+        })
+    }
+}
+
+/// The resolved runtime GitHub integration request for one run: interpolated
+/// permission values plus the declared additional repositories.
+///
+/// This is the single value carried from run materialization into workflow
+/// startup, replacing parallel permission/repository collections that could
+/// drift apart.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct ResolvedGithubIntegration {
+    pub permissions:             HashMap<String, String>,
+    pub additional_repositories: BTreeSet<crate::GitHubRepositorySlug>,
+}
+
+impl ResolvedGithubIntegration {
+    /// Mirrors [`RunIntegrationsGithubSettings::is_token_requested`] for the
+    /// resolved form.
+    #[must_use]
+    pub fn is_token_requested(&self) -> bool {
+        !self.permissions.is_empty()
+    }
+
+    #[must_use]
+    pub fn has_additional_repositories(&self) -> bool {
+        !self.additional_repositories.is_empty()
+    }
 }
 
 #[cfg(test)]
@@ -635,10 +686,11 @@ mod run_integrations_github_tests {
 
     fn settings(permissions: &[(&str, &str)]) -> RunIntegrationsGithubSettings {
         RunIntegrationsGithubSettings {
-            permissions: permissions
+            permissions:             permissions
                 .iter()
                 .map(|(k, v)| ((*k).to_string(), InterpString::parse(v)))
                 .collect(),
+            additional_repositories: std::collections::BTreeSet::new(),
         }
     }
 
@@ -669,6 +721,53 @@ mod run_integrations_github_tests {
     #[test]
     fn resolve_permissions_is_empty_for_empty_settings() {
         assert!(settings(&[]).resolve_permissions().unwrap().is_empty());
+    }
+
+    #[test]
+    fn settings_without_additional_repositories_field_deserialize_to_empty_set() {
+        // Persisted run.created events from releases before
+        // `additional_repositories` existed omit the field entirely.
+        let parsed: RunIntegrationsGithubSettings = serde_json::from_value(serde_json::json!({
+            "permissions": { "contents": "read" }
+        }))
+        .expect("legacy settings should deserialize");
+
+        assert!(parsed.additional_repositories.is_empty());
+        assert!(!parsed.has_additional_repositories());
+    }
+
+    #[test]
+    fn resolve_integration_carries_permissions_and_repositories_together() {
+        let mut s = settings(&[("contents", "read")]);
+        s.additional_repositories
+            .insert("fabro-sh/keystone".parse().unwrap());
+
+        let resolved = s.resolve_integration().unwrap();
+
+        assert!(resolved.is_token_requested());
+        assert!(resolved.has_additional_repositories());
+        assert_eq!(
+            resolved.permissions.get("contents"),
+            Some(&"read".to_string())
+        );
+        assert_eq!(
+            resolved
+                .additional_repositories
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>(),
+            vec!["fabro-sh/keystone"]
+        );
+    }
+
+    #[test]
+    fn resolve_integration_fails_on_an_unresolved_permission_token() {
+        let mut s = settings(&[("contents", "{{ env.GH_PERM_LEVEL }}")]);
+        s.additional_repositories
+            .insert("fabro-sh/keystone".parse().unwrap());
+
+        let err = s.resolve_integration().unwrap_err();
+        assert_eq!(err.namespace, Namespace::Env);
     }
 }
 

--- a/lib/foundation/fabro-types/src/settings/run.rs
+++ b/lib/foundation/fabro-types/src/settings/run.rs
@@ -631,11 +631,21 @@ impl RunIntegrationsGithubSettings {
         !self.additional_repositories.is_empty()
     }
 
+    /// Whether a resolved `contents` permission level lets the token reach
+    /// repository contents — the level a declared `additional_repositories`
+    /// set requires. The one definition shared by config-time validation and
+    /// the runtime re-check after interpolation, so the accepted levels
+    /// cannot drift between the two layers.
+    #[must_use]
+    pub fn contents_permission_allows_repository_access(value: &str) -> bool {
+        value == "read" || value == "write"
+    }
+
     /// Resolve every `permissions` value. `{{ vars.* }}` is substituted
     /// server-side at run creation, so values are literal by this point; a
     /// still-unresolved token fails closed rather than reaching the GitHub API
     /// as literal text.
-    pub fn resolve_permissions(&self) -> Result<HashMap<String, String>, ResolveError> {
+    fn resolve_permissions(&self) -> Result<HashMap<String, String>, ResolveError> {
         let mut ctx = ResolveCtx::new();
         self.permissions
             .iter()

--- a/lib/packages/fabro-api-client/src/models/run-integrations-github-settings.ts
+++ b/lib/packages/fabro-api-client/src/models/run-integrations-github-settings.ts
@@ -16,4 +16,8 @@
 
 export interface RunIntegrationsGithubSettings {
     'permissions': { [key: string]: string; };
+    /**
+     * Additional GitHub repositories, beyond the implicit run origin, that the minted GITHUB_TOKEN must cover. Each entry is a full `owner/repository` slug; every repository must share one owner with the run origin. Omitted when empty; settings persisted before this field existed deserialize to an empty set.
+     */
+    'additional_repositories'?: Array<string>;
 }

--- a/lib/packages/fabro-api-client/src/models/run-spec.ts
+++ b/lib/packages/fabro-api-client/src/models/run-spec.ts
@@ -39,7 +39,7 @@ export interface RunSpec {
     'graph_source'?: string | null;
     'workflow_slug'?: string | null;
     /**
-     * SHA-256 identity of validated canonical workflow-version bytes.
+     * SHA-256 identity of validated canonical workflow-version bytes. Hex input is case-insensitive; Fabro emits the canonical lowercase form.
      */
     'workflow_version_id'?: string | null;
     'automation'?: AutomationRef | null;


### PR DESCRIPTION
Implements `.ai/plans/2026-07-22-additional-github-repositories.md` (revised 2026-08-21).

A run can now declare additional GitHub repositories that its stages may access through the one managed `GITHUB_TOKEN`:

```toml
[run.integrations.github]
additional_repositories = ["fabro-sh/keystone"]
permissions = { contents = "read" }
```

The run origin stays implicit. Fabro mints **one** installation token scoped to the origin plus every declared repository with the shared permission map, and stages reach the declared set through `gh`, raw GitHub API calls, plain Git over HTTPS, and the common SSH URL spellings (bridged to authenticated HTTPS with no secret in Git config).

## Commits

1. **feat(config)** — validated `additional_repositories` field: `GitHubRepositorySlug` gains `FromStr`/`Display`/string serde and case-insensitive identity; resolution validates slug grammar, duplicates, single owner, the 499 cap, and the required `contents` permission with indexed error paths. Wholesale list replacement across layers; `[]` clears.
2. **feat(github)** — `GitHubRepositoryAccess` (validated effective set, primary-first, secret-free), per-repository installation resolution requiring one shared installation ID, multi-repository mint, and `InstallationTokenSource::for_access` with unchanged caching/refresh/single-flight.
3. **feat(workflow)** — one `ResolvedGithubIntegration` value carried from CLI/server workers through `SandboxEnvSpec`; hard initialization errors for declared sets (missing creds/origin, inaccessible repository) with eager installation + token validation; legacy permissions-only stays best-effort. New `git_bridge` module injects secret-free `GIT_CONFIG_*` entries (env-reading credential helper, per-repo SSH→HTTPS rewrites, `GIT_TERMINAL_PROMPT=0`), appended after any valid user Git-config overlay. Contract tests drive the real `git` binary against local fixtures.
4. **feat(server)** — preflight resolves each repository's installation, mints once, probes every effective repository with `git ls-remote … HEAD` (token only in the child env; same-token retry for replication lag), and reports one check per repository in deterministic primary-first order. `GH_TOKEN` in the resolved run environment warns without failing. Primary-only behavior unchanged.
5. **docs(api)** — OpenAPI schema + canonical-type reuse via `with_replacement` with type-identity witnesses, regenerated TS client, integration/run-configuration docs (including the corrected `GITHUB_TOKEN` claim and the `contents = "write"` blast-radius warning), changelog entry, and an opt-in live GitHub App e2e test.

## Scope notes

- All repositories must share one owner and one App installation; cross-owner/cross-installation access is an explicit follow-up.
- Managed cloning of additional repositories is out of scope — workflows add their own clone step.
- PAT mode: the list drives validation and probes but cannot narrow the PAT's inherent scope (documented).

## Verification

- `cargo nextest run --workspace` — 8017 passed
- `cargo +nightly-2026-04-14 fmt --check --all` / `clippy --workspace --all-targets -- -D warnings` — clean
- TS client regenerated; `bun run typecheck` clean
- Live e2e (`fabro-github/tests/live_access.rs`) and the post-deploy acceptance run from the plan still need real App credentials.

🤖 Generated with [Claude Code](https://claude.com/claude-code)