### PR TITLE
Pin pebble to main after lithoscomputer/pebble#10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5863,7 +5863,7 @@ dependencies = [
 [[package]]
 name = "pebble-agent"
 version = "0.1.0"
-source = "git+https://github.com/lithoscomputer/pebble?rev=9ec23d00d37faebcb2da5e3c5f2c1dfc5eec4d7f#9ec23d00d37faebcb2da5e3c5f2c1dfc5eec4d7f"
+source = "git+https://github.com/lithoscomputer/pebble?rev=222d17f17d7384545d3782f3b315210ad2cb0cfe#222d17f17d7384545d3782f3b315210ad2cb0cfe"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -5880,7 +5880,7 @@ dependencies = [
 [[package]]
 name = "pebble-cli-core"
 version = "0.1.0"
-source = "git+https://github.com/lithoscomputer/pebble?rev=9ec23d00d37faebcb2da5e3c5f2c1dfc5eec4d7f#9ec23d00d37faebcb2da5e3c5f2c1dfc5eec4d7f"
+source = "git+https://github.com/lithoscomputer/pebble?rev=222d17f17d7384545d3782f3b315210ad2cb0cfe#222d17f17d7384545d3782f3b315210ad2cb0cfe"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5909,7 +5909,7 @@ dependencies = [
 [[package]]
 name = "pebble-coding-agent"
 version = "0.1.0"
-source = "git+https://github.com/lithoscomputer/pebble?rev=9ec23d00d37faebcb2da5e3c5f2c1dfc5eec4d7f#9ec23d00d37faebcb2da5e3c5f2c1dfc5eec4d7f"
+source = "git+https://github.com/lithoscomputer/pebble?rev=222d17f17d7384545d3782f3b315210ad2cb0cfe#222d17f17d7384545d3782f3b315210ad2cb0cfe"
 dependencies = [
  "async-trait",
  "futures-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,16 +115,15 @@ sandbox-driver-daytona = { git = "https://github.com/lithoscomputer/sandbox-driv
 sandbox-driver-daytona-config = { git = "https://github.com/lithoscomputer/sandbox-driver", rev = "a92c0db6b6a122ca9b6df75de6615544f53c0d47" }
 sandbox-driver-testing = { git = "https://github.com/lithoscomputer/sandbox-driver", rev = "a92c0db6b6a122ca9b6df75de6615544f53c0d47" }
 # pebble: the coding agent loop fabro runs its agent stages, Ask Fabro
-# sessions, hook evaluators, and `fabro exec` on. Pinned by rev to pebble's
-# `sandbox-driver-section-4` branch (lithoscomputer/pebble#10), which is
-# pebble main plus the sandbox-driver pin below: the `PreviewUrls` trait
-# objects fabro hands pebble's MCP servers only cross when both sides name
-# one sandbox-driver revision. Re-pin to main once that lands. Pebble pins
-# the same lithos-llm rev as fabro, and its lockfile policy is that every
-# shared crate resolves to the version lithos-llm locks.
-pebble-agent = { git = "https://github.com/lithoscomputer/pebble", rev = "9ec23d00d37faebcb2da5e3c5f2c1dfc5eec4d7f" }
-pebble-coding-agent = { git = "https://github.com/lithoscomputer/pebble", rev = "9ec23d00d37faebcb2da5e3c5f2c1dfc5eec4d7f", features = ["mcp", "search-providers"] }
-pebble-cli-core = { git = "https://github.com/lithoscomputer/pebble", rev = "9ec23d00d37faebcb2da5e3c5f2c1dfc5eec4d7f" }
+# sessions, hook evaluators, and `fabro exec` on. Pinned by rev to pebble
+# `main`. The `PreviewUrls` trait objects fabro hands pebble's MCP servers
+# only cross when fabro and pebble's `mcp` feature name the same
+# sandbox-driver revision, so move the two pins together. Pebble pins the
+# same lithos-llm rev as fabro, and its lockfile policy is that every shared
+# crate resolves to the version lithos-llm locks.
+pebble-agent = { git = "https://github.com/lithoscomputer/pebble", rev = "222d17f17d7384545d3782f3b315210ad2cb0cfe" }
+pebble-coding-agent = { git = "https://github.com/lithoscomputer/pebble", rev = "222d17f17d7384545d3782f3b315210ad2cb0cfe", features = ["mcp", "search-providers"] }
+pebble-cli-core = { git = "https://github.com/lithoscomputer/pebble", rev = "222d17f17d7384545d3782f3b315210ad2cb0cfe" }
 sentry = { version = "0.35", default-features = false, features = ["backtrace", "contexts", "ureq", "rustls"] }
 fork = "0.2"
 exec = "0.3"


### PR DESCRIPTION
Moves the three pebble pins (`pebble-agent`, `pebble-coding-agent`, `pebble-cli-core`) from `9ec23d0`, the head of pebble's `sandbox-driver-section-4` branch, to pebble `main` at `222d17f`, now that lithoscomputer/pebble#10 is merged. The two pebble commits have an identical tree (`git diff --stat 9ec23d0 222d17f` is empty), so this changes only the pin comment in `Cargo.toml` and the three pebble `source` lines in `Cargo.lock`. The sandbox-driver pin (`a92c0db6`) is unchanged and already matches what pebble's `mcp` feature pins.

Local checks:

- `cargo +nightly-2026-04-14 fmt --check --all`: passed
- `cargo +nightly-2026-04-14 clippy --locked --workspace --all-targets -- -D warnings`: passed
- `cargo metadata --locked`: accepts the lockfile as committed
- `cargo nextest run --workspace`: in progress locally, results will follow as a comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)
