### PR TITLE
fix(agent): serialize parallel write tools per target path

### DIFF
--- a/docs/public/agents/tools.mdx
+++ b/docs/public/agents/tools.mdx
@@ -208,6 +208,8 @@ When an Anthropic session has not used `TaskCreate` or `TaskUpdate` for ten assi
 
 When an LLM returns multiple tool calls in a single response, Fabro can execute them in parallel. Independent tool calls run concurrently, while the results are collected in order. If the agent session is cancelled, pending tool calls return a "Cancelled" error.
 
+Write tools that target the same file are serialized: when multiple `edit_file` or `write_file` calls in one batch point at the same path, Fabro acquires a per-path write lock around the whole read-modify-write span, so every edit lands instead of the fastest write silently discarding the others. Calls targeting different files stay fully concurrent. A contention warning is logged when same-path writes are serialized.
+
 ### Argument validation
 
 Before executing a tool, Fabro validates the arguments against the tool's JSON Schema. Invalid arguments are rejected with a descriptive error before the tool executor runs.

--- a/lib/components/fabro-agent/src/apply_patch.rs
+++ b/lib/components/fabro-agent/src/apply_patch.rs
@@ -959,6 +959,7 @@ mod tests {
 *** End Patch
 ";
         let ctx = ToolContext {
+            write_locks: None,
             env,
             cancel: CancellationToken::new(),
             tool_env_provider: None,

--- a/lib/components/fabro-agent/src/lib.rs
+++ b/lib/components/fabro-agent/src/lib.rs
@@ -87,6 +87,8 @@ pub use types::{
     SkillActivationSource, SkillSummary,
 };
 
+pub mod write_locks;
+
 #[cfg(test)]
 #[allow(
     unreachable_pub,

--- a/lib/components/fabro-agent/src/mcp_integration.rs
+++ b/lib/components/fabro-agent/src/mcp_integration.rs
@@ -98,6 +98,7 @@ mod tests {
         let result = (tool.executor)(
             serde_json::json!({"message": "test message"}),
             ToolContext {
+                write_locks: None,
                 env,
                 cancel: CancellationToken::new(),
                 tool_env_provider: None,

--- a/lib/components/fabro-agent/src/profiles/claude5_tools.rs
+++ b/lib/components/fabro-agent/src/profiles/claude5_tools.rs
@@ -503,6 +503,7 @@ mod tests {
 
     fn context() -> ToolContext {
         ToolContext {
+            write_locks:         None,
             env:                 Arc::new(MockSandbox::default()) as Arc<dyn Sandbox>,
             cancel:              CancellationToken::new(),
             tool_env_provider:   None,

--- a/lib/components/fabro-agent/src/profiles/kimi_tools.rs
+++ b/lib/components/fabro-agent/src/profiles/kimi_tools.rs
@@ -380,6 +380,7 @@ mod tests {
 
     fn ctx(env: Arc<dyn Sandbox>) -> ToolContext {
         ToolContext {
+            write_locks: None,
             env,
             cancel: CancellationToken::new(),
             tool_env_provider: None,

--- a/lib/components/fabro-agent/src/profiles/mod.rs
+++ b/lib/components/fabro-agent/src/profiles/mod.rs
@@ -795,6 +795,7 @@ mod tests {
 
         let env: Arc<dyn Sandbox> = Arc::new(MockSandbox::default());
         let context = |session_id: &str| ToolContext {
+            write_locks:         None,
             env:                 Arc::clone(&env),
             cancel:              CancellationToken::new(),
             tool_env_provider:   None,

--- a/lib/components/fabro-agent/src/question_tools.rs
+++ b/lib/components/fabro-agent/src/question_tools.rs
@@ -961,6 +961,7 @@ mod tests {
                 }]
             }),
             ToolContext {
+                write_locks:         None,
                 env:                 Arc::new(MockSandbox::default()),
                 cancel:              CancellationToken::new(),
                 tool_env_provider:   None,

--- a/lib/components/fabro-agent/src/session.rs
+++ b/lib/components/fabro-agent/src/session.rs
@@ -2275,6 +2275,7 @@ mod tests {
     use super::*;
     use crate::config::{ToolAccess, ToolAccessPolicy, ToolApprovalAdapter, ToolExposureMode};
     use crate::error::CompactionError;
+    use crate::make_edit_file_tool;
     use crate::skills::{Skill, make_use_skill_tool};
     use crate::subagent::{SubAgentStatus, make_wait_tool};
     use crate::test_support::*;
@@ -3735,6 +3736,60 @@ mod tests {
         }
         assert_eq!(start_count, 3);
         assert_eq!(end_count, 3);
+    }
+
+    #[tokio::test]
+    async fn parallel_edit_file_same_file_both_edits_applied_via_session() {
+        // Session-level contract for the same-file write lock: one assistant
+        // response fanning out two edit_file calls to the same file must land
+        // both edits (observed clobber in run 01M0NJZGX7BMJAJC3CZJZ0RNT0).
+        // Slow writes force the interleaving that instant mocks would hide.
+        let mut registry = ToolRegistry::new();
+        registry.register(make_edit_file_tool());
+
+        let responses = vec![
+            multi_tool_call_response(vec![
+                (
+                    "edit_file",
+                    "edit_1",
+                    serde_json::json!({
+                        "file_path": "/main.go",
+                        "old_string": "alpha",
+                        "new_string": "ALPHA"
+                    }),
+                ),
+                (
+                    "edit_file",
+                    "edit_2",
+                    serde_json::json!({
+                        "file_path": "/main.go",
+                        "old_string": "beta",
+                        "new_string": "BETA"
+                    }),
+                ),
+            ]),
+            text_response("All done!"),
+        ];
+
+        let provider = Arc::new(MockLlmProvider::new(responses));
+        let client = make_client(provider).await;
+        let profile = Arc::new(TestProfile::with_tools(registry));
+        let env = Arc::new(SlowWriteMockSandbox::new(
+            HashMap::from([("/main.go".to_string(), "alpha beta".to_string())]),
+            25,
+        ));
+        let mut session = Session::new(
+            client,
+            profile,
+            env.clone(),
+            SessionOptions::default(),
+            None,
+        );
+
+        session.process_input("Edit both markers").await.unwrap();
+
+        let content = env.inner.read_file_text("/main.go").await.unwrap();
+        assert_eq!(content, "ALPHA BETA");
     }
 
     #[tokio::test]
@@ -6106,6 +6161,7 @@ mod tests {
         let mut rx = session.subscribe();
         let env: Arc<dyn Sandbox> = Arc::new(MockSandbox::default());
         let ctx = ToolContext {
+            write_locks: None,
             env,
             cancel: CancellationToken::new(),
             tool_env_provider: None,

--- a/lib/components/fabro-agent/src/skills.rs
+++ b/lib/components/fabro-agent/src/skills.rs
@@ -652,6 +652,7 @@ name: trimmed
         let env: Arc<dyn Sandbox> = Arc::new(MockSandbox::default());
         let args = serde_json::json!({"skill_name": "commit"});
         let ctx = ToolContext {
+            write_locks: None,
             env,
             cancel: CancellationToken::new(),
             tool_env_provider: None,
@@ -675,6 +676,7 @@ name: trimmed
         let env: Arc<dyn Sandbox> = Arc::new(MockSandbox::default());
         let args = serde_json::json!({"skill_name": "nonexistent"});
         let ctx = ToolContext {
+            write_locks: None,
             env,
             cancel: CancellationToken::new(),
             tool_env_provider: None,
@@ -696,6 +698,7 @@ name: trimmed
         let env: Arc<dyn Sandbox> = Arc::new(MockSandbox::default());
         let args = serde_json::json!({});
         let ctx = ToolContext {
+            write_locks: None,
             env,
             cancel: CancellationToken::new(),
             tool_env_provider: None,
@@ -715,6 +718,7 @@ name: trimmed
         let tool = make_use_skill_tool_for_vocabulary(skills, ToolVocabulary::KimiCode);
         let env: Arc<dyn Sandbox> = Arc::new(MockSandbox::default());
         let ctx = ToolContext {
+            write_locks: None,
             env,
             cancel: CancellationToken::new(),
             tool_env_provider: None,
@@ -756,6 +760,7 @@ name: trimmed
         let result = (tool.executor)(
             serde_json::json!({"skill": "commit", "args": "only staged files"}),
             ToolContext {
+                write_locks:         None,
                 env:                 Arc::new(MockSandbox::default()),
                 cancel:              CancellationToken::new(),
                 tool_env_provider:   None,

--- a/lib/components/fabro-agent/src/subagent.rs
+++ b/lib/components/fabro-agent/src/subagent.rs
@@ -1752,6 +1752,7 @@ mod tests {
         let tool = make_wait_tool(manager.clone());
         let tool_cancel = CancellationToken::new();
         let ctx = ToolContext {
+            write_locks:         None,
             env:                 Arc::new(MockSandbox::default()),
             cancel:              tool_cancel.clone(),
             tool_env_provider:   None,

--- a/lib/components/fabro-agent/src/test_support.rs
+++ b/lib/components/fabro-agent/src/test_support.rs
@@ -11,7 +11,10 @@ use fabro_llm::types::{
 };
 use fabro_model::{AgentProfileKind, ProviderId};
 pub use fabro_sandbox::test_support::{MockSandbox, MutableMockSandbox};
+use fabro_sandbox::{GrepOptions, Result as SandboxResult};
 use futures::stream;
+use tokio::time::{Duration, sleep};
+use tokio_util::sync::CancellationToken;
 
 use crate::agent_profile::AgentProfile;
 use crate::config::SessionOptions;
@@ -404,5 +407,114 @@ pub fn multi_tool_call_response(calls: Vec<(&str, &str, serde_json::Value)>) -> 
         rate_limit:    None,
         cost_usd:      None,
         cost_source:   None,
+    }
+}
+
+/// A [`MutableMockSandbox`] whose writes are delayed by `write_delay_ms`.
+///
+/// Tests for parallel tool execution use this to force the read-modify-write
+/// interleaving that instant mock writes would hide: without a delay, the
+/// first edit future can finish its write before the second one is polled.
+pub struct SlowWriteMockSandbox {
+    pub inner:          MutableMockSandbox,
+    pub write_delay_ms: u64,
+}
+
+impl SlowWriteMockSandbox {
+    pub fn new(files: HashMap<String, String>, write_delay_ms: u64) -> Self {
+        Self {
+            inner: MutableMockSandbox::new(files),
+            write_delay_ms,
+        }
+    }
+}
+
+#[async_trait]
+impl Sandbox for SlowWriteMockSandbox {
+    async fn read_file_bytes(&self, path: &str) -> SandboxResult<Vec<u8>> {
+        self.inner.read_file_bytes(path).await
+    }
+
+    async fn write_file(&self, path: &str, content: &str) -> SandboxResult<()> {
+        sleep(Duration::from_millis(self.write_delay_ms)).await;
+        self.inner.write_file(path, content).await
+    }
+
+    async fn delete_file(&self, path: &str) -> SandboxResult<()> {
+        self.inner.delete_file(path).await
+    }
+
+    async fn file_exists(&self, path: &str) -> SandboxResult<bool> {
+        self.inner.file_exists(path).await
+    }
+
+    async fn list_directory(
+        &self,
+        path: &str,
+        depth: Option<usize>,
+    ) -> SandboxResult<Vec<fabro_sandbox::DirEntry>> {
+        self.inner.list_directory(path, depth).await
+    }
+
+    async fn exec_command(
+        &self,
+        command: &str,
+        timeout_ms: u64,
+        working_dir: Option<&str>,
+        env_vars: Option<&std::collections::HashMap<String, String>>,
+        cancel_token: Option<CancellationToken>,
+    ) -> SandboxResult<fabro_sandbox::ExecResult> {
+        self.inner
+            .exec_command(command, timeout_ms, working_dir, env_vars, cancel_token)
+            .await
+    }
+
+    async fn grep(
+        &self,
+        pattern: &str,
+        path: &str,
+        options: &GrepOptions,
+    ) -> SandboxResult<Vec<String>> {
+        self.inner.grep(pattern, path, options).await
+    }
+
+    async fn glob(&self, pattern: &str, path: Option<&str>) -> SandboxResult<Vec<String>> {
+        self.inner.glob(pattern, path).await
+    }
+
+    async fn download_file_to_local(
+        &self,
+        path: &str,
+        local: &std::path::Path,
+    ) -> SandboxResult<()> {
+        self.inner.download_file_to_local(path, local).await
+    }
+
+    async fn upload_file_from_local(
+        &self,
+        local: &std::path::Path,
+        path: &str,
+    ) -> SandboxResult<()> {
+        self.inner.upload_file_from_local(local, path).await
+    }
+
+    async fn initialize(&self) -> SandboxResult<()> {
+        self.inner.initialize().await
+    }
+
+    async fn cleanup(&self) -> SandboxResult<()> {
+        self.inner.cleanup().await
+    }
+
+    fn working_directory(&self) -> &str {
+        self.inner.working_directory()
+    }
+
+    fn platform(&self) -> &str {
+        self.inner.platform()
+    }
+
+    fn os_version(&self) -> String {
+        self.inner.os_version()
     }
 }

--- a/lib/components/fabro-agent/src/todo_runtime.rs
+++ b/lib/components/fabro-agent/src/todo_runtime.rs
@@ -168,6 +168,7 @@ mod tests {
     fn ctx_with(emitter: Arc<CollectingEmitter>) -> ToolContext {
         let env: Arc<dyn Sandbox> = Arc::new(MockSandbox::default());
         ToolContext {
+            write_locks: None,
             env,
             cancel: CancellationToken::new(),
             tool_env_provider: None,

--- a/lib/components/fabro-agent/src/todo_tools.rs
+++ b/lib/components/fabro-agent/src/todo_tools.rs
@@ -671,6 +671,7 @@ mod kimi_todo_tests {
     fn ctx() -> ToolContext {
         let env: Arc<dyn Sandbox> = Arc::new(MockSandbox::default());
         ToolContext {
+            write_locks: None,
             env,
             cancel: CancellationToken::new(),
             tool_env_provider: None,
@@ -791,6 +792,7 @@ mod tests {
     fn ctx_for(session: &str, root: &str) -> ToolContext {
         let env: Arc<dyn Sandbox> = Arc::new(MockSandbox::default());
         ToolContext {
+            write_locks: None,
             env,
             cancel: CancellationToken::new(),
             tool_env_provider: None,

--- a/lib/components/fabro-agent/src/tool_execution.rs
+++ b/lib/components/fabro-agent/src/tool_execution.rs
@@ -13,6 +13,7 @@ use crate::session::ToolEnvProvider;
 use crate::tool_registry::{AgentEventEmitter, RegisteredTool, ToolContext, ToolRegistry};
 use crate::truncation::truncate_tool_output;
 use crate::types::AgentEvent;
+use crate::write_locks::{BatchWriteLocks, new_batch_write_locks};
 
 /// Execute tool calls, choosing parallel or sequential based on `parallel`
 /// flag.
@@ -120,6 +121,7 @@ async fn execute_tool_calls_sequential(
             root_session_id,
             tool_env_provider,
             agent_tool_runtime,
+            None,
         )
         .await;
         results.push(result);
@@ -146,6 +148,7 @@ async fn execute_tool_calls_parallel(
 ) -> Vec<ToolResult> {
     let tool_env_provider = tool_env_provider.cloned();
     let agent_tool_runtime = agent_tool_runtime.clone();
+    let write_locks = new_batch_write_locks();
     let futures: Vec<_> = tool_calls
         .iter()
         .map(|tc| {
@@ -159,6 +162,7 @@ async fn execute_tool_calls_parallel(
             let tool_hooks = tool_hooks.cloned();
             let tool_env_provider = tool_env_provider.clone();
             let agent_tool_runtime = agent_tool_runtime.clone();
+            let write_locks = Some(write_locks.clone());
             let access_denial = config.tool_access_denial_reason(&tc.name);
             // Look up the tool before spawning since ToolRegistry is not Send.
             let registered_tool = if access_denial.is_none() {
@@ -180,6 +184,7 @@ async fn execute_tool_calls_parallel(
                     &root_session_id,
                     tool_env_provider.as_ref(),
                     &agent_tool_runtime,
+                    write_locks,
                 )
                 .await
             }
@@ -232,6 +237,7 @@ async fn execute_question_tool_round(
                     root_session_id,
                     tool_env_provider,
                     agent_tool_runtime,
+                    None,
                 )
                 .await,
             );
@@ -319,6 +325,7 @@ pub async fn execute_and_emit_one_tool(
         root_session_id,
         tool_env_provider,
         &AgentToolRuntime::default(),
+        None,
     )
     .await
 }
@@ -339,6 +346,7 @@ async fn execute_and_emit_one_tool_with_runtime(
     root_session_id: &str,
     tool_env_provider: Option<&Arc<dyn ToolEnvProvider>>,
     agent_tool_runtime: &AgentToolRuntime,
+    write_locks: Option<BatchWriteLocks>,
 ) -> ToolResult {
     let access_denial = config.tool_access_denial_reason(&tc.name);
     let registered_tool = if access_denial.is_none() {
@@ -359,6 +367,7 @@ async fn execute_and_emit_one_tool_with_runtime(
         root_session_id,
         tool_env_provider,
         agent_tool_runtime,
+        write_locks,
     )
     .await
 }
@@ -382,6 +391,7 @@ async fn execute_and_emit_one_tool_with_lookup(
     root_session_id: &str,
     tool_env_provider: Option<&Arc<dyn ToolEnvProvider>>,
     agent_tool_runtime: &AgentToolRuntime,
+    write_locks: Option<BatchWriteLocks>,
 ) -> ToolResult {
     emit_tool_call_started(emitter, session_id, tc);
 
@@ -416,6 +426,7 @@ async fn execute_and_emit_one_tool_with_lookup(
         root_session_id,
         tool_env_provider,
         agent_tool_runtime,
+        write_locks,
     )
     .await;
 
@@ -461,6 +472,7 @@ async fn execute_one_tool(
     root_session_id: &str,
     tool_env_provider: Option<&Arc<dyn ToolEnvProvider>>,
     agent_tool_runtime: &AgentToolRuntime,
+    write_locks: Option<BatchWriteLocks>,
 ) -> ToolResult {
     match registered_tool {
         Some(tool) => {
@@ -482,6 +494,7 @@ async fn execute_one_tool(
                 env,
                 cancel: cancel_token,
                 tool_env_provider: tool_env_provider.cloned(),
+                write_locks,
                 session_id: Some(session_id.to_owned()),
                 root_session_id: Some(root_session_id.to_owned()),
                 tool_call_id: Some(tc.id.clone()),

--- a/lib/components/fabro-agent/src/tool_registry.rs
+++ b/lib/components/fabro-agent/src/tool_registry.rs
@@ -13,6 +13,7 @@ use crate::sandbox::Sandbox;
 use crate::session::ToolEnvProvider;
 use crate::tool_permissions;
 use crate::types::AgentEvent;
+use crate::write_locks::BatchWriteLocks;
 
 /// Narrow handle a tool uses to publish typed agent events (e.g. todo
 /// mutations) onto the active session's event stream. The implementation
@@ -26,6 +27,10 @@ pub struct ToolContext {
     pub env:                 Arc<dyn Sandbox>,
     pub cancel:              CancellationToken,
     pub tool_env_provider:   Option<Arc<dyn ToolEnvProvider>>,
+    /// Per-batch write locks for parallel tool calls. `None` outside parallel
+    /// dispatch (sequential rounds and direct executor tests have no
+    /// same-batch contention). See `crate::write_locks`.
+    pub write_locks:         Option<BatchWriteLocks>,
     /// Emitting session's ID. `None` when a tool is invoked outside of a
     /// session (e.g. ad-hoc unit tests).
     pub session_id:          Option<String>,
@@ -498,6 +503,7 @@ mod tests {
 
         let env: Arc<dyn Sandbox> = Arc::new(MockSandbox::default());
         let ctx = ToolContext {
+            write_locks: None,
             env,
             cancel: CancellationToken::new(),
             tool_env_provider: None,

--- a/lib/components/fabro-agent/src/tools.rs
+++ b/lib/components/fabro-agent/src/tools.rs
@@ -15,6 +15,7 @@ use crate::sandbox::{ExecStreamingResult, GrepOptions};
 use crate::tool_registry::{RegisteredTool, ToolContext, ToolRegistry, ToolSource};
 use crate::types::AgentEvent;
 use crate::web_search::{SearchBackend, make_web_search_tool};
+use crate::write_locks;
 
 const MAX_WEB_FETCH_BYTES: usize = 100 * 1024;
 const MAX_READ_MANY_FILES_CONCURRENCY: usize = 8;
@@ -166,6 +167,14 @@ pub fn make_write_file_tool() -> RegisteredTool {
                 let file_path = required_str(&args, "file_path")?;
                 let content = required_str(&args, "content")?;
 
+                // Serialize same-file writes within one parallel batch so a
+                // write_file cannot interleave with an edit_file's
+                // read-modify-write span on the same path.
+                let _write_guard = match ctx.write_locks.as_ref() {
+                    Some(locks) => Some(write_locks::lock_write_path(locks, file_path).await),
+                    None => None,
+                };
+
                 ctx.env
                     .write_file(file_path, content)
                     .await
@@ -203,6 +212,15 @@ pub fn make_edit_file_tool() -> RegisteredTool {
                     .get("replace_all")
                     .and_then(serde_json::Value::as_bool)
                     .unwrap_or(false);
+
+                // Hold the per-path write lock across the whole
+                // read-modify-write span: parallel edit_file calls to the
+                // same file otherwise read identical base content and the
+                // last write silently discards the other call's edit.
+                let _write_guard = match ctx.write_locks.as_ref() {
+                    Some(locks) => Some(write_locks::lock_write_path(locks, file_path).await),
+                    None => None,
+                };
 
                 let raw_content = ctx
                     .env
@@ -728,11 +746,12 @@ mod tests {
     use crate::event::{Emitter, SessionBoundEmitter};
     use crate::local_sandbox::LocalSandbox;
     use crate::sandbox::*;
-    use crate::test_support::MockSandbox;
+    use crate::test_support::{MockSandbox, SlowWriteMockSandbox};
     use crate::tool_registry::ToolContext;
     use crate::truncation;
     use crate::types::SessionEvent;
     use crate::web_search::make_web_search_tool_with_api_key;
+    use crate::write_locks::{self, BatchWriteLocks};
 
     #[test]
     fn core_tool_descriptions_include_actionable_guidance() {
@@ -824,6 +843,7 @@ mod tests {
             ..Default::default()
         });
         let result = (tool.executor)(serde_json::json!({"file_path": "/test.txt"}), ToolContext {
+            write_locks: None,
             env,
             cancel: CancellationToken::new(),
             tool_env_provider: None,
@@ -849,6 +869,7 @@ mod tests {
         });
 
         let result = (tool.executor)(serde_json::json!({"file_path": "/test.txt"}), ToolContext {
+            write_locks: None,
             env,
             cancel: CancellationToken::new(),
             tool_env_provider: None,
@@ -876,6 +897,7 @@ mod tests {
         let result = (tool.executor)(
             serde_json::json!({"file_path": "/test.txt", "offset": 2, "limit": 2}),
             ToolContext {
+                write_locks: None,
                 env,
                 cancel: CancellationToken::new(),
                 tool_env_provider: None,
@@ -889,6 +911,93 @@ mod tests {
         assert_eq!(result.unwrap(), "2 | line2\n3 | line3\n");
     }
 
+    fn locked_ctx(env: Arc<dyn Sandbox>, locks: &BatchWriteLocks) -> ToolContext {
+        ToolContext {
+            env,
+            cancel: CancellationToken::new(),
+            tool_env_provider: None,
+            write_locks: Some(locks.clone()),
+            session_id: None,
+            root_session_id: None,
+            tool_call_id: None,
+            agent_event_emitter: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn parallel_edit_file_calls_to_same_file_apply_both_edits() {
+        // Reproduces run 01M0NJZGX7BMJAJC3CZJZ0RNT0: two edit_file calls to
+        // one file in a single parallel batch read identical base content and
+        // the last write silently discarded the other edit. The per-path
+        // write lock serializes the read-modify-write span so both land.
+        // The slow writes force the interleaving instant mocks would hide.
+        let tool = make_edit_file_tool();
+        let env = Arc::new(SlowWriteMockSandbox::new(
+            HashMap::from([("/main.go".to_string(), "alpha beta".to_string())]),
+            25,
+        ));
+        let locks = write_locks::new_batch_write_locks();
+
+        let first = (tool.executor)(
+            serde_json::json!({
+                "file_path": "/main.go",
+                "old_string": "alpha",
+                "new_string": "ALPHA"
+            }),
+            locked_ctx(env.clone() as Arc<dyn Sandbox>, &locks),
+        );
+        let second = (tool.executor)(
+            serde_json::json!({
+                "file_path": "/main.go",
+                "old_string": "beta",
+                "new_string": "BETA"
+            }),
+            locked_ctx(env.clone() as Arc<dyn Sandbox>, &locks),
+        );
+        let (first, second) = tokio::join!(first, second);
+
+        assert!(first.is_ok(), "first edit failed: {:?}", first.err());
+        assert!(second.is_ok(), "second edit failed: {:?}", second.err());
+        let content = env.inner.read_file_text("/main.go").await.unwrap();
+        assert_eq!(content, "ALPHA BETA");
+    }
+
+    #[tokio::test]
+    async fn parallel_edit_file_calls_to_different_files_still_apply() {
+        let tool = make_edit_file_tool();
+        let env = Arc::new(SlowWriteMockSandbox::new(
+            HashMap::from([
+                ("/a.go".to_string(), "alpha".to_string()),
+                ("/b.go".to_string(), "beta".to_string()),
+            ]),
+            25,
+        ));
+        let locks = write_locks::new_batch_write_locks();
+
+        let first = (tool.executor)(
+            serde_json::json!({
+                "file_path": "/a.go",
+                "old_string": "alpha",
+                "new_string": "ALPHA"
+            }),
+            locked_ctx(env.clone() as Arc<dyn Sandbox>, &locks),
+        );
+        let second = (tool.executor)(
+            serde_json::json!({
+                "file_path": "/b.go",
+                "old_string": "beta",
+                "new_string": "BETA"
+            }),
+            locked_ctx(env.clone() as Arc<dyn Sandbox>, &locks),
+        );
+        let (first, second) = tokio::join!(first, second);
+
+        assert!(first.is_ok(), "first edit failed: {:?}", first.err());
+        assert!(second.is_ok(), "second edit failed: {:?}", second.err());
+        assert_eq!(env.inner.read_file_text("/a.go").await.unwrap(), "ALPHA");
+        assert_eq!(env.inner.read_file_text("/b.go").await.unwrap(), "BETA");
+    }
+
     #[tokio::test]
     async fn write_file_calls_env() {
         let tool = make_write_file_tool();
@@ -897,6 +1006,7 @@ mod tests {
         let result = (tool.executor)(
             serde_json::json!({"file_path": "/out.txt", "content": "hello"}),
             ToolContext {
+                write_locks:         None,
                 env:                 env_clone,
                 cancel:              CancellationToken::new(),
                 tool_env_provider:   None,
@@ -932,6 +1042,7 @@ mod tests {
                 "new_string": "goodbye"
             }),
             ToolContext {
+                write_locks:         None,
                 env:                 env_clone,
                 cancel:              CancellationToken::new(),
                 tool_env_provider:   None,
@@ -965,6 +1076,7 @@ mod tests {
                 "new_string": "replacement"
             }),
             ToolContext {
+                write_locks: None,
                 env,
                 cancel: CancellationToken::new(),
                 tool_env_provider: None,
@@ -994,6 +1106,7 @@ mod tests {
                 "new_string": "cc"
             }),
             ToolContext {
+                write_locks: None,
                 env,
                 cancel: CancellationToken::new(),
                 tool_env_provider: None,
@@ -1027,6 +1140,7 @@ mod tests {
                 "replace_all": true
             }),
             ToolContext {
+                write_locks:         None,
                 env:                 env_clone,
                 cancel:              CancellationToken::new(),
                 tool_env_provider:   None,
@@ -1060,6 +1174,7 @@ mod tests {
                 "new_string": "goodbye"
             }),
             ToolContext {
+                write_locks:         None,
                 env:                 env_clone,
                 cancel:              CancellationToken::new(),
                 tool_env_provider:   None,
@@ -1078,6 +1193,7 @@ mod tests {
 
     fn shell_context(env: Arc<dyn Sandbox>) -> ToolContext {
         ToolContext {
+            write_locks: None,
             env,
             cancel: CancellationToken::new(),
             tool_env_provider: None,
@@ -1090,6 +1206,7 @@ mod tests {
 
     fn shell_context_with_emitter(env: Arc<dyn Sandbox>, emitter: &Emitter) -> ToolContext {
         ToolContext {
+            write_locks: None,
             session_id: Some("test-session".to_string()),
             root_session_id: Some("test-session".to_string()),
             tool_call_id: Some("call_1".to_string()),
@@ -1176,6 +1293,7 @@ mod tests {
         let _result = (tool.executor)(
             serde_json::json!({"command": "sleep 1", "timeout_ms": 5000}),
             ToolContext {
+                write_locks:         None,
                 env:                 env_clone,
                 cancel:              CancellationToken::new(),
                 tool_env_provider:   None,
@@ -1451,6 +1569,7 @@ mod tests {
         let _result = (tool.executor)(
             serde_json::json!({"command": "echo $MY_KEY"}),
             ToolContext {
+                write_locks:         None,
                 env:                 env_clone,
                 cancel:              CancellationToken::new(),
                 tool_env_provider:   Some(Arc::new(crate::StaticEnvProvider(tool_env.clone()))),
@@ -1499,6 +1618,7 @@ mod tests {
         let _result = (tool.executor)(
             serde_json::json!({"command": "echo $GITHUB_TOKEN"}),
             ToolContext {
+                write_locks:         None,
                 env:                 env.clone(),
                 cancel:              CancellationToken::new(),
                 tool_env_provider:   Some(provider.clone()),
@@ -1520,6 +1640,7 @@ mod tests {
         let _result = (tool.executor)(
             serde_json::json!({"command": "echo $GITHUB_TOKEN"}),
             ToolContext {
+                write_locks:         None,
                 env:                 env.clone(),
                 cancel:              CancellationToken::new(),
                 tool_env_provider:   Some(provider),
@@ -1547,6 +1668,7 @@ mod tests {
         let result = (tool.executor)(
             serde_json::json!({"command": "echo $GITHUB_TOKEN"}),
             ToolContext {
+                write_locks: None,
                 env,
                 cancel: CancellationToken::new(),
                 tool_env_provider: Some(Arc::new(FailingToolEnvProvider)),
@@ -1576,6 +1698,7 @@ mod tests {
         });
 
         let result = (tool.executor)(serde_json::json!({"file_path": "/test.txt"}), ToolContext {
+            write_locks: None,
             env,
             cancel: CancellationToken::new(),
             tool_env_provider: Some(Arc::new(FailingToolEnvProvider)),
@@ -1595,6 +1718,7 @@ mod tests {
         let env = Arc::new(MockSandbox::default());
         let env_clone: Arc<dyn Sandbox> = env.clone();
         let _result = (tool.executor)(serde_json::json!({"command": "echo hello"}), ToolContext {
+            write_locks:         None,
             env:                 env_clone,
             cancel:              CancellationToken::new(),
             tool_env_provider:   None,
@@ -1627,6 +1751,7 @@ mod tests {
         let _result = (tool.executor)(
             serde_json::json!({"url": "https://example.com"}),
             ToolContext {
+                write_locks:         None,
                 env:                 env_clone,
                 cancel:              CancellationToken::new(),
                 tool_env_provider:   Some(Arc::new(crate::StaticEnvProvider(tool_env.clone()))),
@@ -1652,6 +1777,7 @@ mod tests {
             ..Default::default()
         });
         let result = (tool.executor)(serde_json::json!({"pattern": "fn"}), ToolContext {
+            write_locks: None,
             env,
             cancel: CancellationToken::new(),
             tool_env_provider: None,
@@ -1674,6 +1800,7 @@ mod tests {
             ..Default::default()
         });
         let result = (tool.executor)(serde_json::json!({"pattern": "src/**/*.rs"}), ToolContext {
+            write_locks: None,
             env,
             cancel: CancellationToken::new(),
             tool_env_provider: None,
@@ -1702,6 +1829,7 @@ mod tests {
         let tool = make_web_search_tool_with_api_key("fake-key".into());
         let env: Arc<dyn Sandbox> = Arc::new(MockSandbox::default());
         let result = (tool.executor)(serde_json::json!({}), ToolContext {
+            write_locks: None,
             env,
             cancel: CancellationToken::new(),
             tool_env_provider: None,
@@ -1736,6 +1864,7 @@ mod tests {
             .expect("web_search should be registered");
         let env: Arc<dyn Sandbox> = Arc::new(MockSandbox::default());
         let result = (tool.executor)(serde_json::json!({}), ToolContext {
+            write_locks: None,
             env,
             cancel: CancellationToken::new(),
             tool_env_provider: None,
@@ -1770,6 +1899,7 @@ mod tests {
         let result = (tool.executor)(
             serde_json::json!({"url": "https://example.com"}),
             ToolContext {
+                write_locks:         None,
                 env:                 env_clone,
                 cancel:              CancellationToken::new(),
                 tool_env_provider:   None,
@@ -1811,6 +1941,7 @@ mod tests {
         let result = (tool.executor)(
             serde_json::json!({"url": "ftp://example.com/file"}),
             ToolContext {
+                write_locks: None,
                 env,
                 cancel: CancellationToken::new(),
                 tool_env_provider: None,
@@ -1836,6 +1967,7 @@ mod tests {
         let _result = (tool.executor)(
             serde_json::json!({"url": "https://example.com", "timeout_ms": 15000}),
             ToolContext {
+                write_locks:         None,
                 env:                 env_clone,
                 cancel:              CancellationToken::new(),
                 tool_env_provider:   None,
@@ -1862,6 +1994,7 @@ mod tests {
         let _result = (tool.executor)(
             serde_json::json!({"url": "https://example.com", "timeout_ms": 120_000}),
             ToolContext {
+                write_locks:         None,
                 env:                 env_clone,
                 cancel:              CancellationToken::new(),
                 tool_env_provider:   None,
@@ -1897,6 +2030,7 @@ mod tests {
         let result = (tool.executor)(
             serde_json::json!({"url": "https://example.com"}),
             ToolContext {
+                write_locks: None,
                 env,
                 cancel: CancellationToken::new(),
                 tool_env_provider: None,
@@ -1928,6 +2062,7 @@ mod tests {
         let result = (tool.executor)(
             serde_json::json!({"url": "https://nonexistent.example.com"}),
             ToolContext {
+                write_locks: None,
                 env,
                 cancel: CancellationToken::new(),
                 tool_env_provider: None,
@@ -1980,6 +2115,7 @@ mod tests {
         let result = (tool.executor)(
             serde_json::json!({"url": "https://example.com", "prompt": "What is Rust?"}),
             ToolContext {
+                write_locks: None,
                 env,
                 cancel: CancellationToken::new(),
                 tool_env_provider: None,
@@ -2015,6 +2151,7 @@ mod tests {
         let result = (tool.executor)(
             serde_json::json!({"url": "https://example.com", "prompt": "What is Rust?"}),
             ToolContext {
+                write_locks: None,
                 env,
                 cancel: CancellationToken::new(),
                 tool_env_provider: None,
@@ -2088,6 +2225,7 @@ mod tests {
         let result = (tool.executor)(
             serde_json::json!({"url": "https://example.com", "prompt": "Summarize this"}),
             ToolContext {
+                write_locks: None,
                 env,
                 cancel: CancellationToken::new(),
                 tool_env_provider: None,
@@ -2146,6 +2284,7 @@ mod tests {
         let result = (tool.executor)(
             serde_json::json!({"query": "rust programming language"}),
             ToolContext {
+                write_locks: None,
                 env,
                 cancel: CancellationToken::new(),
                 tool_env_provider: None,

--- a/lib/components/fabro-agent/src/web_search.rs
+++ b/lib/components/fabro-agent/src/web_search.rs
@@ -322,6 +322,7 @@ mod tests {
     async fn execute(tool: &RegisteredTool, args: serde_json::Value) -> Result<String, String> {
         let env: Arc<dyn Sandbox> = Arc::new(MockSandbox::default());
         (tool.executor)(args, ToolContext {
+            write_locks: None,
             env,
             cancel: CancellationToken::new(),
             tool_env_provider: None,

--- a/lib/components/fabro-agent/src/write_locks.rs
+++ b/lib/components/fabro-agent/src/write_locks.rs
@@ -1,0 +1,99 @@
+//! Per-path serialization for parallel write tools.
+//!
+//! `edit_file` mutates a file with a read-modify-write cycle against the
+//! sandbox. When one assistant response fans out multiple write calls to the
+//! same file, unconstrained parallel execution lets them clobber each other:
+//! both calls read the same base content, each writes its own variant, and
+//! the last write silently discards the other call's edit (observed in run
+//! `01M0NJZGX7BMJAJC3CZJZ0RNT0`: two parallel `edit_file` calls to `main.go`
+//! lost a `strconv` import and two call-site updates).
+//!
+//! The dispatcher creates one [`BatchWriteLocks`] map per parallel tool-call
+//! batch and threads it into the executors via
+//! [`crate::tool_registry::ToolContext`]. Write tools acquire the per-path
+//! mutex for the whole read-modify-write span, so same-file calls serialize
+//! while different-file calls stay concurrent. Locking is best-effort by
+//! lexical path: keys are normalized without touching the filesystem (the
+//! sandbox may be remote) and different spellings of the same file simply fail
+//! to share a lock.
+
+use std::collections::HashMap;
+use std::path::{Component, Path, PathBuf};
+use std::sync::{Arc, Mutex};
+
+use tokio::sync::{Mutex as AsyncMutex, OwnedMutexGuard};
+
+/// Per-batch map from normalized path to that path's write mutex.
+pub type BatchWriteLocks = Arc<Mutex<HashMap<PathBuf, Arc<AsyncMutex<()>>>>>;
+
+/// Create the lock map for one parallel tool-call batch.
+#[must_use]
+pub fn new_batch_write_locks() -> BatchWriteLocks {
+    Arc::default()
+}
+
+/// Lexically normalize a path for use as a lock key: drop `.` components and
+/// resolve `..` without filesystem access.
+fn lock_key(path: &str) -> PathBuf {
+    let mut normalized = PathBuf::new();
+    for component in Path::new(path).components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                normalized.pop();
+            }
+            other => normalized.push(other.as_os_str()),
+        }
+    }
+    normalized
+}
+
+/// Acquire the write lock for `path`, warning when another same-batch write
+/// call already holds it (the silent-clobber case this module exists for).
+pub async fn lock_write_path(locks: &BatchWriteLocks, path: &str) -> OwnedMutexGuard<()> {
+    let mutex = {
+        let mut map = locks.lock().expect("write lock map poisoned");
+        map.entry(lock_key(path))
+            .or_insert_with(|| Arc::new(AsyncMutex::new(())))
+            .clone()
+    };
+    match mutex.clone().try_lock_owned() {
+        Ok(guard) => guard,
+        Err(_would_block) => {
+            tracing::warn!(
+                path = path,
+                "concurrent write to the same file in one batch; serializing",
+            );
+            mutex.lock_owned().await
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lock_key_normalizes_lexically() {
+        assert_eq!(lock_key("/a/./b/c.go"), PathBuf::from("/a/b/c.go"));
+        assert_eq!(lock_key("/a/b/../c.go"), PathBuf::from("/a/c.go"));
+        assert_eq!(lock_key("relative.go"), PathBuf::from("relative.go"));
+    }
+
+    #[tokio::test]
+    async fn same_path_serializes_and_different_paths_do_not() {
+        let locks = new_batch_write_locks();
+        let first = lock_write_path(&locks, "/a/./b/c.go").await;
+        assert!(
+            locks
+                .lock()
+                .unwrap()
+                .get(&PathBuf::from("/a/b/c.go"))
+                .is_some()
+        );
+        drop(first);
+
+        let _a = lock_write_path(&locks, "/x.go").await;
+        let _b = lock_write_path(&locks, "/y.go").await;
+    }
+}

--- a/lib/components/fabro-agent/tests/it/docker_shell.rs
+++ b/lib/components/fabro-agent/tests/it/docker_shell.rs
@@ -44,6 +44,7 @@ async fn shell_reports_real_docker_process_outcome() {
     let result = (tool.executor)(
         serde_json::json!({"command": "printf 'out'; printf 'err' >&2; exit 7"}),
         ToolContext {
+            write_locks:         None,
             env:                 sandbox.clone() as Arc<dyn Sandbox>,
             cancel:              CancellationToken::new(),
             tool_env_provider:   None,

--- a/lib/components/fabro-hooks/src/executor.rs
+++ b/lib/components/fabro-hooks/src/executor.rs
@@ -424,6 +424,7 @@ impl HookExecutorImpl {
                         env:                 sandbox.clone(),
                         cancel:              cancel.child_token(),
                         tool_env_provider:   None,
+                        write_locks:         None,
                         session_id:          None,
                         root_session_id:     None,
                         tool_call_id:        Some(tc.id.clone()),


### PR DESCRIPTION
## Problem

When one assistant response fans out multiple write tool calls to the **same file**, parallel execution silently clobbers them. `edit_file` is a read-modify-write cycle (`read_file_text` → replace → `write_existing_file`); unconstrained `join_all` dispatch let two calls read identical base content and the last write discarded the other call's edit.

Observed in a real run: two parallel `edit_file` calls to `main.go` (1 ms apart) reported success, but a `strconv` import and two `run()` call-site updates were silently lost — only caught later by `go vet`. A silent lost edit is worse than a failed one: the model believes its edit landed.

## Fix

- The parallel dispatcher creates one **per-batch write-lock map** (`write_locks.rs`) and threads it into `ToolContext`.
- `edit_file` and `write_file` acquire a **per-path tokio mutex** for their whole write span:
  - same-file calls in one batch serialize — every edit lands;
  - different-file calls stay fully concurrent;
  - a `warn!` fires when same-path writes actually contend.
- Lock keys are lexically normalized (`.`/`..` resolved without filesystem access — the sandbox may be remote).
- Sequential dispatch passes no locks (no same-batch contention by construction).

## Tests

- Regression: two parallel `edit_file` calls to one file, forced interleaving via a slow-write sandbox — **fails on `main`, passes with the lock** (both edits land: `ALPHA BETA`).
- Session-level contract: one LLM response with two same-file `edit_file` calls lands both.
- Control: parallel edits to different files still work.

## Scope / limitations

- `apply_patch` (multi-file) has the same hazard class and is **not covered yet** — it needs sorted multi-path lock acquisition; happy to follow up.
- Cross-batch and cross-session writes on a shared sandbox (e.g. parallel workflow stages in one container) are out of scope for this fix.

Docs: `docs/public/agents/tools.mdx` "Parallel execution" now states the guarantee.