### PR TITLE
Extend Daytona snapshot activation timeout

### DIFF
--- a/docs/public/integrations/daytona.mdx
+++ b/docs/public/integrations/daytona.mdx
@@ -231,7 +231,7 @@ Custom Daytona snapshot names are computed from the Dockerfile, resource hints, 
 
 ### "Timed out waiting for snapshot to become active"
 
-Snapshot creation took longer than 10 minutes. This can happen with large Dockerfiles. Check the snapshot status in the Daytona dashboard — it may still be building. Subsequent runs will reuse the snapshot once it's active.
+Snapshot creation took longer than 30 minutes. This can happen with large Dockerfiles. Check the snapshot status in the Daytona dashboard — it may still be building. Subsequent runs will reuse the snapshot once it's active.
 
 ### Git clone fails for private repositories
 

--- a/lib/components/fabro-sandbox/src/daytona/mod.rs
+++ b/lib/components/fabro-sandbox/src/daytona/mod.rs
@@ -76,6 +76,8 @@ const DAYTONA_POST_CLONE_SETUP_TIMEOUT: Duration = Duration::from_mins(5);
 /// Best-effort push-credential setup should not consume or extend the required
 /// post-clone setup budget.
 const DAYTONA_CREDENTIAL_SETUP_TIMEOUT: Duration = Duration::from_secs(10);
+/// Budget for a custom snapshot to reach Daytona's active state.
+const DAYTONA_SNAPSHOT_ACTIVE_TIMEOUT: Duration = Duration::from_mins(30);
 /// Grace for the toolbox to return the server-side command timeout response.
 /// The SDK truncates the server timeout to whole seconds, so the server can
 /// fire up to one second before the shared deadline; this additional grace
@@ -1121,7 +1123,7 @@ impl DaytonaSandbox {
         use daytona_api_client::models::SnapshotState;
         let mut delay = std::time::Duration::from_secs(2);
         let max_delay = std::time::Duration::from_secs(30);
-        let deadline = Instant::now() + std::time::Duration::from_mins(10);
+        let deadline = Instant::now() + DAYTONA_SNAPSHOT_ACTIVE_TIMEOUT;
 
         while Instant::now() < deadline {
             time::sleep(delay).await;


### PR DESCRIPTION
## Summary

- increase the Daytona custom snapshot activation timeout from 10 to 30 minutes
- name the timeout budget in the sandbox provider
- update the Daytona troubleshooting documentation

## Validation

- cargo +nightly-2026-04-14 fmt --check --all
- cargo +nightly-2026-04-14 clippy -p fabro-sandbox --all-targets --all-features -- -D warnings
- cargo nextest run -p fabro-sandbox --all-features (286 passed, 10 skipped)