### PR TITLE
Warn when run title generation fails

### DIFF
--- a/lib/apps/fabro-server/src/run_title_generation.rs
+++ b/lib/apps/fabro-server/src/run_title_generation.rs
@@ -57,7 +57,7 @@ pub(crate) async fn generate_title_or_current(input: GenerateTitleInput<'_>) -> 
     let result = match generate::generate_object(params, title_response_schema()).await {
         Ok(result) => result,
         Err(err) => {
-            tracing::debug!(error = %err, "Run title generation failed");
+            tracing::warn!(run_id = %input.prompt.run_id, error = %err, "Run title generation failed");
             return current_title;
         }
     };

--- a/lib/apps/fabro-server/src/server/handler/runs.rs
+++ b/lib/apps/fabro-server/src/server/handler/runs.rs
@@ -1405,7 +1405,7 @@ fn spawn_generated_title_task(task: GeneratedTitleTask) {
         let run_store = match task.state.stores.runs.open_run(&task.run_id).await {
             Ok(store) => store,
             Err(err) => {
-                tracing::debug!(run_id = %task.run_id, error = %err, "Failed to open run store for title update");
+                tracing::warn!(run_id = %task.run_id, error = %err, "Failed to open run store for title update");
                 return;
             }
         };
@@ -1423,7 +1423,7 @@ fn spawn_generated_title_task(task: GeneratedTitleTask) {
         )
         .await
         {
-            tracing::debug!(run_id = %task.run_id, error = %err, "Failed to append generated run title event");
+            tracing::warn!(run_id = %task.run_id, error = %err, "Failed to append generated run title event");
         }
     });
 }


### PR DESCRIPTION
## Summary

- log LLM run-title generation failures at WARN so production logs retain the cause
- include the run ID on generation failures
- promote run-store and title-event persistence failures to WARN because they also preserve the fallback title

## Why

Run-title generation is best-effort, but a failure leaves the deterministic fallback in place. Production defaults to INFO, so DEBUG failures could not be diagnosed after the fact.

## Validation

- cargo +nightly-2026-04-14 fmt --check --all
- cargo nextest run -p fabro-server run_title_generation
- cargo +nightly-2026-04-14 clippy -p fabro-server --all-targets -- -D warnings