### PR TITLE
fix(github): name both causes of an installation lookup 404

### DIFF
--- a/lib/components/fabro-github/src/lib.rs
+++ b/lib/components/fabro-github/src/lib.rs
@@ -617,8 +617,8 @@ async fn mint_installation_token_with_jwt(
                 str::to_string,
             );
             bail!(
-                "GitHub App is not installed for {owner}. \
-                 Install it at {install_url}"
+                "GitHub App is not installed for {owner}, or its installation does not \
+                 include {owner}/{primary_repo}. Check repository access at {install_url}"
             );
         }
         InstallationLookup::Failed(403) => {


### PR DESCRIPTION
## Problem

When preflight's Repository Access check fails, the error can claim the GitHub App is not installed when it actually is:

```
Repository Access — Failed to verify repository access: Failed to resolve GitHub credentials: GitHub App is not installed for veniceai. Install it at https://github.com/organizations/veniceai/settings/apps/venice-fabro/installations
```

`GET /repos/{owner}/{repo}/installation` returns 404 in two distinct cases:

1. The App is not installed for the owner at all.
2. The App is installed, but the installation's repository selection ("Only select repositories") does not include this repository.

The `InstallationLookup::NotFound` doc comment already records this ambiguity, but the single-repository mint path reported only cause 1. A user whose App is installed but not scoped to the repository gets told to install an App that is already installed. (The multi-repository path in `access.rs` already names the repository correctly.)

## Fix

Cheap wording fix: the error now names both possible causes and the specific repository:

> GitHub App is not installed for {owner}, or its installation does not include {owner}/{repo}. Check repository access at {install_url}

A follow-up could disambiguate for real with a second lookup (`GET /orgs/{owner}/installation`) and report exactly one cause.

## Testing

- `cargo test -p fabro-github` — 82 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)