### PR TITLE
Add --name to fabro mcp config and fabro mcp init

### DIFF
--- a/docs/public/agents/mcp.mdx
+++ b/docs/public/agents/mcp.mdx
@@ -28,6 +28,15 @@ fabro mcp start
 
 Pass `--server` when the MCP client should connect to a specific Fabro server, or `--storage-dir` when it should use a non-default CLI storage directory.
 
+Both commands register the entry under the `mcpServers` key `fabro` by default. Pass `--name` to choose a different key. Each named entry launches its own single-target `fabro mcp start` process, so you can register more than one Fabro server in the same MCP client:
+
+```bash
+fabro mcp init claude --name fabro-production --server https://fabro.example.com
+fabro mcp init claude --name fabro-testing --server https://fabro-testing.example.com
+```
+
+`fabro mcp init` keeps entries with other names and replaces only the entry that matches `--name`.
+
 | Tool | Purpose |
 |---|---|
 | `fabro_run_create` | Create one or more workflow runs, optionally under a parent run, starting them by default. |

--- a/docs/public/reference/cli.mdx
+++ b/docs/public/reference/cli.mdx
@@ -611,6 +611,7 @@ fabro mcp config [OPTIONS]
 
 | Option | Description |
 | --- | --- |
+| `--name <name>` | Name of the mcpServers entry; use distinct names to register multiple Fabro servers (default: fabro) |
 | `--server <server>` | Fabro server target: http(s) URL or absolute Unix socket path |
 | `--storage-dir <storage_dir>` | Local storage directory (default: ~/.fabro/storage) |
 
@@ -632,6 +633,7 @@ fabro mcp init [OPTIONS] <AGENT>
 
 | Option | Description |
 | --- | --- |
+| `--name <name>` | Name of the mcpServers entry; use distinct names to register multiple Fabro servers (default: fabro) |
 | `--server <server>` | Fabro server target: http(s) URL or absolute Unix socket path |
 | `--storage-dir <storage_dir>` | Local storage directory (default: ~/.fabro/storage) |
 

--- a/docs/public/reference/cli.mdx
+++ b/docs/public/reference/cli.mdx
@@ -611,7 +611,7 @@ fabro mcp config [OPTIONS]
 
 | Option | Description |
 | --- | --- |
-| `--name <name>` | Name of the mcpServers entry; use distinct names to register multiple Fabro servers (default: fabro) |
+| `--name <name>` | Name of the mcpServers entry; use distinct names to register multiple Fabro servers<br />Default: `fabro` |
 | `--server <server>` | Fabro server target: http(s) URL or absolute Unix socket path |
 | `--storage-dir <storage_dir>` | Local storage directory (default: ~/.fabro/storage) |
 
@@ -633,7 +633,7 @@ fabro mcp init [OPTIONS] <AGENT>
 
 | Option | Description |
 | --- | --- |
-| `--name <name>` | Name of the mcpServers entry; use distinct names to register multiple Fabro servers (default: fabro) |
+| `--name <name>` | Name of the mcpServers entry; use distinct names to register multiple Fabro servers<br />Default: `fabro` |
 | `--server <server>` | Fabro server target: http(s) URL or absolute Unix socket path |
 | `--storage-dir <storage_dir>` | Local storage directory (default: ~/.fabro/storage) |
 

