### PR TITLE
Select the sole managed run environment when default is absent

### DIFF
--- a/docs/public/api-reference/fabro-api.yaml
+++ b/docs/public/api-reference/fabro-api.yaml
@@ -9377,7 +9377,11 @@ components:
           $ref: "#/components/schemas/RunIntentArgs"
         environment_id:
           type: string
-          description: Server environment catalog ID. Omission selects `default`.
+          description: >-
+            Server environment catalog ID. When omitted, the server selects an
+            environment named `default`, or the sole Docker or Daytona
+            environment when `default` does not exist. Omission is rejected if
+            that fallback is absent or ambiguous.
         parent_id:
           type: string
           description: Optional orchestration parent run ID.

--- a/docs/public/api-reference/fabro-api.yaml
+++ b/docs/public/api-reference/fabro-api.yaml
@@ -1181,8 +1181,8 @@ paths:
         Failures return the standard error body. The intent lane responds
         `404` (`workflow_version_not_found`, `environment_not_found`), `422`
         (`run_intent_invalid`, `target_invalid`,
-        `target_environment_unsupported`, `workflow_version_unusable`,
-        `run_compile_invalid`), `503` (`integration_unavailable`), or `500`
+        `target_environment_unsupported`, `environment_selection_required`,
+        `workflow_version_unusable`, `run_compile_invalid`), `503` (`integration_unavailable`), or `500`
         (`workflow_version_store_error`, `credential_store_error`,
         `variable_store_error`, `run_persistence_failed`).
       requestBody:

--- a/docs/public/execution/environments.mdx
+++ b/docs/public/execution/environments.mdx
@@ -178,10 +178,10 @@ fabro server start --environment default
 ## Seeded Environments
 
 Install seeds a `default` environment into SQLite. It is a normal persisted