--- a/lib/apps/fabro-cli/src/args.rs
+++ b/lib/apps/fabro-cli/src/args.rs
@@ -206,13 +206,8 @@ pub(crate) struct McpConfigArgs {
 pub(crate) struct McpInitArgs {
     pub(crate) agent: McpAgent,
 
-    /// Name of the mcpServers entry; use distinct names to register multiple
-    /// Fabro servers
-    #[arg(long, value_name = "NAME", default_value = fabro_mcp_server::SERVER_NAME, value_parser = clap::builder::NonEmptyStringValueParser::new())]
-    pub(crate) name: String,
-
     #[command(flatten)]
-    pub(crate) connection: ServerConnectionArgs,
+    pub(crate) config: McpConfigArgs,
 }
 
 #[derive(Debug, Clone, Copy, ValueEnum)]

--- a/lib/apps/fabro-cli/src/args.rs
+++ b/lib/apps/fabro-cli/src/args.rs
@@ -191,8 +191,13 @@ pub(crate) struct McpStartArgs {
     pub(crate) connection: ServerConnectionArgs,
 }
 
-#[derive(Args, Debug, Clone, Default)]
+#[derive(Args, Debug, Clone)]
 pub(crate) struct McpConfigArgs {
+    /// Name of the mcpServers entry; use distinct names to register multiple
+    /// Fabro servers
+    #[arg(long, value_name = "NAME", default_value = fabro_mcp_server::SERVER_NAME, value_parser = clap::builder::NonEmptyStringValueParser::new())]
+    pub(crate) name: String,
+
     #[command(flatten)]
     pub(crate) connection: ServerConnectionArgs,
 }
@@ -200,6 +205,11 @@ pub(crate) struct McpConfigArgs {
 #[derive(Args, Debug, Clone)]
 pub(crate) struct McpInitArgs {
     pub(crate) agent: McpAgent,
+
+    /// Name of the mcpServers entry; use distinct names to register multiple
+    /// Fabro servers
+    #[arg(long, value_name = "NAME", default_value = fabro_mcp_server::SERVER_NAME, value_parser = clap::builder::NonEmptyStringValueParser::new())]
+    pub(crate) name: String,
 
     #[command(flatten)]
     pub(crate) connection: ServerConnectionArgs,

--- a/lib/apps/fabro-cli/src/commands/mcp/mod.rs
+++ b/lib/apps/fabro-cli/src/commands/mcp/mod.rs
@@ -2,7 +2,9 @@ use std::fmt::Write as _;
 
 use anyhow::{Context as _, Result};
 
-use crate::args::{McpAgent, McpCommand, McpInitArgs, McpNamespace, ServerConnectionArgs};
+use crate::args::{
+    McpAgent, McpCommand, McpConfigArgs, McpInitArgs, McpNamespace, ServerConnectionArgs,
+};
 use crate::command_context::CommandContext;
 use crate::server_client;
 
@@ -12,8 +14,7 @@ pub(crate) async fn dispatch(ns: McpNamespace, base_ctx: &CommandContext) -> Res
             fabro_mcp_server::start(server_settings(base_ctx, &args.connection)?).await
         }
         McpCommand::Config(args) => {
-            let json =
-                fabro_mcp_server::config_json(&config_settings(&args.name, &args.connection))?;
+            let json = fabro_mcp_server::config_json(&config_settings(&args))?;
             let _ = write!(base_ctx.printer().stdout_important(), "{json}");
             Ok(())
         }
@@ -60,19 +61,16 @@ fn server_settings(
 fn init_settings(args: &McpInitArgs) -> Result<fabro_mcp_server::McpInitSettings> {
     Ok(fabro_mcp_server::McpInitSettings {
         agent:    McpAgentForServer(args.agent).into(),
-        config:   config_settings(&args.name, &args.connection),
+        config:   config_settings(&args.config),
         home_dir: home_dir()?,
     })
 }
 
-fn config_settings(
-    name: &str,
-    connection: &ServerConnectionArgs,
-) -> fabro_mcp_server::McpConfigSettings {
+fn config_settings(args: &McpConfigArgs) -> fabro_mcp_server::McpConfigSettings {
     fabro_mcp_server::McpConfigSettings {
-        name:        name.to_string(),
-        server:      connection.target.server.clone(),
-        storage_dir: connection.storage_dir.clone_path(),
+        name:        args.name.clone(),
+        server:      args.connection.target.server.clone(),
+        storage_dir: args.connection.storage_dir.clone_path(),
     }
 }
 

--- a/lib/apps/fabro-cli/src/commands/mcp/mod.rs
+++ b/lib/apps/fabro-cli/src/commands/mcp/mod.rs
@@ -2,7 +2,7 @@ use std::fmt::Write as _;
 
 use anyhow::{Context as _, Result};
 
-use crate::args::{McpAgent, McpCommand, McpNamespace, ServerConnectionArgs};
+use crate::args::{McpAgent, McpCommand, McpInitArgs, McpNamespace, ServerConnectionArgs};
 use crate::command_context::CommandContext;
 use crate::server_client;
 
@@ -12,12 +12,13 @@ pub(crate) async fn dispatch(ns: McpNamespace, base_ctx: &CommandContext) -> Res
             fabro_mcp_server::start(server_settings(base_ctx, &args.connection)?).await
         }
         McpCommand::Config(args) => {
-            let json = fabro_mcp_server::config_json(&config_settings(&args.connection))?;
+            let json =
+                fabro_mcp_server::config_json(&config_settings(&args.name, &args.connection))?;
             let _ = write!(base_ctx.printer().stdout_important(), "{json}");
             Ok(())
         }
         McpCommand::Init(args) => {
-            fabro_mcp_server::init_agent(&init_settings(args.agent, &args.connection)?)?;
+            fabro_mcp_server::init_agent(&init_settings(&args)?)?;
             Ok(())
         }
     }
@@ -56,19 +57,20 @@ fn server_settings(
     })
 }
 