-environment, so you can edit or delete it. When it is absent, run creation that
-does not name an environment uses the sole Docker or Daytona environment in the
-catalog; zero or multiple compatible environments require an explicit
-selection. The standard Docker default is:
+environment, so you can edit or delete it. Runs that do not name an environment
+select it implicitly; see
+[Run Configuration](/execution/run-configuration#runenvironment-and-server-managed-environments)
+for the fallback rule when it is absent. The standard Docker default is:
 
 ```json title="GET /api/v1/environments/default"
 {

--- a/docs/public/execution/environments.mdx
+++ b/docs/public/execution/environments.mdx
@@ -177,7 +177,11 @@ fabro server start --environment default
 
 ## Seeded Environments
 
-Install seeds a `default` environment into SQLite. It is a normal persisted environment, so deleting it removes the default run target until you recreate it. The standard Docker default is:
+Install seeds a `default` environment into SQLite. It is a normal persisted
+environment, so you can edit or delete it. When it is absent, run creation that
+does not name an environment uses the sole Docker or Daytona environment in the
+catalog; zero or multiple compatible environments require an explicit
+selection. The standard Docker default is:
 
 ```json title="GET /api/v1/environments/default"
 {

--- a/docs/public/execution/run-configuration.mdx
+++ b/docs/public/execution/run-configuration.mdx
@@ -282,10 +282,12 @@ push = true
 
 Runs select a reusable server-managed environment by slug. For `fabro run` and
 `fabro create`, use `--environment <slug>` to select it; omitting the flag
-selects `default`. Configure the catalog on the server rather than relying on
-the CLI machine's `settings.toml` or the source checkout's
-`.fabro/project.toml`, because those `environments` tables are not transmitted
-during intent creation.
+selects an environment named `default`. If `default` does not exist, Fabro uses
+the sole Docker or Daytona environment in the server catalog. If there are zero
+or multiple compatible environments, specify `--environment` explicitly.
+Configure the catalog on the server rather than relying on the CLI machine's
+`settings.toml` or the source checkout's `.fabro/project.toml`, because those
+`environments` tables are not transmitted during intent creation.
 
 ```toml title="server settings.toml"
 [environments.ci]

--- a/docs/public/execution/run-configuration.mdx
+++ b/docs/public/execution/run-configuration.mdx
@@ -318,7 +318,7 @@ memory = "8GB"
 
 | Field | Description |
 |---|---|
-| `run.environment.id` | Environment slug to select. Defaults to `default`. |
+| `run.environment.id` | Environment slug to select. When omitted, the implicit selection described above applies. |
 | `environments.<slug>.provider` | Required provider: `local`, `docker`, or `daytona`. |
 | `image.docker` | Docker image. Docker runs it directly; Daytona uses it to create or reuse an internally named snapshot. |
 | `image.dockerfile` | Inline Dockerfile or `{ path = "Dockerfile" }`; Daytona uses it to create or reuse an internally named snapshot. Do not set it with `image.docker`. |

--- a/lib/apps/fabro-cli/src/commands/run/create.rs
+++ b/lib/apps/fabro-cli/src/commands/run/create.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 
 use anyhow::{Context as _, anyhow, bail};
 use fabro_config::project;
-use fabro_environment::{DEFAULT_ENVIRONMENT_ID, Environment, select_implicit_run_environment};
+use fabro_environment::{Environment, select_implicit_run_environment};
 use fabro_types::settings::run::EnvironmentProvider;
 use fabro_types::{DirtyStatus, RunId, RunIntent, RunTarget};
 use fabro_util::terminal::Styles;
@@ -109,24 +109,23 @@ pub(crate) async fn create_run(
     })
 }
 
+/// Resolves the run environment the same way the server does for an omitted
+/// `environment_id`, so the CLI can derive the run target from its provider.
 async fn resolve_run_environment(
     client: &fabro_client::Client,
     explicit_id: Option<&str>,
 ) -> anyhow::Result<Environment> {
-    let id = explicit_id.unwrap_or(DEFAULT_ENVIRONMENT_ID);
-    match client.retrieve_environment(id).await {
-        Ok(environment) => Ok(environment),
-        Err(error) if explicit_id.is_none() && fabro_client::is_not_found_error(&error) => {
-            let environments = client
-                .list_environments()
-                .await
-                .context("could not list environments")?;
-            select_implicit_run_environment(&environments)
-                .cloned()
-                .map_err(anyhow::Error::new)
-        }
-        Err(error) => Err(error).with_context(|| format!("could not retrieve environment `{id}`")),
-    }
+    let Some(id) = explicit_id else {
+        let environments = client
+            .list_environments()
+            .await
+            .context("could not list environments")?;
+        return Ok(select_implicit_run_environment(&environments)?.clone());
+    };
+    client
+        .retrieve_environment(id)
+        .await
+        .with_context(|| format!("could not retrieve environment `{id}`"))
 }
 
 fn warn_untransmitted_settings(

--- a/lib/apps/fabro-cli/src/commands/run/create.rs
+++ b/lib/apps/fabro-cli/src/commands/run/create.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 
 use anyhow::{Context as _, anyhow, bail};
 use fabro_config::project;
-use fabro_environment::DEFAULT_ENVIRONMENT_ID;
+use fabro_environment::{DEFAULT_ENVIRONMENT_ID, Environment, select_implicit_run_environment};
 use fabro_types::settings::run::EnvironmentProvider;
 use fabro_types::{DirtyStatus, RunId, RunIntent, RunTarget};
 use fabro_util::terminal::Styles;
@@ -61,10 +61,6 @@ pub(crate) async fn create_run(
     }
 
     let client = ctx.server().await?;
-    let environment_id = args
-        .environment
-        .as_deref()
-        .unwrap_or(DEFAULT_ENVIRONMENT_ID);
     let (parent_id, environment) = tokio::try_join!(
         async {
             match args.parent.as_deref() {
@@ -74,12 +70,7 @@ pub(crate) async fn create_run(
                 None => Ok(None),
             }
         },
-        async {
-            client
-                .retrieve_environment(environment_id)
-                .await
-                .with_context(|| format!("could not retrieve environment `{environment_id}`"))
-        },
+        resolve_run_environment(client.as_ref(), args.environment.as_deref()),
     )?;
     let (target, dirty_worktree) =
         run_target_for_environment(environment.settings.provider, &canonical_cwd)?;
@@ -116,6 +107,26 @@ pub(crate) async fn create_run(
     Ok(CreatedRun {
         run_id: created_run_id,
     })
+}
+
+async fn resolve_run_environment(
+    client: &fabro_client::Client,
+    explicit_id: Option<&str>,
+) -> anyhow::Result<Environment> {
+    let id = explicit_id.unwrap_or(DEFAULT_ENVIRONMENT_ID);
+    match client.retrieve_environment(id).await {
+        Ok(environment) => Ok(environment),
+        Err(error) if explicit_id.is_none() && fabro_client::is_not_found_error(&error) => {
+            let environments = client
+                .list_environments()
+                .await
+                .context("could not list environments")?;
+            select_implicit_run_environment(&environments)
+                .cloned()
+                .map_err(anyhow::Error::new)
+        }
+        Err(error) => Err(error).with_context(|| format!("could not retrieve environment `{id}`")),
+    }
 }
 
 fn warn_untransmitted_settings(

--- a/lib/apps/fabro-cli/tests/it/cmd/create.rs
+++ b/lib/apps/fabro-cli/tests/it/cmd/create.rs
@@ -156,6 +156,61 @@ fn create_uses_explicit_server_target_and_prints_remote_run_id() {
 }
 
 #[test]
+fn create_uses_the_sole_clone_based_environment_when_default_is_missing() {
+    let context = test_context!();
+    let server = MockServer::start();
+    let run_id = unique_run_id();
+    let default_mock = server.mock(|when, then| {
+        when.method("GET").path("/api/v1/environments/default");
+        then.status(404)
+            .header("content-type", "application/json")
+            .json_body(json!({
+                "errors": [{
+                    "status": "404",
+                    "title": "Not Found",
+                    "detail": "environment `default` not found",
+                    "code": "environment_not_found"
+                }]
+            }));
+    });
+    let list_mock = server.mock(|when, then| {
+        when.method("GET").path("/api/v1/environments");
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(json!({
+                "data": [environment_json("production", "docker")],
+                "meta": { "total": 1 }
+            }));
+    });
+    let version_mock = mock_workflow_version_registrations(&server);
+    let requests = Arc::new(Mutex::new(Vec::new()));
+    let create_mock = mock_intent_create(&server, &run_id, Arc::clone(&requests));
+
+    let output = context
+        .create_cmd()
+        .args([
+            "--server",
+            &format!("{}/api/v1", server.base_url()),
+            "--dry-run",
+            fixture("simple.fabro").to_str().unwrap(),
+        ])
+        .output()
+        .expect("command should execute");
+
+    assert!(
+        output.status.success(),
+        "command failed:\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    default_mock.assert();
+    list_mock.assert();
+    version_mock.assert();
+    create_mock.assert();
+    assert_eq!(requests.lock().unwrap()[0]["environment_id"], "production");
+}
+
+#[test]
 fn create_defers_provider_validation_to_the_server() {
     let context = test_context!();
     let server = MockServer::start();

--- a/lib/apps/fabro-cli/tests/it/cmd/create.rs
+++ b/lib/apps/fabro-cli/tests/it/cmd/create.rs
@@ -12,7 +12,7 @@ use insta::assert_snapshot;
 use serde_json::json;
 
 use super::support::{
-    created_run_id, environment_json, fixture, mock_environment,
+    created_run_id, environment_catalog_json, fixture, mock_environment, mock_environment_catalog,
     mock_workflow_version_registrations, mock_workflow_version_registrations_recording,
     output_stderr, output_stdout, remote_run_summary_json, resolve_run, run_count_for_test_case,
     run_git, run_state,
@@ -123,7 +123,7 @@ fn create_uses_explicit_server_target_and_prints_remote_run_id() {
     let context = test_context!();
     let server = MockServer::start();
     let run_id = unique_run_id();
-    let environment_mock = mock_environment(&server, "default", "docker");
+    let environment_mock = mock_environment_catalog(&server, &[("default", "docker")]);
     let version_mock = mock_workflow_version_registrations(&server);
     let mock = server.mock(|when, then| {
         when.method("POST").path("/api/v1/runs");
@@ -160,28 +160,7 @@ fn create_uses_the_sole_clone_based_environment_when_default_is_missing() {
     let context = test_context!();
     let server = MockServer::start();
     let run_id = unique_run_id();
-    let default_mock = server.mock(|when, then| {
-        when.method("GET").path("/api/v1/environments/default");
-        then.status(404)
-            .header("content-type", "application/json")
-            .json_body(json!({
-                "errors": [{
-                    "status": "404",
-                    "title": "Not Found",
-                    "detail": "environment `default` not found",
-                    "code": "environment_not_found"
-                }]
-            }));
-    });
-    let list_mock = server.mock(|when, then| {
-        when.method("GET").path("/api/v1/environments");
-        then.status(200)
-            .header("content-type", "application/json")
-            .json_body(json!({
-                "data": [environment_json("production", "docker")],
-                "meta": { "total": 1 }
-            }));
-    });
+    let list_mock = mock_environment_catalog(&server, &[("production", "docker")]);
     let version_mock = mock_workflow_version_registrations(&server);
     let requests = Arc::new(Mutex::new(Vec::new()));
     let create_mock = mock_intent_create(&server, &run_id, Arc::clone(&requests));
@@ -203,7 +182,6 @@ fn create_uses_the_sole_clone_based_environment_when_default_is_missing() {
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );
-    default_mock.assert();
     list_mock.assert();
     version_mock.assert();
     create_mock.assert();
@@ -215,7 +193,7 @@ fn create_defers_provider_validation_to_the_server() {
     let context = test_context!();
     let server = MockServer::start();
     let run_id = unique_run_id();
-    let environment_mock = mock_environment(&server, "default", "docker");
+    let environment_mock = mock_environment_catalog(&server, &[("default", "docker")]);
     let registered_versions = Arc::new(Mutex::new(Vec::new()));
     let version_mock =
         mock_workflow_version_registrations_recording(&server, Arc::clone(&registered_versions));
@@ -258,7 +236,7 @@ fn create_uses_configured_server_target_without_server_flag() {
     let context = test_context!();
     let server = MockServer::start();
     let run_id = unique_run_id();
-    let environment_mock = mock_environment(&server, "default", "docker");
+    let environment_mock = mock_environment_catalog(&server, &[("default", "docker")]);
     let version_mock = mock_workflow_version_registrations(&server);
     let mock = server.mock(|when, then| {
         when.method("POST").path("/api/v1/runs");
@@ -293,7 +271,7 @@ fn create_parent_resolves_parent_and_sends_parent_id_in_intent() {
     let run_id = unique_run_id();
     let parent_id = unique_run_id();
     let resolve_mock = super::support::mock_resolved_run(&server, "nightly-parent", &parent_id);
-    let environment_mock = mock_environment(&server, "default", "docker");
+    let environment_mock = mock_environment_catalog(&server, &[("default", "docker")]);
     let version_mock = mock_workflow_version_registrations(&server);
     let create_mock = server.mock(|when, then| {
         when.method("POST")
@@ -363,7 +341,7 @@ fn create_cli_server_target_overrides_configured_server_target() {
     });
     let cli_server = MockServer::start();
     let run_id = unique_run_id();
-    let environment_mock = mock_environment(&cli_server, "default", "docker");
+    let environment_mock = mock_environment_catalog(&cli_server, &[("default", "docker")]);
     let version_mock = mock_workflow_version_registrations(&cli_server);
     let cli_mock = cli_server.mock(|when, then| {
         when.method("POST").path("/api/v1/runs");
@@ -693,7 +671,7 @@ fn create_clone_targets_require_exact_git_observations() {
     let environment_calls = Arc::new(AtomicUsize::new(0));
     let environment_calls_for_mock = Arc::clone(&environment_calls);
     let environment_mock = server.mock(|when, then| {
-        when.method("GET").path("/api/v1/environments/default");
+        when.method("GET").path("/api/v1/environments");
         then.respond_with(move |_| {
             let provider = match environment_calls_for_mock.fetch_add(1, Ordering::SeqCst) {
                 0 | 2 => "docker",
@@ -703,7 +681,7 @@ fn create_clone_targets_require_exact_git_observations() {
             HttpMockResponse::builder()
                 .status(200)
                 .header("content-type", "application/json")
-                .body(environment_json("default", provider).to_string())
+                .body(environment_catalog_json(&[("default", provider)]).to_string())
                 .build()
         });
     });
@@ -866,7 +844,7 @@ fn create_clone_targets_require_exact_git_observations() {
 fn create_rejects_unusable_git_checkouts_instead_of_sending_an_empty_target() {
     let context = test_context!();
     let server = MockServer::start();
-    let environment_mock = mock_environment(&server, "default", "docker");
+    let environment_mock = mock_environment_catalog(&server, &[("default", "docker")]);
     let version_mock = mock_workflow_version_registrations(&server);
     let run_id = unique_run_id();
     let requests = Arc::new(Mutex::new(Vec::new()));
@@ -935,7 +913,7 @@ fn create_rejects_unusable_git_checkouts_instead_of_sending_an_empty_target() {
 fn create_rejects_an_unsupported_attached_origin_before_upload() {
     let context = test_context!();
     let server = MockServer::start();
-    let environment_mock = mock_environment(&server, "default", "docker");
+    let environment_mock = mock_environment_catalog(&server, &[("default", "docker")]);
     let version_mock = mock_workflow_version_registrations(&server);
     let run_id = unique_run_id();
     let requests = Arc::new(Mutex::new(Vec::new()));

--- a/lib/apps/fabro-cli/tests/it/cmd/run.rs
+++ b/lib/apps/fabro-cli/tests/it/cmd/run.rs
@@ -10,7 +10,7 @@ use httpmock::MockServer;
 use serde_json::Value;
 
 use super::support::{
-    created_run_id, mock_environment, mock_workflow_version_registrations, output_stderr,
+    created_run_id, mock_environment_catalog, mock_workflow_version_registrations, output_stderr,
     remote_run_summary_json, run_state, wait_for_event_names,
 };
 use crate::support::{LightweightCli, run_output_filters, run_projection_json, unique_run_id};
@@ -155,7 +155,7 @@ fn detach_uses_explicit_server_target_and_prints_remote_run_id() {
     let context = test_context!();
     let server = MockServer::start();
     let run_id = unique_run_id();
-    let environment_mock = mock_environment(&server, "default", "docker");
+    let environment_mock = mock_environment_catalog(&server, &[("default", "docker")]);
     let version_mock = mock_workflow_version_registrations(&server);
     let create_mock = server.mock(|when, then| {
         when.method("POST").path("/api/v1/runs");
@@ -209,7 +209,7 @@ fn run_parent_resolves_parent_and_sends_parent_id_in_intent() {
     let run_id = unique_run_id();
     let parent_id = unique_run_id();
     let resolve_mock = super::support::mock_resolved_run(&server, "nightly-parent", &parent_id);
-    let environment_mock = mock_environment(&server, "default", "docker");
+    let environment_mock = mock_environment_catalog(&server, &[("default", "docker")]);
     let version_mock = mock_workflow_version_registrations(&server);
     let create_mock = server.mock(|when, then| {
         when.method("POST")
@@ -265,7 +265,7 @@ fn detach_uses_configured_server_target_without_server_flag() {
     let context = test_context!();
     let server = MockServer::start();
     let run_id = unique_run_id();
-    let environment_mock = mock_environment(&server, "default", "docker");
+    let environment_mock = mock_environment_catalog(&server, &[("default", "docker")]);
     let version_mock = mock_workflow_version_registrations(&server);
     let create_mock = server.mock(|when, then| {
         when.method("POST").path("/api/v1/runs");
@@ -314,7 +314,7 @@ fn detach_uses_configured_server_target_without_server_flag() {
 fn run_create_failure_shows_action_context_and_response_body() {
     let context = test_context!();
     let server = MockServer::start();
-    let environment_mock = mock_environment(&server, "default", "docker");
+    let environment_mock = mock_environment_catalog(&server, &[("default", "docker")]);
     let version_mock = mock_workflow_version_registrations(&server);
     let create_mock = server.mock(|when, then| {
         when.method("POST").path("/api/v1/runs");
@@ -496,7 +496,7 @@ fn detach_cli_server_target_overrides_configured_server_target() {
     });
     let cli_server = MockServer::start();
     let run_id = unique_run_id();
-    let environment_mock = mock_environment(&cli_server, "default", "docker");
+    let environment_mock = mock_environment_catalog(&cli_server, &[("default", "docker")]);
     let version_mock = mock_workflow_version_registrations(&cli_server);
     let cli_create = cli_server.mock(|when, then| {
         when.method("POST").path("/api/v1/runs");
@@ -550,7 +550,7 @@ fn remote_foreground_run_consumes_paginated_events_and_prints_server_backed_summ
     let context = test_context!();
     let server = MockServer::start();
     let run_id = unique_run_id();
-    let environment_mock = mock_environment(&server, "default", "docker");
+    let environment_mock = mock_environment_catalog(&server, &[("default", "docker")]);
     let version_mock = mock_workflow_version_registrations(&server);
     let preflight = server.mock(|when, then| {
         when.method("POST").path("/api/v1/preflight");
@@ -672,7 +672,7 @@ fn remote_foreground_run_consumes_paginated_events_and_prints_server_backed_summ
 fn run_surfaces_server_rejection_for_unbound_template_inputs() {
     let context = test_context!();
     let server = MockServer::start();
-    let environment_mock = mock_environment(&server, "default", "docker");
+    let environment_mock = mock_environment_catalog(&server, &[("default", "docker")]);
     let version_mock = mock_workflow_version_registrations(&server);
     let create = server.mock(|when, then| {
         when.method("POST").path("/api/v1/runs");
@@ -714,7 +714,7 @@ fn run_surfaces_server_rejection_for_unbound_template_inputs() {
 fn foreground_run_surfaces_server_rejection_for_invalid_workflow() {
     let context = test_context!();
     let server = MockServer::start();
-    let environment_mock = mock_environment(&server, "default", "docker");
+    let environment_mock = mock_environment_catalog(&server, &[("default", "docker")]);
     let version_mock = mock_workflow_version_registrations(&server);
     let create = server.mock(|when, then| {
         when.method("POST").path("/api/v1/runs");

--- a/lib/apps/fabro-cli/tests/it/cmd/support.rs
+++ b/lib/apps/fabro-cli/tests/it/cmd/support.rs
@@ -172,6 +172,32 @@ pub(crate) fn mock_environment<'a>(server: &'a MockServer, id: &str, provider: &
     })
 }
 
+/// Canonical environment catalog body for mock servers, matching the
+/// `GET /api/v1/environments` shape the run-intent create path reads when no
+/// `--environment` is given.
+pub(crate) fn environment_catalog_json(environments: &[(&str, &str)]) -> Value {
+    serde_json::json!({
+        "data": environments
+            .iter()
+            .map(|(id, provider)| environment_json(id, provider))
+            .collect::<Vec<_>>(),
+        "meta": { "total": environments.len() }
+    })
+}
+
+pub(crate) fn mock_environment_catalog<'a>(
+    server: &'a MockServer,
+    environments: &[(&str, &str)],
+) -> Mock<'a> {
+    let body = environment_catalog_json(environments);
+    server.mock(|when, then| {
+        when.method("GET").path("/api/v1/environments");
+        then.status(200)
+            .header("content-type", "application/json")
+            .json_body(body);
+    })
+}
+
 pub(crate) fn mock_workflow_version_registrations(server: &MockServer) -> Mock<'_> {
     mock_workflow_version_registrations_recording(server, Arc::new(Mutex::new(Vec::new())))
 }

--- a/lib/apps/fabro-server/src/run_intent.rs
+++ b/lib/apps/fabro-server/src/run_intent.rs
@@ -3,7 +3,7 @@ use std::path::{Component, Path, PathBuf};
 
 use fabro_config::parse::SettingsSource;
 use fabro_config::{EnvironmentLayer, RunEnvironmentLayer, RunGoalLayer, SettingsLayer};
-use fabro_environment::{EnvironmentId, EnvironmentValidationError};
+use fabro_environment::{EnvironmentId, EnvironmentValidationError, ImplicitRunEnvironmentError};
 use fabro_manifest::CollectedWorkflowClosure;
 use fabro_types::settings::InterpString;
 use fabro_types::{
@@ -123,6 +123,8 @@ fn canonical_folder_text(path: &Path) -> Result<String, FolderTargetValidationEr
 
 #[derive(Debug, Error)]
 pub(crate) enum EnvironmentSelectionError {
+    #[error(transparent)]
+    Implicit(#[from] ImplicitRunEnvironmentError),
     #[error("invalid environment ID `{value}`")]
     InvalidId {
         value:  String,

--- a/lib/apps/fabro-server/src/server/handler/runs.rs
+++ b/lib/apps/fabro-server/src/server/handler/runs.rs
@@ -1078,9 +1078,7 @@ fn select_intent_environment_id(
 ) -> Result<EnvironmentId, EnvironmentSelectionError> {
     let Some(value) = value else {
         let environments = state.environment_store().list();
-        return select_implicit_run_environment(&environments)
-            .map(|environment| environment.id.clone())
-            .map_err(EnvironmentSelectionError::from);
+        return Ok(select_implicit_run_environment(&environments)?.id.clone());
     };
     let id =
         value

--- a/lib/apps/fabro-server/src/server/handler/runs.rs
+++ b/lib/apps/fabro-server/src/server/handler/runs.rs
@@ -19,7 +19,7 @@ use fabro_api::types::{
     UpdateRunParentRequest, UpdateRunRequest,
 };
 use fabro_config::{CliLayer, RunLayer, Storage, project};
-use fabro_environment::{DEFAULT_ENVIRONMENT_ID, EnvironmentId};
+use fabro_environment::{EnvironmentId, select_implicit_run_environment};
 use fabro_interview::AnswerSubmission;
 use fabro_llm::client::Client as LlmClient;
 use fabro_manifest::RunOverrideInput;
@@ -630,16 +630,11 @@ pub(crate) async fn create_run_from_intent(
         Ok(validated) => validated,
         Err(error) => return run_intent_admission_error(error.into()),
     };
-    let environment_id = match select_intent_environment_id(
-        &state,
-        intent
-            .environment_id
-            .as_deref()
-            .unwrap_or(DEFAULT_ENVIRONMENT_ID),
-    ) {
-        Ok(id) => id,
-        Err(error) => return run_intent_admission_error(error.into()),
-    };
+    let environment_id =
+        match select_intent_environment_id(&state, intent.environment_id.as_deref()) {
+            Ok(id) => id,
+            Err(error) => return run_intent_admission_error(error.into()),
+        };
     let blobs = state.store_ref().blobs();
     let version_store = fabro_workflow_version::WorkflowVersionStore::new(blobs);
     let closure = match version_store.get_closure(&intent.workflow_version_id).await {
@@ -1026,6 +1021,11 @@ fn run_intent_admission_error(error: RunIntentAdmissionError) -> Response {
             "target_invalid",
         ),
         RunIntentAdmissionError::Environment(error) => match error {
+            EnvironmentSelectionError::Implicit(_) => intent_error(
+                StatusCode::UNPROCESSABLE_ENTITY,
+                error.to_string(),
+                "environment_selection_required",
+            ),
             EnvironmentSelectionError::InvalidId { source, .. } => intent_error(
                 StatusCode::UNPROCESSABLE_ENTITY,
                 source.to_string(),
@@ -1074,8 +1074,14 @@ fn run_intent_admission_error(error: RunIntentAdmissionError) -> Response {
 
 fn select_intent_environment_id(
     state: &AppState,
-    value: &str,
+    value: Option<&str>,
 ) -> Result<EnvironmentId, EnvironmentSelectionError> {
+    let Some(value) = value else {
+        let environments = state.environment_store().list();
+        return select_implicit_run_environment(&environments)
+            .map(|environment| environment.id.clone())
+            .map_err(EnvironmentSelectionError::from);
+    };
     let id =
         value
             .parse::<EnvironmentId>()

--- a/lib/apps/fabro-server/src/server/tests.rs
+++ b/lib/apps/fabro-server/src/server/tests.rs
@@ -24,7 +24,7 @@ use fabro_llm::types::{Message as LlmMessage, Request as LlmRequest, TokenCounts
 use fabro_model::catalog::LlmCatalogSettings;
 use fabro_model::{Catalog, ModelRef, ProviderId, ReasoningEffort, Speed};
 use fabro_types::settings::ServerAuthMethod;
-use fabro_types::settings::run::{ApprovalMode, EnvironmentProvider};
+use fabro_types::settings::run::{ApprovalMode, EnvironmentProvider, EnvironmentSettings};
 use fabro_types::{
     AgentBackend, AttrValue, AuthMethod, BlobHash, CommandTermination, FailureCategory,
     FailureDetail, GitRunTarget, Graph, InterviewQuestionRecord, Node, Outcome, ParallelBranchId,
@@ -3567,6 +3567,21 @@ async fn store_workflow_version(
     store_workflow_version_with_entrypoint(state, "workflow.fabro", graph, workflow_toml).await
 }
 
+async fn create_test_environment(state: &AppState, id: &str, provider: EnvironmentProvider) {
+    state
+        .environment_store()
+        .create(fabro_environment::EnvironmentDraft {
+            id:       id.parse().expect("test environment ID should be valid"),
+            settings: EnvironmentSettings {
+                provider,
+                ..EnvironmentSettings::default()
+            },
+        })
+        .await
+        .expect("test environment should be created");
+    state.refresh_manifest_run_settings_from_environment_catalog();
+}
+
 async fn store_workflow_version_with_entrypoint(
     state: &AppState,
     entrypoint: &str,
@@ -3640,6 +3655,65 @@ async fn post_runs_run_intent_derives_workflow_slug_from_immutable_entrypoint() 
             Some(workflow_version_id)
         );
     }
+}
+
+#[tokio::test]
+async fn post_runs_run_intent_uses_sole_clone_based_environment_when_default_is_absent() {
+    let state = TestAppStateBuilder::new()
+        .default_environment_provider(None)
+        .vault_entries([(EnvVars::OPENAI_API_KEY, "test-openai-api-key")])
+        .build();
+    create_test_environment(&state, "production", EnvironmentProvider::Docker).await;
+    let app = crate::test_support::build_test_router(Arc::clone(&state));
+    let workflow_version_id = store_workflow_version(&state, MINIMAL_DOT, None).await;
+
+    let body = post_run_manifest(
+        &app,
+        json!({
+            "workflow_version_id": workflow_version_id,
+            "target": { "kind": "none" },
+            "args": {}
+        }),
+    )
+    .await;
+
+    let run_id = body["id"].as_str().unwrap().parse::<RunId>().unwrap();
+    let run_store = state.stores.runs.open_run_reader(&run_id).await.unwrap();
+    let projection = run_store.state().await.unwrap();
+    assert_eq!(
+        projection.spec.settings.run.environment.provider,
+        EnvironmentProvider::Docker
+    );
+}
+
+#[tokio::test]
+async fn post_runs_run_intent_rejects_ambiguous_implicit_environment() {
+    let state = TestAppStateBuilder::new()
+        .default_environment_provider(None)
+        .build();
+    create_test_environment(&state, "development", EnvironmentProvider::Docker).await;
+    create_test_environment(&state, "production", EnvironmentProvider::Daytona).await;
+    let app = crate::test_support::build_test_router(Arc::clone(&state));
+    let workflow_version_id = store_workflow_version(&state, MINIMAL_DOT, None).await;
+
+    let response = post_run_intent_response(
+        &app,
+        json!({
+            "workflow_version_id": workflow_version_id,
+            "target": { "kind": "none" },
+            "args": {}
+        }),
+    )
+    .await;
+    let body = response_json!(response, StatusCode::UNPROCESSABLE_ENTITY).await;
+
+    assert_eq!(body["errors"][0]["code"], "environment_selection_required");
+    assert!(
+        body["errors"][0]["detail"]
+            .as_str()
+            .is_some_and(|detail| detail.contains("found 2")),
+        "unexpected response: {body}"
+    );
 }
 
 #[tokio::test]

--- a/lib/components/fabro-environment/src/error.rs
+++ b/lib/components/fabro-environment/src/error.rs
@@ -134,3 +134,13 @@ impl EnvironmentStoreError {
         }
     }
 }
+
+/// Error returned when an omitted run environment cannot be resolved without
+/// making an arbitrary choice.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+#[error(
+    "no environment was specified and no environment named `default` exists; expected exactly one Docker or Daytona environment, found {compatible_count}"
+)]
+pub struct ImplicitRunEnvironmentError {
+    pub compatible_count: usize,
+}

--- a/lib/components/fabro-environment/src/lib.rs
+++ b/lib/components/fabro-environment/src/lib.rs
@@ -3,11 +3,11 @@ mod id;
 mod model;
 mod store;
 
-pub use error::{EnvironmentStoreError, EnvironmentValidationError};
+pub use error::{EnvironmentStoreError, EnvironmentValidationError, ImplicitRunEnvironmentError};
 pub use id::{EnvironmentId, EnvironmentRevision, EnvironmentRevisionParseError};
 pub use model::{Environment, EnvironmentDraft};
 pub use store::{
-    DEFAULT_ENVIRONMENT_ID, EnvironmentStore, ImplicitRunEnvironmentError, ImportReport,
-    import_legacy_directory_once, seed_default_environment, seed_environments,
-    seeded_catalog_layer, select_implicit_run_environment,
+    DEFAULT_ENVIRONMENT_ID, EnvironmentStore, ImportReport, import_legacy_directory_once,
+    seed_default_environment, seed_environments, seeded_catalog_layer,
+    select_implicit_run_environment,
 };

--- a/lib/components/fabro-environment/src/lib.rs
+++ b/lib/components/fabro-environment/src/lib.rs
@@ -7,6 +7,7 @@ pub use error::{EnvironmentStoreError, EnvironmentValidationError};
 pub use id::{EnvironmentId, EnvironmentRevision, EnvironmentRevisionParseError};
 pub use model::{Environment, EnvironmentDraft};
 pub use store::{
-    DEFAULT_ENVIRONMENT_ID, EnvironmentStore, ImportReport, import_legacy_directory_once,
-    seed_default_environment, seed_environments, seeded_catalog_layer,
+    DEFAULT_ENVIRONMENT_ID, EnvironmentStore, ImplicitRunEnvironmentError, ImportReport,
+    import_legacy_directory_once, seed_default_environment, seed_environments,
+    seeded_catalog_layer, select_implicit_run_environment,
 };

--- a/lib/components/fabro-environment/src/store.rs
+++ b/lib/components/fabro-environment/src/store.rs
@@ -30,6 +30,48 @@ use crate::{
 /// reserved, in-memory environment.
 pub const DEFAULT_ENVIRONMENT_ID: &str = "default";
 
+/// Error returned when an omitted run environment cannot be resolved without
+/// making an arbitrary choice.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+#[error(
+    "no environment was specified and no environment named `default` exists; expected exactly one Docker or Daytona environment, found {compatible_count}"
+)]
+pub struct ImplicitRunEnvironmentError {
+    pub compatible_count: usize,
+}
+
+/// Selects the environment used when run creation omits an environment ID.
+///
+/// A catalog entry named `default` preserves the established behavior. If it
+/// is absent, the sole clone-based (Docker or Daytona) environment is selected.
+/// Zero or multiple compatible environments are intentionally ambiguous.
+pub fn select_implicit_run_environment(
+    environments: &[Environment],
+) -> Result<&Environment, ImplicitRunEnvironmentError> {
+    if let Some(environment) = environments
+        .iter()
+        .find(|environment| environment.id.as_str() == DEFAULT_ENVIRONMENT_ID)
+    {
+        return Ok(environment);
+    }
+
+    let mut compatible = environments
+        .iter()
+        .filter(|environment| environment.settings.provider.is_clone_based());
+    let Some(environment) = compatible.next() else {
+        return Err(ImplicitRunEnvironmentError {
+            compatible_count: 0,
+        });
+    };
+    let Some(_second) = compatible.next() else {
+        return Ok(environment);
+    };
+
+    Err(ImplicitRunEnvironmentError {
+        compatible_count: 2 + compatible.count(),
+    })
+}
+
 /// `local` is a reserved environment: it is synthesized in memory only when the
 /// local sandbox provider is enabled, is never persisted, and cannot be
 /// created, replaced, or deleted through the store.

--- a/lib/components/fabro-environment/src/store.rs
+++ b/lib/components/fabro-environment/src/store.rs
@@ -20,7 +20,7 @@ use tracing::info;
 
 use crate::{
     Environment, EnvironmentDraft, EnvironmentId, EnvironmentRevision, EnvironmentStoreError,
-    EnvironmentValidationError,
+    EnvironmentValidationError, ImplicitRunEnvironmentError,
 };
 
 /// Built-in default environment seeded by install/test setup. The server itself
@@ -29,16 +29,6 @@ use crate::{
 /// explicitly. `local` is intentionally absent from SQLite because it is a
 /// reserved, in-memory environment.
 pub const DEFAULT_ENVIRONMENT_ID: &str = "default";
-
-/// Error returned when an omitted run environment cannot be resolved without
-/// making an arbitrary choice.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
-#[error(
-    "no environment was specified and no environment named `default` exists; expected exactly one Docker or Daytona environment, found {compatible_count}"
-)]
-pub struct ImplicitRunEnvironmentError {
-    pub compatible_count: usize,
-}
 
 /// Selects the environment used when run creation omits an environment ID.
 ///
@@ -55,21 +45,16 @@ pub fn select_implicit_run_environment(
         return Ok(environment);
     }
 
-    let mut compatible = environments
+    let compatible: Vec<&Environment> = environments
         .iter()
-        .filter(|environment| environment.settings.provider.is_clone_based());
-    let Some(environment) = compatible.next() else {
-        return Err(ImplicitRunEnvironmentError {
-            compatible_count: 0,
-        });
-    };
-    let Some(_second) = compatible.next() else {
-        return Ok(environment);
-    };
-
-    Err(ImplicitRunEnvironmentError {
-        compatible_count: 2 + compatible.count(),
-    })
+        .filter(|environment| environment.settings.provider.is_clone_based())
+        .collect();
+    match compatible.as_slice() {
+        [environment] => Ok(environment),
+        _ => Err(ImplicitRunEnvironmentError {
+            compatible_count: compatible.len(),
+        }),
+    }
 }
 
 /// `local` is a reserved environment: it is synthesized in memory only when the

--- a/lib/components/fabro-environment/tests/store.rs
+++ b/lib/components/fabro-environment/tests/store.rs
@@ -4,6 +4,7 @@ use std::path::{Path, PathBuf};
 use fabro_environment::{
     EnvironmentDraft, EnvironmentId, EnvironmentStore, EnvironmentStoreError,
     import_legacy_directory_once, seed_default_environment, seed_environments,
+    select_implicit_run_environment,
 };
 use fabro_types::settings::InterpString;
 use fabro_types::settings::run::{
@@ -152,6 +153,58 @@ async fn default_is_deletable() -> anyhow::Result<()> {
 
     assert!(store.get(&default.id).is_none());
     assert_eq!(sql_environment_count(&test.pool).await?, 0);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn implicit_run_environment_prefers_default() -> anyhow::Result<()> {
+    let test = test_store(false).await?;
+    test.store
+        .create(draft("production", EnvironmentProvider::Daytona))
+        .await?;
+    test.store
+        .create(draft("default", EnvironmentProvider::Docker))
+        .await?;
+
+    let environments = test.store.list();
+    let selected = select_implicit_run_environment(&environments)?;
+
+    assert_eq!(selected.id.as_str(), "default");
+    Ok(())
+}
+
+#[tokio::test]
+async fn implicit_run_environment_selects_the_sole_clone_based_environment() -> anyhow::Result<()> {
+    let test = test_store(true).await?;
+    test.store
+        .create(draft("production", EnvironmentProvider::Daytona))
+        .await?;
+
+    let environments = test.store.list();
+    let selected = select_implicit_run_environment(&environments)?;
+
+    assert_eq!(selected.id.as_str(), "production");
+    Ok(())
+}
+
+#[tokio::test]
+async fn implicit_run_environment_rejects_zero_or_multiple_clone_based_environments()
+-> anyhow::Result<()> {
+    let test = test_store(true).await?;
+    let environments = test.store.list();
+    let error = select_implicit_run_environment(&environments).unwrap_err();
+    assert_eq!(error.compatible_count, 0);
+
+    test.store
+        .create(draft("development", EnvironmentProvider::Docker))
+        .await?;
+    test.store
+        .create(draft("production", EnvironmentProvider::Daytona))
+        .await?;
+    let environments = test.store.list();
+    let error = select_implicit_run_environment(&environments).unwrap_err();
+    assert_eq!(error.compatible_count, 2);
 
     Ok(())
 }

--- a/lib/foundation/fabro-client/src/client.rs
+++ b/lib/foundation/fabro-client/src/client.rs
@@ -712,6 +712,14 @@ impl Client {
         Ok(response.into_inner())
     }
 
+    /// Lists the canonical server-managed environment catalog.
+    pub async fn list_environments(&self) -> Result<Vec<types::Environment>> {
+        let response = self
+            .send_api(|client| async move { client.list_environments().send().await })
+            .await?;
+        Ok(response.into_inner().data)
+    }
+
     /// Registers one workflow version and verifies the server assigned the
     /// content-derived id, so a mismatched response fails loudly here rather
     /// than being trusted downstream.
@@ -2458,6 +2466,33 @@ mod tests {
         mock.assert_async().await;
         assert_eq!(environment.id.as_str(), "local");
         assert_eq!(environment.settings.provider, EnvironmentProvider::Local);
+    }
+
+    #[tokio::test]
+    async fn list_environments_returns_the_canonical_catalog() {
+        let server = MockServer::start_async().await;
+        let mock = server
+            .mock_async(|when, then| {
+                when.method(GET).path("/api/v1/environments");
+                then.status(200)
+                    .header("content-type", "application/json")
+                    .json_body(json!({
+                        "data": [environment_json("production", "daytona")],
+                        "meta": { "total": 1 }
+                    }));
+            })
+            .await;
+        let client = Client::new_no_proxy(&server.url("")).unwrap();
+
+        let environments = client.list_environments().await.unwrap();
+
+        mock.assert_async().await;
+        assert_eq!(environments.len(), 1);
+        assert_eq!(environments[0].id.as_str(), "production");
+        assert_eq!(
+            environments[0].settings.provider,
+            EnvironmentProvider::Daytona
+        );
     }
 
     #[tokio::test]

--- a/lib/packages/fabro-api-client/src/api/runs-api.ts
+++ b/lib/packages/fabro-api-client/src/api/runs-api.ts
@@ -372,7 +372,7 @@ export const RunsApiAxiosParamCreator = function (configuration?: Configuration)
             };
         },
         /**
-         * Creates a new workflow run in `submitted` status from either a self-contained legacy manifest or an immutable workflow-version intent. Creation does not start or schedule the run.  Failures return the standard error body. The intent lane responds `404` (`workflow_version_not_found`, `environment_not_found`), `422` (`run_intent_invalid`, `target_invalid`, `target_environment_unsupported`, `workflow_version_unusable`, `run_compile_invalid`), `503` (`integration_unavailable`), or `500` (`workflow_version_store_error`, `credential_store_error`, `variable_store_error`, `run_persistence_failed`).
+         * Creates a new workflow run in `submitted` status from either a self-contained legacy manifest or an immutable workflow-version intent. Creation does not start or schedule the run.  Failures return the standard error body. The intent lane responds `404` (`workflow_version_not_found`, `environment_not_found`), `422` (`run_intent_invalid`, `target_invalid`, `target_environment_unsupported`, `environment_selection_required`, `workflow_version_unusable`, `run_compile_invalid`), `503` (`integration_unavailable`), or `500` (`workflow_version_store_error`, `credential_store_error`, `variable_store_error`, `run_persistence_failed`).
          * @summary Create Run
          * @param {CreateRunRequest} createRunRequest
          * @param {*} [options] Override http request option.
@@ -1677,7 +1677,7 @@ export const RunsApiFp = function(configuration?: Configuration) {
             return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
         },
         /**
-         * Creates a new workflow run in `submitted` status from either a self-contained legacy manifest or an immutable workflow-version intent. Creation does not start or schedule the run.  Failures return the standard error body. The intent lane responds `404` (`workflow_version_not_found`, `environment_not_found`), `422` (`run_intent_invalid`, `target_invalid`, `target_environment_unsupported`, `workflow_version_unusable`, `run_compile_invalid`), `503` (`integration_unavailable`), or `500` (`workflow_version_store_error`, `credential_store_error`, `variable_store_error`, `run_persistence_failed`).
+         * Creates a new workflow run in `submitted` status from either a self-contained legacy manifest or an immutable workflow-version intent. Creation does not start or schedule the run.  Failures return the standard error body. The intent lane responds `404` (`workflow_version_not_found`, `environment_not_found`), `422` (`run_intent_invalid`, `target_invalid`, `target_environment_unsupported`, `environment_selection_required`, `workflow_version_unusable`, `run_compile_invalid`), `503` (`integration_unavailable`), or `500` (`workflow_version_store_error`, `credential_store_error`, `variable_store_error`, `run_persistence_failed`).
          * @summary Create Run
          * @param {CreateRunRequest} createRunRequest
          * @param {*} [options] Override http request option.
@@ -2137,7 +2137,7 @@ export const RunsApiFactory = function (configuration?: Configuration, basePath?
             return localVarFp.closeRunPullRequest(id, options).then((request) => request(axios, basePath));
         },
         /**
-         * Creates a new workflow run in `submitted` status from either a self-contained legacy manifest or an immutable workflow-version intent. Creation does not start or schedule the run.  Failures return the standard error body. The intent lane responds `404` (`workflow_version_not_found`, `environment_not_found`), `422` (`run_intent_invalid`, `target_invalid`, `target_environment_unsupported`, `workflow_version_unusable`, `run_compile_invalid`), `503` (`integration_unavailable`), or `500` (`workflow_version_store_error`, `credential_store_error`, `variable_store_error`, `run_persistence_failed`).
+         * Creates a new workflow run in `submitted` status from either a self-contained legacy manifest or an immutable workflow-version intent. Creation does not start or schedule the run.  Failures return the standard error body. The intent lane responds `404` (`workflow_version_not_found`, `environment_not_found`), `422` (`run_intent_invalid`, `target_invalid`, `target_environment_unsupported`, `environment_selection_required`, `workflow_version_unusable`, `run_compile_invalid`), `503` (`integration_unavailable`), or `500` (`workflow_version_store_error`, `credential_store_error`, `variable_store_error`, `run_persistence_failed`).
          * @summary Create Run
          * @param {CreateRunRequest} createRunRequest
          * @param {*} [options] Override http request option.
@@ -2518,7 +2518,7 @@ export class RunsApi extends BaseAPI {
     }
 
     /**
-     * Creates a new workflow run in `submitted` status from either a self-contained legacy manifest or an immutable workflow-version intent. Creation does not start or schedule the run.  Failures return the standard error body. The intent lane responds `404` (`workflow_version_not_found`, `environment_not_found`), `422` (`run_intent_invalid`, `target_invalid`, `target_environment_unsupported`, `workflow_version_unusable`, `run_compile_invalid`), `503` (`integration_unavailable`), or `500` (`workflow_version_store_error`, `credential_store_error`, `variable_store_error`, `run_persistence_failed`).
+     * Creates a new workflow run in `submitted` status from either a self-contained legacy manifest or an immutable workflow-version intent. Creation does not start or schedule the run.  Failures return the standard error body. The intent lane responds `404` (`workflow_version_not_found`, `environment_not_found`), `422` (`run_intent_invalid`, `target_invalid`, `target_environment_unsupported`, `environment_selection_required`, `workflow_version_unusable`, `run_compile_invalid`), `503` (`integration_unavailable`), or `500` (`workflow_version_store_error`, `credential_store_error`, `variable_store_error`, `run_persistence_failed`).
      * @summary Create Run
      * @param {CreateRunRequest} createRunRequest
      * @param {*} [options] Override http request option.

--- a/lib/packages/fabro-api-client/src/models/run-intent.ts
+++ b/lib/packages/fabro-api-client/src/models/run-intent.ts
@@ -31,7 +31,7 @@ export interface RunIntent {
     'target': RunTarget;
     'args': RunIntentArgs;
     /**
-     * Server environment catalog ID. Omission selects `default`.
+     * Server environment catalog ID. When omitted, the server selects an environment named `default`, or the sole Docker or Daytona environment when `default` does not exist. Omission is rejected if that fallback is absent or ambiguous.
      */
     'environment_id'?: string;
     /**


### PR DESCRIPTION
## Summary

- preserve explicit environment selection and the existing `default` convention
- when `default` is absent, select the sole Docker or Daytona environment for both CLI and direct API run creation
- reject zero or multiple compatible environments with `environment_selection_required` instead of choosing arbitrarily
- document the fallback and refresh the generated TypeScript client comment

This matches the conservative selection rule used by the existing automation environment migration. The synthetic `local` environment does not count as a Docker/Daytona fallback candidate.

## Testing

- `cargo nextest run -p fabro-environment -p fabro-client -p fabro-cli -p fabro-server` (2,190 passed; one existing leaky-test warning)
- `cargo +nightly-2026-04-14 clippy -p fabro-environment -p fabro-client -p fabro-cli -p fabro-server --all-targets -- -D warnings`
- `cargo +nightly-2026-04-14 fmt --check --all`
- `bun run typecheck` in `lib/packages/fabro-api-client`