-fn init_settings(
-    agent: McpAgent,
-    connection: &ServerConnectionArgs,
-) -> Result<fabro_mcp_server::McpInitSettings> {
+fn init_settings(args: &McpInitArgs) -> Result<fabro_mcp_server::McpInitSettings> {
     Ok(fabro_mcp_server::McpInitSettings {
-        agent:    McpAgentForServer(agent).into(),
-        config:   config_settings(connection),
+        agent:    McpAgentForServer(args.agent).into(),
+        config:   config_settings(&args.name, &args.connection),
         home_dir: home_dir()?,
     })
 }
 
-fn config_settings(connection: &ServerConnectionArgs) -> fabro_mcp_server::McpConfigSettings {
+fn config_settings(
+    name: &str,
+    connection: &ServerConnectionArgs,
+) -> fabro_mcp_server::McpConfigSettings {
     fabro_mcp_server::McpConfigSettings {
+        name:        name.to_string(),
         server:      connection.target.server.clone(),
         storage_dir: connection.storage_dir.clone_path(),
     }

--- a/lib/apps/fabro-cli/tests/it/cmd/mcp.rs
+++ b/lib/apps/fabro-cli/tests/it/cmd/mcp.rs
@@ -122,10 +122,11 @@ fn config_help() {
 
     Options:
           --json                       Output as JSON [env: FABRO_JSON=]
-          --storage-dir <STORAGE_DIR>  Local storage directory (default: ~/.fabro/storage) [env: FABRO_STORAGE_DIR=]
+          --name <NAME>                Name of the mcpServers entry; use distinct names to register multiple Fabro servers [default: fabro]
           --debug                      Enable DEBUG-level logging (default is INFO) [env: FABRO_DEBUG=]
-          --server <SERVER>            Fabro server target: http(s) URL or absolute Unix socket path [env: FABRO_SERVER=]
+          --storage-dir <STORAGE_DIR>  Local storage directory (default: ~/.fabro/storage) [env: FABRO_STORAGE_DIR=]
           --no-upgrade-check           Disable automatic upgrade check [env: FABRO_NO_UPGRADE_CHECK=true]
+          --server <SERVER>            Fabro server target: http(s) URL or absolute Unix socket path [env: FABRO_SERVER=]
           --quiet                      Suppress non-essential output [env: FABRO_QUIET=]
           --verbose                    Enable verbose output [env: FABRO_VERBOSE=]
       -h, --help                       Print help
@@ -151,10 +152,11 @@ fn init_help() {
 
     Options:
           --json                       Output as JSON [env: FABRO_JSON=]
-          --storage-dir <STORAGE_DIR>  Local storage directory (default: ~/.fabro/storage) [env: FABRO_STORAGE_DIR=]
+          --name <NAME>                Name of the mcpServers entry; use distinct names to register multiple Fabro servers [default: fabro]
           --debug                      Enable DEBUG-level logging (default is INFO) [env: FABRO_DEBUG=]
-          --server <SERVER>            Fabro server target: http(s) URL or absolute Unix socket path [env: FABRO_SERVER=]
+          --storage-dir <STORAGE_DIR>  Local storage directory (default: ~/.fabro/storage) [env: FABRO_STORAGE_DIR=]
           --no-upgrade-check           Disable automatic upgrade check [env: FABRO_NO_UPGRADE_CHECK=true]
+          --server <SERVER>            Fabro server target: http(s) URL or absolute Unix socket path [env: FABRO_SERVER=]
           --quiet                      Suppress non-essential output [env: FABRO_QUIET=]
           --verbose                    Enable verbose output [env: FABRO_VERBOSE=]
       -h, --help                       Print help
@@ -219,6 +221,55 @@ fn config_preserves_connection_flags() {
     }
     ----- stderr -----
     "#);
+}
+
+#[test]
+fn config_uses_custom_entry_name() {
+    let context = test_context!();
+    let mut cmd = context.command();
+    cmd.args([
+        "mcp",
+        "config",
+        "--name",
+        "fabro-production",
+        "--server",
+        "https://fabro.example.test",
+    ]);
+    fabro_snapshot!(context.filters(), cmd, @r#"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    {
+      "mcpServers": {
+        "fabro-production": {
+          "command": "fabro",
+          "args": [
+            "mcp",
+            "start",
+            "--server",
+            "https://fabro.example.test"
+          ]
+        }
+      }
+    }
+    ----- stderr -----
+    "#);
+}
+
+#[test]
+fn config_rejects_empty_entry_name() {
+    let context = test_context!();
+    let mut cmd = context.command();
+    cmd.args(["mcp", "config", "--name", ""]);
+    fabro_snapshot!(context.filters(), cmd, @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+    ----- stderr -----
+    error: a value is required for '--name <NAME>' but none was supplied
+
+    For more information, try '--help'.
+    ");
 }
 
 #[test]
@@ -413,6 +464,91 @@ fn init_preserves_existing_servers() {
         }
       },
       "theme": "dark"
+    }
+    "#);
+}
+
+#[test]
+fn init_merges_multiple_named_fabro_entries() {
+    let context = test_context!();
+    context
+        .command()
+        .args(["mcp", "init", "cursor"])
+        .assert()
+        .success();
+    context
+        .command()
+        .args([
+            "mcp",
+            "init",
+            "cursor",
+            "--name",
+            "fabro-production",
+            "--server",
+            "https://production.example.test",
+        ])
+        .assert()
+        .success();
+    context
+        .command()
+        .args([
+            "mcp",
+            "init",
+            "cursor",
+            "--name",
+            "fabro-testing",
+            "--server",
+            "https://testing.example.test",
+        ])
+        .assert()
+        .success();
+    // Reusing a name updates only that entry.
+    context
+        .command()
+        .args([
+            "mcp",
+            "init",
+            "cursor",
+            "--name",
+            "fabro-production",
+            "--server",
+            "https://production.example.test:8443",
+        ])
+        .assert()
+        .success();
+
+    let config_path = context.home_dir.join(".cursor").join("mcp.json");
+    let config: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(config_path).unwrap()).unwrap();
+    fabro_json_snapshot!(context, config, @r#"
+    {
+      "mcpServers": {
+        "fabro": {
+          "command": "fabro",
+          "args": [
+            "mcp",
+            "start"
+          ]
+        },
+        "fabro-production": {
+          "command": "fabro",
+          "args": [
+            "mcp",
+            "start",
+            "--server",
+            "https://production.example.test:8443"
+          ]
+        },
+        "fabro-testing": {
+          "command": "fabro",
+          "args": [
+            "mcp",
+            "start",
+            "--server",
+            "https://testing.example.test"
+          ]
+        }
+      }
     }
     "#);
 }

--- a/lib/apps/fabro-mcp-server/src/config.rs
+++ b/lib/apps/fabro-mcp-server/src/config.rs
@@ -18,9 +18,8 @@ pub fn config_json(settings: &McpConfigSettings) -> Result<String> {
 }
 
 pub fn init_agent(settings: &McpInitSettings) -> Result<()> {
-    let entry = server_entry(&settings.config);
     for path in agent_config_paths(settings.agent, &settings.home_dir) {
-        merge_server_entry(&path, &settings.config.name, entry.clone())?;
+        merge_server_entry(&path, &settings.config)?;
     }
     Ok(())
 }
@@ -51,7 +50,7 @@ fn start_args(settings: &McpConfigSettings) -> Vec<String> {
     args
 }
 
-fn merge_server_entry(path: &Path, name: &str, entry: Value) -> Result<()> {
+fn merge_server_entry(path: &Path, settings: &McpConfigSettings) -> Result<()> {
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)
             .with_context(|| format!("failed to create {}", parent.display()))?;
@@ -78,7 +77,7 @@ fn merge_server_entry(path: &Path, name: &str, entry: Value) -> Result<()> {
             path.display()
         )
     })?;
-    servers_object.insert(name.to_string(), entry);
+    servers_object.insert(settings.name.clone(), server_entry(settings));
 
     let rendered = serde_json::to_string_pretty(&root)
         .map(|json| format!("{json}\n"))

--- a/lib/apps/fabro-mcp-server/src/config.rs
+++ b/lib/apps/fabro-mcp-server/src/config.rs
@@ -9,7 +9,7 @@ use anyhow::{Context as _, Result, anyhow};
 use serde_json::map::Entry;
 use serde_json::{Map, Value, json};
 
-use crate::{McpAgent, McpConfigSettings, McpInitSettings, SERVER_NAME};
+use crate::{McpAgent, McpConfigSettings, McpInitSettings};
 
 pub fn config_json(settings: &McpConfigSettings) -> Result<String> {
     serde_json::to_string_pretty(&generic_config(settings))
@@ -20,17 +20,15 @@ pub fn config_json(settings: &McpConfigSettings) -> Result<String> {
 pub fn init_agent(settings: &McpInitSettings) -> Result<()> {
     let entry = server_entry(&settings.config);
     for path in agent_config_paths(settings.agent, &settings.home_dir) {
-        merge_server_entry(&path, entry.clone())?;
+        merge_server_entry(&path, &settings.config.name, entry.clone())?;
     }
     Ok(())
 }
 
 fn generic_config(settings: &McpConfigSettings) -> Value {
-    json!({
-        "mcpServers": {
-            SERVER_NAME: server_entry(settings)
-        }
-    })
+    let mut servers = Map::new();
+    servers.insert(settings.name.clone(), server_entry(settings));
+    json!({ "mcpServers": servers })
 }
 
 fn server_entry(settings: &McpConfigSettings) -> Value {
@@ -53,7 +51,7 @@ fn start_args(settings: &McpConfigSettings) -> Vec<String> {
     args
 }
 
-fn merge_server_entry(path: &Path, entry: Value) -> Result<()> {
+fn merge_server_entry(path: &Path, name: &str, entry: Value) -> Result<()> {
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)
             .with_context(|| format!("failed to create {}", parent.display()))?;
@@ -80,7 +78,7 @@ fn merge_server_entry(path: &Path, entry: Value) -> Result<()> {
             path.display()
         )
     })?;
-    servers_object.insert(SERVER_NAME.to_string(), entry);
+    servers_object.insert(name.to_string(), entry);
 
     let rendered = serde_json::to_string_pretty(&root)
         .map(|json| format!("{json}\n"))

--- a/lib/apps/fabro-mcp-server/src/lib.rs
+++ b/lib/apps/fabro-mcp-server/src/lib.rs
@@ -13,9 +13,9 @@ pub use config::{config_json, init_agent};
 use fabro_client::Client;
 pub use server::start;
 
-/// The name this MCP server reports over the wire and registers under in agent
-/// config files.
-pub(crate) const SERVER_NAME: &str = "fabro";
+/// The name this MCP server reports over the wire. It is also the default
+/// `mcpServers` key that `fabro mcp config` and `fabro mcp init` register.
+pub const SERVER_NAME: &str = "fabro";
 
 pub type FabroClientFuture = Pin<Box<dyn Future<Output = Result<Client>> + Send>>;
 
@@ -39,8 +39,10 @@ impl std::fmt::Debug for FabroMcpServerSettings {
     }
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct McpConfigSettings {
+    /// The `mcpServers` key the generated client entry is registered under.
+    pub name:        String,
     pub server:      Option<String>,
     pub storage_dir: Option<PathBuf>,
 }


### PR DESCRIPTION
Closes #808

## Summary

`fabro mcp config` and `fabro mcp init` always registered the MCP client entry under the fixed `mcpServers` key `fabro`. Running `mcp init` a second time replaced that entry, so users could not register separate Fabro servers (e.g. production and testing) in one MCP host without editing the JSON by hand.

This adds `--name <NAME>` to both commands:

```shell
fabro mcp init claude --name fabro-production --server https://fabro.example.com
fabro mcp init claude --name fabro-testing --server https://fabro-testing.example.com
```

- Defaults to `fabro`, so existing behavior is unchanged when `--name` is omitted.
- Rejects empty names (clap `NonEmptyStringValueParser`).
- `mcp init` upserts only the named entry; entries with other names are preserved, and reusing a name updates that entry in place.
- The MCP wire-level `serverInfo.name` stays `fabro`; each named entry still launches its own single-target `fabro mcp start` process.

## Changes

- `fabro-mcp-server`: `McpConfigSettings` gains `name`; `config_json` / `init_agent` use it as the `mcpServers` key. `SERVER_NAME` is now `pub` and serves as the default.
- `fabro-cli`: `--name` on `McpConfigArgs` and `McpInitArgs`; threaded through `commands/mcp/mod.rs`.
- Docs: `docs/public/agents/mcp.mdx` and `docs/public/reference/cli.mdx` describe the option.

## Tests

- `config_uses_custom_entry_name` — custom key in generated JSON
- `config_rejects_empty_entry_name` — exit 2 with clap error
- `init_merges_multiple_named_fabro_entries` — `fabro`, `fabro-production`, `fabro-testing` coexist; re-running `fabro-production` with a new `--server` updates only that entry
- Existing default-name tests unchanged; `config_help` / `init_help` snapshots updated for the new flag

`cargo nextest run -p fabro-cli -p fabro-mcp-server -E 'test(/mcp/)'` — 53 passed. Clippy (`-D warnings`) and `fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
